### PR TITLE
Vital Bug in Tilecode gen fixed

### DIFF
--- a/src/modlunky2/ui/levels.py
+++ b/src/modlunky2/ui/levels.py
@@ -925,7 +925,7 @@ class LevelsTab(Tab):
             count_col = count_col + 1
 
         ref_tile = []
-        ref_tile.append(r"\?" + new_tile_code + " " + str(usable_code))
+        ref_tile.append(new_tile_code + " " + str(usable_code))
         ref_tile.append(tile_image)
         self.tile_pallete_ref_in_use.append(ref_tile)
         new_tile = tk.Button(


### PR DESCRIPTION
Due to me changing the structure of the combobox items, "\?" was getting added to tilecodes twice, altho it's not something that would become apparent until you save and reopen the file. That's now been fixed. My apologies