### PR TITLE
Renaming lua script files to main.lua

### DIFF
--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -164,7 +164,7 @@ def install_local_mod(call, install_dir: Path, source: Path, pack: str):
     elif source.suffix == ".lua":
         main_lua = dest_dir / "main.lua"
         logger.info("Copying file %s to %s", source.name, main_lua)
-        shutil.copy(source.resolve(), main.lua)
+        shutil.copy(source.resolve(), main_lua)
 
     else:
         logger.info("Copying file %s to %s", source.name, dest_dir)

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -161,6 +161,11 @@ def install_local_mod(call, install_dir: Path, source: Path, pack: str):
         with zipfile.ZipFile(source) as zip_file:
             zip_file.extractall(dest_dir, get_members_without_commonprefix(zip_file))
 
+    elif source.suffix == ".lua":
+        main_lua = dest_dir / "main.lua"
+        logger.info("Copying file %s to %s", source.name, main_lua)
+        shutil.copy(source.resolve(), main.lua)
+
     else:
         logger.info("Copying file %s to %s", source.name, dest_dir)
         shutil.copy(source.resolve(), dest_dir.resolve())
@@ -280,9 +285,18 @@ def download_file(call, url: str, dest_path: Path):
         logger.warning("Failed to download file from %s", url)
         return
 
+
     with dest_path.open("wb") as dest_file:
         shutil.copyfileobj(contents, dest_file)
 
+    if dest_path.suffix == ".lua":
+        lua_path = Path(dest_path)
+
+        try:
+            lua_path.rename(lua_path.parent / "main.lua")
+
+        except Exception as err:
+            logger.warning(err)
 
 def get_members_without_commonprefix(zip_file):
     paths = set()

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -288,15 +288,6 @@ def download_file(call, url: str, dest_path: Path):
     with dest_path.open("wb") as dest_file:
         shutil.copyfileobj(contents, dest_file)
 
-    if dest_path.suffix == ".lua":
-        lua_path = Path(dest_path)
-
-        try:
-            lua_path.rename(lua_path.parent / "main.lua")
-
-        except Exception as err:
-            logger.warning(err)
-
 def get_members_without_commonprefix(zip_file):
     paths = set()
 
@@ -336,8 +327,12 @@ def download_mod_file(call, mod_file, pack_dir):
     download_url = mod_file["download_url"]
     filename = Path(mod_file["filename"])
 
+    if filename.suffix == ".lua":
+        filename = Path("main.lua")
+
     if filename.suffix == ".zip":
         download_zip(call, download_url, pack_dir)
+
     else:
         download_file(call, download_url, pack_dir / filename)
 

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -285,7 +285,6 @@ def download_file(call, url: str, dest_path: Path):
         logger.warning("Failed to download file from %s", url)
         return
 
-
     with dest_path.open("wb") as dest_file:
         shutil.copyfileobj(contents, dest_file)
 


### PR DESCRIPTION
This will rename lua script files to main.lua when installing locally or downloading from spelunky.fyi