### PR TITLE
Keep trackers from dying while Spelunky 2 is shutting down

### DIFF
--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -10,7 +10,7 @@ import win32con
 import win32process
 
 from .entities import EntityDB
-from .state import State
+from .state import FeedcodeNotFound, State
 
 VirtualQueryEx = ctypes.windll.kernel32.VirtualQueryEx
 CreateToolhelp32Snapshot = ctypes.windll.kernel32.CreateToolhelp32Snapshot
@@ -325,7 +325,11 @@ class Spel2Process:
         return None
 
     def get_state(self) -> State:
-        return State(self)
+        try:
+            return State(self)
+        except FeedcodeNotFound:
+            # This can happen if the game is starting up or shutting down
+            return None
 
     @property
     def state(self) -> State:

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -113,10 +113,17 @@ class WinState(enum.IntEnum):
     COSMIC_OCEAN = 3
 
 
+class FeedcodeNotFound(Exception):
+    """Failed to find feedcode within Spelunky2 memory."""
+
+
 class State:
     def __init__(self, proc):
         self._proc: "Spel2Process" = proc
-        self._offset = proc.get_feedcode() - 0x5F
+        feedcode = proc.get_feedcode()
+        if feedcode is None:
+            raise FeedcodeNotFound("Failed to find feedcode within Spelunky2 memory")
+        self._offset = feedcode - 0x5F
         self._uid_to_entity = None
 
     @property

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -103,8 +103,7 @@ class WatcherThread(threading.Thread):
                 self._really_poll()
             else:
                 self.wait()
-                if not self._attach():
-                    interval = self.ATTACH_INTERVAL
+                interval = self.ATTACH_INTERVAL
 
             time.sleep(interval)
 

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -77,12 +77,8 @@ class WatcherThread(threading.Thread):
             self.die("Failed to open handle to Spel2.exe")
             return False
 
-        if proc.get_feedcode() is None:
-            # Game might still be starting, we should try again
-            return False
-
         if proc.state is None:
-            self.die("Failed to open handle to expected array of bytes")
+            # Game might still be starting, we should try again
             return False
 
         self.proc = proc


### PR DESCRIPTION
Sometimes trackers will fail because they (seemingly) try to reattach while Spelunky 2 is shutting down. In this scenario, the `get_feedcode()` check succeeds in `_attach()` but `State.__init__()` gets `None` shortly afterwards. Example stacktrace:
```
2021-07-10 01:28:55,095: Failed in thread: Traceback (most recent call last):
  File "modlunky2\ui\trackers\common.py", line 37, in run
  File "modlunky2\ui\trackers\common.py", line 110, in _run
  File "modlunky2\ui\trackers\common.py", line 84, in _attach
  File "modlunky2\mem\__init__.py", line 333, in state
  File "modlunky2\mem\__init__.py", line 328, in get_state
  File "modlunky2\mem\state.py", line 119, in __init__
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
2021-07-10 01:28:55,115: Thread went away. Closing window.
```
I haven't identified a good way to reproduce. I just know I encountered this problem twice in ~24h. I haven't seen it with my changes after restarting a bunch, but it also didn't recur on main branch.

I do wonder why `GetExitCodeProcess() != STILL_ACTIVE` but it still appears when walking processes...

Setting aside that mystery, I've tried to avoid this problem in two ways:

- Check `get_feedcode()` in `State.__init__()`. Remove the extra call in `_attach()` since it's unclear whether its helping
- When we detect that the game is exiting, waiting `ATTACH_INTERVAL` before trying to attach

We could also check `Spel2Process.running()` in `_attach()`, but that only helps with the shutdown case (startup is still an issue).