### PR TITLE
Instead of trackers exiting when game isn't running, wait for it

### DIFF
--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -131,6 +131,9 @@ class Spel2Process:
 
         return cls(handle)
 
+    def running(self):
+        return win32con.STILL_ACTIVE == win32process.GetExitCodeProcess(self.proc_handle)
+
     def read_memory(self, offset, size):
         try:
             return win32process.ReadProcessMemory(self.proc_handle, offset, size)

--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -132,7 +132,9 @@ class Spel2Process:
         return cls(handle)
 
     def running(self):
-        return win32con.STILL_ACTIVE == win32process.GetExitCodeProcess(self.proc_handle)
+        return win32con.STILL_ACTIVE == win32process.GetExitCodeProcess(
+            self.proc_handle
+        )
 
     def read_memory(self, offset, size):
         try:

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -78,10 +78,6 @@ class CategoryWatcherThread(WatcherThread):
         return time_total
 
     def _poll(self):
-        # If we've never been initialized go ahead and do that now.
-        if self.time_total is None:
-            self.initialize()
-
         # Check if we've reset, if so, reinitialize
         new_time_total = self.get_time_total()
         if new_time_total < self.time_total:

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -125,6 +125,8 @@ class CategoryWindow(TrackerWindow):
                 if msg["command"] == CommonCommand.DIE:
                     schedule_again = False
                     self.shut_down(CRITICAL, msg["data"])
+                elif msg["command"] == CommonCommand.WAIT:
+                    self.update_text("Waiting for game...")
                 elif msg["command"] == Command.LABEL:
                     self.update_text(msg["data"])
 

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -22,6 +22,9 @@ class CommonCommand(Enum):
 
 
 class WatcherThread(threading.Thread):
+    POLL_INTERVAL = 0.1
+    ATTACH_INTERVAL = 1.0
+
     def __init__(self, queue):
         super().__init__()
         self.shut_down = False
@@ -96,15 +99,17 @@ class WatcherThread(threading.Thread):
                 shutting_down = True
                 break
 
+            interval = self.ATTACH_INTERVAL
             if self.proc is None:
                 self._attach()
             elif self.proc.running():
+                interval = self.POLL_INTERVAL
                 self._really_poll()
             else:
                 self.wait()
                 self._attach()
 
-            time.sleep(0.1)
+            time.sleep(interval)
 
         logger.info("Stopped watching process memory")
 

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -48,6 +48,10 @@ class PacifistButtons(ttk.Frame):
 
 
 class PacifistWatcherThread(WatcherThread):
+    def initialize(self):
+        #  Nothing to initialize
+        return
+
     def poll(self):
         run_recap_flags = self.proc.state.run_recap_flags
         if run_recap_flags is None:

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -86,6 +86,8 @@ class PacifistWindow(TrackerWindow):
                 if msg["command"] == CommonCommand.DIE:
                     schedule_again = False
                     self.shut_down(CRITICAL, msg["data"])
+                elif msg["command"] == CommonCommand.WAIT:
+                    self.update_text("Waiting for game...")
                 elif msg["command"] == Command.IS_PACIFIST:
                     is_pacifist = msg["data"]
                     new_text = "Pacifist" if is_pacifist else "MURDERER!"


### PR DESCRIPTION
This implements #121

Notably, if you close modlunky2 while a tracker window is open, there's an unhandled exception (example below). This change makes the situation more likely. I haven't looked into how to address it, and don't understand how serious this is.
```
10:32:32: Shutting Down.
10:32:32: Unhandled Exception: Traceback (most recent call last):
  File "C:\Python39\lib\tkinter\__init__.py", line 1892, in __call__
    return self.func(*args)
  File "c:\users\mauve\dev\modlunky2\src\modlunky2\ui\__init__.py", line 394, in quit
    self.root.destroy()
  File "C:\Python39\lib\tkinter\__init__.py", line 2311, in destroy
    for c in list(self.children.values()): c.destroy()
  File "c:\users\mauve\dev\modlunky2\src\modlunky2\ui\trackers\category.py", line 142, in destroy
    self.on_close()
  File "c:\users\mauve\dev\modlunky2\src\modlunky2\ui\trackers\category.py", line 56, in enable_button
    self.category_button["state"] = tk.NORMAL
  File "C:\Python39\lib\tkinter\__init__.py", line 1657, in __setitem__
    self.configure({key: value})
  File "C:\Python39\lib\tkinter\__init__.py", line 1646, in configure
    return self._configure('configure', cnf, kw)
  File "C:\Python39\lib\tkinter\__init__.py", line 1636, in _configure
    self.tk.call(_flatten((self._w, cmd)) + self._options(cnf))
_tkinter.TclError: invalid command name ".!frame.!notebook.!trackerstab.!trackersframe.!categorybuttons.!button"
10:32:32: Stopped watching process memory
```