### PR TITLE
Convert entities to declarative structs

### DIFF
--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -11,7 +11,7 @@ import win32api
 import win32con
 import win32process
 
-from .entities import EntityDB, EntityMap
+from .entities import EntityMap
 from .state import State
 from .memrauder.model import (
     DataclassStruct,
@@ -31,7 +31,6 @@ TH32CS_SNAPPROCESS = 0x00000002
 INVALID_HANDLE_VALUE = -1
 
 STATE_MEM_TYPE = DataclassStruct(FieldPath(), State)
-ENTITY_DB_MEM_TYPE = DataclassStruct(FieldPath(), EntityDB)
 
 
 @dataclass
@@ -361,15 +360,6 @@ class Spel2Process:
     def state(self) -> State:
         addr = self.get_feedcode() - 0x5F
         return mem_type_at_addr(STATE_MEM_TYPE, addr, self.mem_reader)
-
-    def get_entity_db(self):
-        offset = self.get_offset_past_bundle()
-        entity_db_addr = self._get_entity_db_ptr(offset)
-        return mem_type_at_addr(ENTITY_DB_MEM_TYPE, entity_db_addr, self.mem_reader)
-
-    def _get_entity_db_ptr(self, offset):
-        entity_instr = self.find(offset, b"\x48\xB8\x02\x55\xA7\x74\x52\x9D\x51\x43")
-        return self.read_void_p(entity_instr + self.read_u32(entity_instr - 4))
 
     @property
     def uid_to_entity(self):

--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -11,7 +11,7 @@ import win32api
 import win32con
 import win32process
 
-from .entities import EntityDB, EntityMap, Player
+from .entities import EntityDB, EntityMap
 from .state import State
 from .memrauder.model import (
     DataclassStruct,
@@ -370,26 +370,6 @@ class Spel2Process:
     def _get_entity_db_ptr(self, offset):
         entity_instr = self.find(offset, b"\x48\xB8\x02\x55\xA7\x74\x52\x9D\x51\x43")
         return self.read_void_p(entity_instr + self.read_u32(entity_instr - 4))
-
-    # TODO put players back into State
-    @property
-    def players(self) -> List[Player]:  # items
-        addr = self.get_feedcode() - 0x5F + 0x12B0
-        items_ptr = self.read_void_p(addr) + 8
-        player_pointers = self.read_memory(items_ptr, 8 * 4)
-
-        players = []
-
-        for idx in range(0, len(player_pointers), 8):
-            player_pointer = player_pointers[idx : idx + 8]
-            if player_pointer == b"\x00\x00\x00\x00\x00\x00\x00\x00":
-                players.append(None)
-                continue
-
-            player_pointer = unpack("P", player_pointer)[0]
-            players.append(Player(self, player_pointer))
-
-        return players
 
     @property
     def uid_to_entity(self):

--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations  # PEP 563
 import ctypes
 from ctypes.wintypes import DWORD, HANDLE, LONG, MAX_PATH, WPARAM
 from dataclasses import dataclass
@@ -30,6 +31,7 @@ TH32CS_SNAPPROCESS = 0x00000002
 INVALID_HANDLE_VALUE = -1
 
 STATE_MEM_TYPE = DataclassStruct(FieldPath(), State)
+ENTITY_DB_MEM_TYPE = DataclassStruct(FieldPath(), EntityDB)
 
 
 @dataclass
@@ -141,7 +143,7 @@ class Spel2Process:
     def __init__(self, proc_handle):
         self.proc_handle = proc_handle
         self._feedcode = None
-        self._mem_reader = Spel2Reader(self)
+        self.mem_reader = Spel2Reader(self)
 
     @classmethod
     def from_pid(cls, pid):
@@ -358,11 +360,18 @@ class Spel2Process:
     @property
     def state(self) -> State:
         addr = self.get_feedcode() - 0x5F
-        return mem_type_at_addr(STATE_MEM_TYPE, addr, self._mem_reader)
+        return mem_type_at_addr(STATE_MEM_TYPE, addr, self.mem_reader)
 
     def get_entity_db(self):
-        return EntityDB(self)
+        offset = self.get_offset_past_bundle()
+        entity_db_addr = self._get_entity_db_ptr(offset)
+        return mem_type_at_addr(ENTITY_DB_MEM_TYPE, entity_db_addr, self.mem_reader)
 
+    def _get_entity_db_ptr(self, offset):
+        entity_instr = self.find(offset, b"\x48\xB8\x02\x55\xA7\x74\x52\x9D\x51\x43")
+        return self.read_void_p(entity_instr + self.read_u32(entity_instr - 4))
+
+    # TODO put players back into State
     @property
     def players(self) -> List[Player]:  # items
         addr = self.get_feedcode() - 0x5F + 0x12B0

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -209,8 +209,8 @@ class Entity:
 
 @dataclass(frozen=True)
 class Movable(Entity):
-    state: CharState = struct_field(0x10C, sc_uint8)
     holding_uid: int = struct_field(0x108, sc_int32)
+    state: CharState = struct_field(0x10C, sc_uint8)
     last_state: CharState = struct_field(0x10D, sc_uint8)
     health: int = struct_field(0x10F, sc_int8)
 

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -170,12 +170,18 @@ class EntityMap(UnorderedMap):
     KEY_CHAR = "<L"
     VALUE_CHAR = "P"
 
-    def get(self, key, meta=None):
+    def get(self, key: int, meta=None) -> EntityWrapper:
         result = super().get(key)
         if result is None:
             return None
 
-        return Entity(self._proc, result)
+        return EntityWrapper(result)
+
+    def get_as_entity(self, key: int, mem_reader: MemoryReader) -> Optional[Entity]:
+        result = self.get(key)
+        if result is None:
+            return None
+        return result.as_entity(mem_reader)
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -202,17 +202,17 @@ class EntityDBEntry:
 @dataclass(frozen=True)
 class Entity:
     type: Optional[EntityDBEntry] = struct_field(0x08, pointer(dc_struct))
+    overlay: EntityWrapper = struct_field(0x10, sc_void_p)
     items: Optional[Tuple[int, ...]] = struct_field(0x18, vector(sc_uint32))
     layer: int = struct_field(0x98, sc_uint8)
-    overlay: EntityWrapper = struct_field(0x10, sc_void_p)
 
 
 @dataclass(frozen=True)
 class Movable(Entity):
     state: CharState = struct_field(0x10C, sc_uint8)
+    holding_uid: int = struct_field(0x108, sc_int32)
     last_state: CharState = struct_field(0x10D, sc_uint8)
     health: int = struct_field(0x10F, sc_int8)
-    holding_uid: int = struct_field(0x108, sc_int32)
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -6,7 +6,6 @@ from typing import ClassVar, Optional, TYPE_CHECKING, Tuple
 
 from modlunky2.constants import BASE_DIR
 from modlunky2.mem.memrauder.dsl import (
-    array,
     struct_field,
     dc_struct,
     pointer,
@@ -198,18 +197,6 @@ class EntityDBEntry:
     @property
     def name(self):
         return self.entity_type.name
-
-
-@dataclass(frozen=True)
-class EntityDB:
-    ENTITY_DB_ENTRIES: ClassVar[int] = 911  # Number off entries
-
-    db: Tuple[EntityDBEntry, ...] = struct_field(  # pylint: disable=invalid-name
-        0x00, array(dc_struct, ENTITY_DB_ENTRIES)
-    )
-
-    def get_entity_db_entry_by_id(self, entity_id) -> EntityDBEntry:
-        return self.db[entity_id]
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -1,8 +1,30 @@
+from __future__ import annotations  # PEP 563
+from dataclasses import dataclass
 import json
 from enum import IntEnum
-from typing import Optional, TYPE_CHECKING
+from typing import ClassVar, Optional, TYPE_CHECKING, Tuple
 
 from modlunky2.constants import BASE_DIR
+from modlunky2.mem.memrauder.dsl import (
+    array,
+    struct_field,
+    dc_struct,
+    pointer,
+    sc_uint8,
+    sc_uint32,
+    sc_int8,
+    sc_int16,
+    sc_int32,
+    sc_void_p,
+    sc_bool,
+)
+from modlunky2.mem.memrauder.model import (
+    DataclassStruct,
+    FieldPath,
+    MemoryReader,
+    mem_type_at_addr,
+)
+from modlunky2.mem.memrauder.msvc import vector
 
 from .unordered_map import UnorderedMap
 
@@ -156,15 +178,13 @@ class EntityMap(UnorderedMap):
         return Entity(self._proc, result)
 
 
+@dataclass(frozen=True)
 class EntityDBEntry:
-    def __init__(self, proc, offset):
-        self._proc: "Spel2Process" = proc
-        self._offset = offset
+    _size_as_element_: ClassVar[int] = 256  # Size of EntityDB struct
 
-    @property
-    def id(self):  # pylint: disable=invalid-name
-        return self._proc.read_u32(self._offset + 0x14)
+    id: int = struct_field(0x14, sc_uint32)  # pylint: disable=invalid-name
 
+    # TODO try constructing eagerly
     @property
     def entity_type(self):
         return EntityType(self.id)
@@ -174,180 +194,72 @@ class EntityDBEntry:
         return self.entity_type.name
 
 
+@dataclass(frozen=True)
 class EntityDB:
+    ENTITY_DB_ENTRIES: ClassVar[int] = 911  # Number off entries
 
-    ENTITY_DB_SIZE = 256  # Size of EntityDB
-
-    def __init__(self, proc):
-        self._proc: "Spel2Process" = proc
-        self._offset = proc.get_offset_past_bundle()
-        self._entity_db_ptr = self._get_entity_db_ptr()
-
-    def _get_entity_db_ptr(self):
-        entity_instr = self._proc.find(
-            self._offset, b"\x48\xB8\x02\x55\xA7\x74\x52\x9D\x51\x43"
-        )
-        return self._proc.read_void_p(
-            entity_instr + self._proc.read_u32(entity_instr - 4)
-        )
+    db: Tuple[EntityDBEntry, ...] = struct_field(  # pylint: disable=invalid-name
+        0x00, array(dc_struct, ENTITY_DB_ENTRIES)
+    )
 
     def get_entity_db_entry_by_id(self, entity_id) -> EntityDBEntry:
-        return EntityDBEntry(
-            self._proc, self._entity_db_ptr + (self.ENTITY_DB_SIZE * entity_id)
-        )
+        return self.db[entity_id]
 
 
+@dataclass(frozen=True)
 class Entity:
-    def __init__(self, proc, offset):
-        self._proc: "Spel2Process" = proc
-        self._offset = offset
-
-    @property
-    def type(self):
-        result = self._proc.read_void_p(self._offset + 8)
-        return EntityDBEntry(self._proc, result)
-
-    @property
-    def overlay(self) -> Optional["Entity"]:
-        offset = self._offset + 0x10
-        entity_ptr = self._proc.read_void_p(offset)
-        if not entity_ptr:
-            return None
-        return Entity(self._proc, entity_ptr)
-
-    @property
-    def items(self):
-        offset = self._offset + 0x18
-        return self._proc.read_vector(offset, "<L")
-
-    @property
-    def layer(self):
-        result = self._proc.read_u8(self._offset + 0x98)
-        if result is None:
-            return None
-        return Layer(result)
-
-    def as_movable(self) -> "Movable":
-        return Movable(self._proc, self._offset)
-
-    def as_mount(self) -> "Mount":
-        return Mount(self._proc, self._offset)
-
-    def as_player(self) -> "Player":
-        return Player(self._proc, self._offset)
+    type: Optional[EntityDBEntry] = struct_field(0x08, pointer(dc_struct))
+    items: Optional[Tuple[int, ...]] = struct_field(0x18, vector(sc_uint32))
+    layer: int = struct_field(0x98, sc_uint8)
+    overlay: EntityWrapper = struct_field(0x10, sc_void_p)
 
 
+@dataclass(frozen=True)
 class Movable(Entity):
-    @property
-    def state(self):
-        result = self._proc.read_u8(self._offset + 0x10C)
-        if result is None:
-            return None
-        return CharState(result)
-
-    @property
-    def last_state(self):
-        result = self._proc.read_u8(self._offset + 0x10D)
-        if result is None:
-            return None
-        return CharState(result)
-
-    @property
-    def health(self):
-        return self._proc.read_i8(self._offset + 0x10F)
-
-    @property
-    def holding_uid(self):
-        return self._proc.read_i32(self._offset + 0x108)
+    state: CharState = struct_field(0x10C, sc_uint8)
+    last_state: CharState = struct_field(0x10D, sc_uint8)
+    health: int = struct_field(0x10F, sc_int8)
+    holding_uid: int = struct_field(0x108, sc_int32)
 
 
+@dataclass(frozen=True)
 class Mount(Movable):
-    @property
-    def is_tamed(self) -> bool:
-        offset = self._offset + 0x149
-        return self._proc.read_bool(offset)
+    is_tamed: bool = struct_field(0x149, sc_bool)
 
 
+@dataclass(frozen=True)
 class Inventory:
-    def __init__(self, proc, offset):
-        self._proc: "Spel2Process" = proc
-        self._offset = offset
-
-    @property
-    def money(self):
-        """Amount of money collected in the current level"""
-        return self._proc.read_u32(self._offset)
-
-    @property
-    def bombs(self):
-        return self._proc.read_u8(self._offset + 0x04)
-
-    @property
-    def ropes(self):
-        return self._proc.read_u8(self._offset + 0x05)
-
-    @property
-    def poison_tick_timer(self):
-        return self._proc.read_i16(self._offset + 0x06)
-
-    @property
-    def cursed(self):
-        return self._proc.read_bool(self._offset + 0x08)
-
-    @property
-    def kills_level(self):
-        return self._proc.read_u32(self._offset + 0x1424)
-
-    @property
-    def kills_total(self):
-        return self._proc.read_u32(self._offset + 0x1428)
-
-    @property
-    def collected_money_total(self):
-        """Amount of money collected in earlier levels."""
-        return self._proc.read_u32(self._offset + 0x1520)
+    # Amount of money collected in the current level
+    money: int = struct_field(0x00, sc_uint32)
+    bombs: int = struct_field(0x04, sc_uint8)
+    ropes: int = struct_field(0x05, sc_uint8)
+    poison_tick_timer: int = struct_field(0x06, sc_int16)
+    cursed: bool = struct_field(0x08, sc_bool)
+    kills_level: int = struct_field(0x1424, sc_uint32)
+    kills_total: int = struct_field(0x1428, sc_uint32)
+    collected_money_total: int = struct_field(0x1520, sc_uint32)
 
 
+@dataclass(frozen=True)
 class Player(Movable):
-    @property
-    def inventory(self):
-        offset = self._offset + 0x138
-        inventory_ptr = self._proc.read_void_p(offset)
-        if not inventory_ptr:
-            return None
-        return Inventory(self._proc, inventory_ptr)
+    inventory: Optional[Inventory] = struct_field(0x138, pointer(dc_struct))
 
-    def inside(self):
-        """std::map. Need to implement red/black tree."""
-        # inside = player1_ent_addr + 0x128
-        # print("inside", hex(inside))
-        # print("")
 
-        # node1_addr = proc.read_void_p(inside)
-        # print("node1_addr", hex(node1_addr))
-        # print("")
+class EntityWrapper(int):
+    def as_entity(self, mem_reader: MemoryReader) -> Optional[Entity]:
+        return mem_type_at_addr(ENTITY_MEM_TYPE, self, mem_reader)
 
-        # x = proc.read_memory(node1_addr, 8 * 3)
-        # pointers = unpack(b"PPP", x)
-        # print("x", list(map(hex, pointers)))
-        # print("x more", proc.read_memory(node1_addr + (8 * 3), 4))
-        # print(proc.read_memory(node1_addr + (8 * 3) + 4, 16))
-        # print("x more", proc.read_u16(node1_addr + (8 * 3) + 4))
+    def as_movable(self, mem_reader: MemoryReader) -> Optional[Movable]:
+        return mem_type_at_addr(MOVABLE_MEM_TYPE, self, mem_reader)
 
-        # print("")
-        # p = pointers[0]
-        # x = proc.read_memory(p, 8 * 3)
-        # pointers = unpack(b"PPP", x)
-        # print("x", list(map(hex, pointers)))
-        # print("x more", proc.read_memory(p + (8 * 3), 4))
-        # print(proc.read_memory(p + (8 * 3) + 4, 16))
-        # print("x more", proc.read_u16(p + (8 * 3) + 4))
+    def as_mount(self, mem_reader: MemoryReader) -> Optional[Mount]:
+        return mem_type_at_addr(MOUNT_MEM_TYPE, self, mem_reader)
 
-        # print("")
-        # p = pointers[2]
-        # x = proc.read_memory(p, 8 * 3)
-        # pointers = unpack(b"PPP", x)
-        # print("x", list(map(hex, pointers)))
-        # print("x more", proc.read_memory(p + (8 * 3), 4))
-        # print("x more", hex(proc.read_u16(p + (8 * 3) + 4)))
-        # item_count = proc.read_u64(inside + 8)
+    def as_player(self, mem_reader: MemoryReader) -> Optional[Player]:
+        return mem_type_at_addr(PLAYER_MEM_TYPE, self, mem_reader)
+
+
+ENTITY_MEM_TYPE = DataclassStruct(FieldPath(), Entity)
+MOVABLE_MEM_TYPE = DataclassStruct(FieldPath(), Movable)
+MOUNT_MEM_TYPE = DataclassStruct(FieldPath(), Mount)
+PLAYER_MEM_TYPE = DataclassStruct(FieldPath(), Player)

--- a/src/modlunky2/mem/memrauder/dsl.py
+++ b/src/modlunky2/mem/memrauder/dsl.py
@@ -25,10 +25,10 @@ def struct_field(
     return dataclasses.field(metadata=metadata, **kwargs)
 
 
-dc_struct = DataclassStruct  # pylint: disable=invalid-name
+dc_struct: DeferredMemType = DataclassStruct  # pylint: disable=invalid-name
 
 
-def scalar_c_type(c_type):
+def scalar_c_type(c_type) -> DeferredMemType:
     def build(path: FieldPath, py_type: type):
         return ScalarCType(path, py_type, c_type)
 
@@ -44,19 +44,20 @@ sc_int8 = scalar_c_type(ctypes.c_int8)
 sc_int16 = scalar_c_type(ctypes.c_int16)
 sc_int32 = scalar_c_type(ctypes.c_int32)
 sc_int64 = scalar_c_type(ctypes.c_int64)
+sc_void_p = scalar_c_type(ctypes.c_void_p)
 sc_float = scalar_c_type(ctypes.c_float)
 sc_double = scalar_c_type(ctypes.c_double)
 sc_longdouble = scalar_c_type(ctypes.c_longdouble)
 
 
-def array(elem: DeferredMemType, count: int):
+def array(elem: DeferredMemType, count: int) -> DeferredMemType:
     def build(path: FieldPath, py_type: type):
         return Array(path, py_type, elem, count)
 
     return build
 
 
-def pointer(pointed: DeferredMemType):
+def pointer(pointed: DeferredMemType) -> DeferredMemType:
     def build(path: FieldPath, py_type: type):
         return Pointer(path, py_type, pointed)
 

--- a/src/modlunky2/mem/memrauder/dsl.py
+++ b/src/modlunky2/mem/memrauder/dsl.py
@@ -35,18 +35,18 @@ def scalar_c_type(c_type):
     return build
 
 
-c_bool = scalar_c_type(ctypes.c_bool)
-c_uint8 = scalar_c_type(ctypes.c_uint8)
-c_uint16 = scalar_c_type(ctypes.c_uint16)
-c_uint32 = scalar_c_type(ctypes.c_uint32)
-c_uint64 = scalar_c_type(ctypes.c_uint64)
-c_int8 = scalar_c_type(ctypes.c_int8)
-c_int16 = scalar_c_type(ctypes.c_int16)
-c_int32 = scalar_c_type(ctypes.c_int32)
-c_int64 = scalar_c_type(ctypes.c_int64)
-c_float = scalar_c_type(ctypes.c_float)
-c_double = scalar_c_type(ctypes.c_double)
-c_longdouble = scalar_c_type(ctypes.c_longdouble)
+sc_bool = scalar_c_type(ctypes.c_bool)
+sc_uint8 = scalar_c_type(ctypes.c_uint8)
+sc_uint16 = scalar_c_type(ctypes.c_uint16)
+sc_uint32 = scalar_c_type(ctypes.c_uint32)
+sc_uint64 = scalar_c_type(ctypes.c_uint64)
+sc_int8 = scalar_c_type(ctypes.c_int8)
+sc_int16 = scalar_c_type(ctypes.c_int16)
+sc_int32 = scalar_c_type(ctypes.c_int32)
+sc_int64 = scalar_c_type(ctypes.c_int64)
+sc_float = scalar_c_type(ctypes.c_float)
+sc_double = scalar_c_type(ctypes.c_double)
+sc_longdouble = scalar_c_type(ctypes.c_longdouble)
 
 
 def array(elem: DeferredMemType, count: int):

--- a/src/modlunky2/mem/memrauder/dsl.py
+++ b/src/modlunky2/mem/memrauder/dsl.py
@@ -1,0 +1,63 @@
+import ctypes
+import dataclasses
+
+from modlunky2.mem.memrauder.model import (
+    StructFieldMeta,
+    DataclassStruct,
+    ScalarCType,
+    Array,
+    Pointer,
+    DeferredMemType,
+    FieldPath,
+)
+
+
+def struct_field(
+    offset: int,
+    deferred_mem_type: DeferredMemType,
+    metadata: dict = None,
+    **kwargs,
+):
+    if metadata is None:
+        metadata = {}
+    field_meta = StructFieldMeta(offset, deferred_mem_type)
+    field_meta.put_into(metadata)
+    return dataclasses.field(metadata=metadata, **kwargs)
+
+
+dc_struct = DataclassStruct  # pylint: disable=invalid-name
+
+
+def scalar_c_type(c_type):
+    def build(path: FieldPath, py_type: type):
+        return ScalarCType(path, py_type, c_type)
+
+    return build
+
+
+c_bool = scalar_c_type(ctypes.c_bool)
+c_uint8 = scalar_c_type(ctypes.c_uint8)
+c_uint16 = scalar_c_type(ctypes.c_uint16)
+c_uint32 = scalar_c_type(ctypes.c_uint32)
+c_uint64 = scalar_c_type(ctypes.c_uint64)
+c_int8 = scalar_c_type(ctypes.c_int8)
+c_int16 = scalar_c_type(ctypes.c_int16)
+c_int32 = scalar_c_type(ctypes.c_int32)
+c_int64 = scalar_c_type(ctypes.c_int64)
+c_float = scalar_c_type(ctypes.c_float)
+c_double = scalar_c_type(ctypes.c_double)
+c_longdouble = scalar_c_type(ctypes.c_longdouble)
+
+
+def array(elem: DeferredMemType, count: int):
+    def build(path: FieldPath, py_type: type):
+        return Array(path, py_type, elem, count)
+
+    return build
+
+
+def pointer(pointed: DeferredMemType):
+    def build(path: FieldPath, py_type: type):
+        return Pointer(path, py_type, pointed)
+
+    return build

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -405,7 +405,7 @@ class Pointer(MemType[T]):
 
     def from_bytes(self, buf: bytes, mem_reader: MemoryReader) -> Optional[T]:
         addr = ctypes.c_void_p.from_buffer_copy(buf).value
-        if addr == 0:
+        if addr is None:
             return None
 
         buf = mem_reader.read(addr, self.read_size)

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -3,13 +3,11 @@ from abc import ABC, abstractmethod
 import ctypes
 from dataclasses import InitVar, dataclass
 import dataclasses
-from enum import IntEnum, IntFlag
 from typing import (
     Callable,
     ClassVar,
     Collection,
     Dict,
-    FrozenSet,
     Generic,
     Optional,
     Tuple,
@@ -18,7 +16,6 @@ from typing import (
     Union,
 )
 import typing
-
 
 # Abstract memory-reader interface, used if pointers are derefrenced.
 class MemoryReader(ABC):
@@ -168,74 +165,30 @@ def unwrap_collection_type(path: FieldPath, py_type: type) -> Tuple[type, type]:
         raise ValueError(f"field {path} must be tuple or frozenset. Got type {py_type}")
 
 
-def _build_allowed_c_types():
-    pair_list = [(ctypes.c_bool, bool)]
-    for c_type in [
-        ctypes.c_int8,
-        ctypes.c_uint8,
-        ctypes.c_int16,
-        ctypes.c_uint16,
-        ctypes.c_int32,
-        ctypes.c_uint32,
-        ctypes.c_int64,
-        ctypes.c_uint64,
-        ctypes.c_void_p,
-    ]:
-        pair_list.append((c_type, int))
-    for c_type in [
-        ctypes.c_float,
-        ctypes.c_double,
-        ctypes.c_longdouble,
-    ]:
-        pair_list.append((c_type, float))
+DeferredMemType = Callable[[FieldPath, Type], MemType]
 
-    return tuple(pair_list)
+# Metadata stored during dataclass definition
+@dataclass(frozen=True)
+class StructFieldMeta:
+    _METADATA_KEY: ClassVar[str] = "ml2_field_metadata"
+
+    offset: int
+    deferred_mem_type: DeferredMemType
+
+    def put_into(self, metadata: dict):
+        if self._METADATA_KEY in metadata:
+            raise ValueError(f"metadata dict already has {self._METADATA_KEY}")
+        metadata[self._METADATA_KEY] = self
+
+    @classmethod
+    def from_field(cls, field: dataclasses.Field) -> StructFieldMeta:
+        if cls._METADATA_KEY not in field.metadata:
+            raise ValueError(f"field {field.name} has no stuct_field() metadata")
+        return field.metadata[cls._METADATA_KEY]
 
 
 @dataclass(frozen=True)
-class ScalarCType(MemType[T]):
-    path: InitVar[FieldPath]
-    py_type: T
-    c_type: type
-
-    # Dict doesn't work correctly, presumably c_foo isn't hashable
-    _allowed_c_types: ClassVar[Tuple[Tuple[type, type]]] = _build_allowed_c_types()
-
-    # TODO validate in constructor
-    def __post_init__(self, path: FieldPath):
-        expected_type = None
-        for known_c_type, known_py_type in self._allowed_c_types:
-            if known_c_type is self.c_type:
-                expected_type = known_py_type
-                break
-        if expected_type is None:
-            raise ValueError(f"field {path} has unsupported c_type {self.c_type}")
-
-        if expected_type not in self.py_type.__mro__:
-            raise ValueError(
-                f"field {path} has {self.c_type} we expect the py_type ({self.py_type}) to be a subtype of {expected_type}"  # pylint: disable=line-too-long
-            )
-
-        if expected_type not in self.py_type.__mro__:
-            raise TypeError(
-                f"field {path}: {self.py_type} must be a subtype of {expected_type}"
-            )
-
-    def field_size(self) -> int:
-        return ctypes.sizeof(self.c_type)
-
-    def from_bytes(self, buf: bytes, mem_reader: MemoryReader) -> T:
-        try:
-            mem_value = self.c_type.from_buffer_copy(buf).value
-            return self.py_type(mem_value)
-        except Exception as err:
-            raise ValueError(
-                f"failed to deserialize value for field {self.path}"
-            ) from err
-
-
-@dataclass(frozen=True)
-class StructField:
+class _StructField:
     path: FieldPath
     offset: int
     mem_type: MemType
@@ -247,7 +200,7 @@ class DataclassStruct(MemType[T]):
     path: FieldPath
     dataclass: T
 
-    struct_fields: Dict[str, StructField] = dataclasses.field(init=False)
+    struct_fields: Dict[str, _StructField] = dataclasses.field(init=False)
 
     def __post_init__(self):
         if not dataclasses.is_dataclass(self.dataclass):
@@ -262,7 +215,7 @@ class DataclassStruct(MemType[T]):
             meta = StructFieldMeta.from_field(field)
             inner_path = self.path.append(field.name)
             inner_mem_type = meta.deferred_mem_type(inner_path, type_hints[field.name])
-            struct_fields[field.name] = StructField(
+            struct_fields[field.name] = _StructField(
                 inner_path, meta.offset, inner_mem_type, inner_mem_type.field_size()
             )
 
@@ -303,9 +256,74 @@ class DataclassStruct(MemType[T]):
             ) from err
 
 
+def _build_allowed_c_types():
+    pair_list = [(ctypes.c_bool, bool)]
+    for c_type in [
+        ctypes.c_int8,
+        ctypes.c_uint8,
+        ctypes.c_int16,
+        ctypes.c_uint16,
+        ctypes.c_int32,
+        ctypes.c_uint32,
+        ctypes.c_int64,
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+    ]:
+        pair_list.append((c_type, int))
+    for c_type in [
+        ctypes.c_float,
+        ctypes.c_double,
+        ctypes.c_longdouble,
+    ]:
+        pair_list.append((c_type, float))
+
+    return tuple(pair_list)
+
+
+@dataclass(frozen=True)
+class ScalarCType(MemType[T]):
+    path: FieldPath
+    py_type: T
+    c_type: type
+
+    # Dict doesn't work correctly, presumably c_foo isn't hashable
+    _allowed_c_types: ClassVar[Tuple[Tuple[type, type]]] = _build_allowed_c_types()
+
+    def __post_init__(self):
+        expected_type = None
+        for known_c_type, known_py_type in self._allowed_c_types:
+            if known_c_type is self.c_type:
+                expected_type = known_py_type
+                break
+        if expected_type is None:
+            raise ValueError(f"field {self.path} has unsupported c_type {self.c_type}")
+
+        if expected_type not in self.py_type.__mro__:
+            raise ValueError(
+                f"field {self.path} has {self.c_type} we expect the py_type ({self.py_type}) to be a subtype of {expected_type}"  # pylint: disable=line-too-long
+            )
+
+        if expected_type not in self.py_type.__mro__:
+            raise TypeError(
+                f"field {self.path}: {self.py_type} must be a subtype of {expected_type}"
+            )
+
+    def field_size(self) -> int:
+        return ctypes.sizeof(self.c_type)
+
+    def from_bytes(self, buf: bytes, mem_reader: MemoryReader) -> T:
+        try:
+            mem_value = self.c_type.from_buffer_copy(buf).value
+            return self.py_type(mem_value)
+        except Exception as err:
+            raise ValueError(
+                f"failed to deserialize value for field {self.path}"
+            ) from err
+
+
 @dataclass(frozen=True)
 class Array(MemType[T]):
-    path: InitVar[FieldPath]
+    path: FieldPath
     py_type: InitVar[type]
     deferred_elem_mem_type: InitVar[DeferredMemType]
     count: int
@@ -314,9 +332,9 @@ class Array(MemType[T]):
     _total_field_size: MemType[T] = dataclasses.field(init=False)
     collection_type: Collection[T] = dataclasses.field(init=False)
 
-    def __post_init__(self, path, py_type, deferred_elem_mem_type):
-        collection_type, elem_py_type = unwrap_collection_type(path, py_type)
-        elem_mem_type = deferred_elem_mem_type(path, elem_py_type)
+    def __post_init__(self, py_type, deferred_elem_mem_type):
+        collection_type, elem_py_type = unwrap_collection_type(self.path, py_type)
+        elem_mem_type = deferred_elem_mem_type(self.path, elem_py_type)
         total_field_size = elem_mem_type.element_size() * self.count
         object.__setattr__(self, "elem_mem_type", elem_mem_type)
         object.__setattr__(self, "_total_field_size", total_field_size)
@@ -373,83 +391,14 @@ class Pointer(MemType[T]):
         return self.mem_type.from_bytes(buf, mem_reader)
 
 
-### DSL
-
-DeferredMemType = Callable[[FieldPath, Type], MemType]
-
-
-@dataclass(frozen=True)
-class StructFieldMeta:
-    _METADATA_KEY: ClassVar[str] = "ml2_field_metadata"
-
-    offset: int
-    deferred_mem_type: DeferredMemType
-
-    def put_into(self, metadata: dict):
-        if self._METADATA_KEY in metadata:
-            raise ValueError(f"metadata dict already has {self._METADATA_KEY}")
-        metadata[self._METADATA_KEY] = self
-
-    @classmethod
-    def from_field(cls, field: dataclasses.Field) -> StructFieldMeta:
-        if cls._METADATA_KEY not in field.metadata:
-            raise ValueError(f"field {field.name} has no stuct_field() metadata")
-        return field.metadata[cls._METADATA_KEY]
-
-
-def struct_field(
-    offset: int,
-    deferred_mem_type: DeferredMemType,
-    metadata: dict = None,
-    **kwargs,
-):
-    if metadata is None:
-        metadata = {}
-    field_meta = StructFieldMeta(offset, deferred_mem_type)
-    field_meta.put_into(metadata)
-    return dataclasses.field(metadata=metadata, **kwargs)
-
-
-dc_struct = DataclassStruct  # pylint: disable=invalid-name
-
-
-def scalar_c_type(c_type):
-    def build(path: FieldPath, py_type: type):
-        return ScalarCType(path, py_type, c_type)
-
-    return build
-
-
-uint8 = scalar_c_type(ctypes.c_uint8)
-
-
-uint32 = scalar_c_type(ctypes.c_uint32)
-
-# TODO other C scalar types
-
-
-def array(elem: DeferredMemType, count: int):
-    def build(path: FieldPath, py_type: type):
-        return Array(path, py_type, elem, count)
-
-    return build
-
-
-def pointer(pointed: DeferredMemType):
-    def build(path: FieldPath, py_type: type):
-        return Pointer(path, py_type, pointed)
-
-    return build
-
-
-### Convenience functions
+_EMPTY_BYTES_READER = BytesReader(bytes())
 
 
 def mem_type_from_bytes(
     mem_type: MemType[T], buf: bytes, mem_reader: MemoryReader = None
 ) -> T:
     if mem_reader is None:
-        mem_reader = BytesReader(bytes())
+        mem_reader = _EMPTY_BYTES_READER
     return mem_type.from_bytes(buf, mem_reader)
 
 
@@ -461,61 +410,3 @@ def mem_type_at_addr(
     if buf is None:
         return None
     return mem_type.from_bytes(buf, mem_reader)
-
-
-### Demo
-
-
-class HudFlags(IntFlag):
-    UPBEAT_DWELLING_MUSIC = 1 << 1 - 1
-    RUNNING_TUTORIAL_SPEEDRUN = 1 << 3 - 1
-    ALLOW_PAUSE = 1 << 20 - 1
-    HAVE_CLOVER = 1 << 23 - 1
-
-
-class WinState(IntEnum):
-    UNKNOWN = -1
-    NO_WIN = 0
-    TIAMAT = 1
-    HUNDUN = 2
-    COSMIC_OCEAN = 3
-
-
-@dataclass(frozen=True)
-class Player:
-    # Overall struct size, used for computing array element offsets
-    _size_as_element_: ClassVar[int] = 4
-    bombs: int = struct_field(0x0, uint8)
-    ropes: int = struct_field(0x1, uint8)
-
-
-@dataclass(frozen=True)
-class State:
-    level: int = struct_field(0x0, uint8)
-    hud_flags: HudFlags = struct_field(0x1, uint32)
-    win_state: WinState = struct_field(0x5, uint8)
-    direct_player: Player = struct_field(0x6, dc_struct)
-    nums_list: Tuple[int, ...] = struct_field(0x6, array(uint8, 2))
-    enum_list: Tuple[WinState, ...] = struct_field(0xA, array(uint8, 2))
-    player_set: FrozenSet[Player] = struct_field(0x8, array(dc_struct, 2))
-    pointed_player: Optional[Player] = struct_field(0x10, pointer(dc_struct))
-
-
-# Demo output:
-# State(
-#     level=2,
-#     hud_flags=<HudFlags.HAVE_CLOVER: 4194304>,
-#     win_state=<WinState.COSMIC_OCEAN: 3>,
-#     direct_player=Player(bombs=99, ropes=42),
-#     nums_list=(99, 42), enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
-#     player_set=frozenset({Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)}),
-#     pointed_player=Player(bombs=99, ropes=42)
-# )
-# Player(bombs=99, ropes=42)
-DEMO_BUFFER = b"\x02\x00\x00\x40\x00\x03\x63\x2a\x01\x02\x00\x00\x03\x04\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00"
-
-state_mt = DataclassStruct(FieldPath(), State)
-player_mt = DataclassStruct(FieldPath(), Player)
-bytes_reader = BytesReader(DEMO_BUFFER)
-print(mem_type_from_bytes(state_mt, DEMO_BUFFER, bytes_reader))
-print(mem_type_at_addr(player_mt, 0x6, bytes_reader))

--- a/src/modlunky2/mem/memrauder/msvc.py
+++ b/src/modlunky2/mem/memrauder/msvc.py
@@ -1,0 +1,84 @@
+import dataclasses
+from dataclasses import InitVar, dataclass
+from typing import TypeVar
+
+from modlunky2.mem.memrauder.dsl import struct_field, sc_uint32, sc_void_p
+from modlunky2.mem.memrauder.model import (
+    DataclassStruct,
+    DeferredMemType,
+    FieldPath,
+    MemType,
+    MemoryReader,
+    ScalarCValueConstructionError,
+    unwrap_optional_type,
+    unwrap_collection_type,
+)
+
+
+@dataclass(frozen=True)
+class VectorMeta:
+    array_addr: int = struct_field(0x8, sc_void_p)
+    size: int = struct_field(0x10, sc_uint32)
+
+
+T = TypeVar("T")  # pylint: disable=invalid-name
+
+
+@dataclass(frozen=True)
+class Vector(MemType[T]):
+    path: FieldPath
+    py_type: InitVar[type]
+    deferred_mem_type: InitVar[DeferredMemType]
+
+    elem_mem_type: MemType = dataclasses.field(init=False)
+    collection_type: T = dataclasses.field(init=False)
+    vector_meta_mem_type: MemType[VectorMeta] = dataclasses.field(init=False)
+
+    def __post_init__(self, py_type, deferred_elem_mem_type):
+        opt_inner_type = unwrap_optional_type(self.path, py_type)
+        collection_type, elem_py_type = unwrap_collection_type(
+            self.path, opt_inner_type
+        )
+        elem_mem_type = deferred_elem_mem_type(self.path, elem_py_type)
+        vector_meta_mem_type = DataclassStruct(
+            self.path.append("__vector_meta"), VectorMeta
+        )
+
+        object.__setattr__(self, "collection_type", collection_type)
+        object.__setattr__(self, "elem_mem_type", elem_mem_type)
+        object.__setattr__(self, "vector_meta_mem_type", vector_meta_mem_type)
+
+    def field_size(self) -> int:
+        return self.vector_meta_mem_type.field_size()
+
+    def from_bytes(self, buf: bytes, mem_reader: MemoryReader) -> T:
+        elem_size = self.elem_mem_type.element_size()
+        vector_meta = self.vector_meta_mem_type.from_bytes(buf, mem_reader)
+        elem_buf = mem_reader.read(vector_meta.array_addr, elem_size * vector_meta.size)
+        if elem_buf is None:
+            return None
+
+        values = []
+        for i in range(0, vector_meta.size):
+            elem_offset = elem_size * i
+            elem_end = elem_size * (i + 1)
+            try:
+                elem = self.elem_mem_type.from_bytes(
+                    elem_buf[elem_offset:elem_end], mem_reader
+                )
+                values.append(elem)
+            except ScalarCValueConstructionError:
+                # TODO include index when re-raising?
+                raise
+            except Exception as err:
+                raise ValueError(
+                    f"failed to deserialize index {i} of field {self.path}"
+                ) from err
+        return self.collection_type(values)
+
+
+def vector(elem: DeferredMemType) -> DeferredMemType:
+    def build(path: FieldPath, py_type: type):
+        return Vector(path, py_type, elem)
+
+    return build

--- a/src/modlunky2/mem/memrauder/msvc.py
+++ b/src/modlunky2/mem/memrauder/msvc.py
@@ -54,6 +54,11 @@ class Vector(MemType[T]):
     def from_bytes(self, buf: bytes, mem_reader: MemoryReader) -> T:
         elem_size = self.elem_mem_type.element_size()
         vector_meta = self.vector_meta_mem_type.from_bytes(buf, mem_reader)
+
+        # Don't try to dereference NULL
+        if vector_meta.array_addr == 0:
+            return None
+
         elem_buf = mem_reader.read(vector_meta.array_addr, elem_size * vector_meta.size)
         if elem_buf is None:
             return None

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass
 import enum
 
-from modlunky2.mem.memrauder.dsl import struct_field, c_int32, c_uint32, c_int8, c_uint8
+from modlunky2.mem.memrauder.dsl import (
+    struct_field,
+    sc_int32,
+    sc_uint32,
+    sc_int8,
+    sc_uint8,
+)
 
 
 class RunRecapFlags(enum.IntFlag):
@@ -116,24 +122,24 @@ class FeedcodeNotFound(Exception):
 
 @dataclass(frozen=True)
 class State:
-    screen_last: int = struct_field(0x08, c_int32)
-    screen: int = struct_field(0x0C, c_int32)
-    screen_next: int = struct_field(0x10, c_int32)
-    quest_flags: QuestFlags = struct_field(0x38, c_uint32)
-    world_start: int = struct_field(0x5C, c_uint8)
-    level_start: int = struct_field(0x5D, c_uint8)
-    theme_start: int = struct_field(0x5E, c_uint8)
-    time_total: int = struct_field(0x64, c_uint32)
-    world: int = struct_field(0x68, c_uint8)
-    world_next: int = struct_field(0x69, c_uint8)
-    level: int = struct_field(0x6A, c_uint8)
-    level_next: int = struct_field(0x6B, c_uint8)
-    theme: Theme = struct_field(0x74, c_uint8)
-    theme_next: Theme = struct_field(0x75, c_uint8)
-    win_state: WinState = struct_field(0x76, c_int8)
-    presence_flags: PresenceFlags = struct_field(0xA14, c_uint32)
-    run_recap_flags: RunRecapFlags = struct_field(0x9F4, c_uint32)
-    hud_flags: HudFlags = struct_field(0xA10, c_uint32)
+    screen_last: int = struct_field(0x08, sc_int32)
+    screen: int = struct_field(0x0C, sc_int32)
+    screen_next: int = struct_field(0x10, sc_int32)
+    quest_flags: QuestFlags = struct_field(0x38, sc_uint32)
+    world_start: int = struct_field(0x5C, sc_uint8)
+    level_start: int = struct_field(0x5D, sc_uint8)
+    theme_start: int = struct_field(0x5E, sc_uint8)
+    time_total: int = struct_field(0x64, sc_uint32)
+    world: int = struct_field(0x68, sc_uint8)
+    world_next: int = struct_field(0x69, sc_uint8)
+    level: int = struct_field(0x6A, sc_uint8)
+    level_next: int = struct_field(0x6B, sc_uint8)
+    theme: Theme = struct_field(0x74, sc_uint8)
+    theme_next: Theme = struct_field(0x75, sc_uint8)
+    win_state: WinState = struct_field(0x76, sc_int8)
+    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32)
+    run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32)
+    hud_flags: HudFlags = struct_field(0xA10, sc_uint32)
     # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
     # If the run ends in a victory, the bonus will be added to this during the score screen.
-    money_shop_total: int = struct_field(0x58, c_int32)
+    money_shop_total: int = struct_field(0x58, sc_int32)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -139,6 +139,9 @@ class State:
     screen: int = struct_field(0x0C, sc_int32)
     screen_next: int = struct_field(0x10, sc_int32)
     quest_flags: QuestFlags = struct_field(0x38, sc_uint32)
+    # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
+    # If the run ends in a victory, the bonus will be added to this during the score screen.
+    money_shop_total: int = struct_field(0x58, sc_int32)
     world_start: int = struct_field(0x5C, sc_uint8)
     level_start: int = struct_field(0x5D, sc_uint8)
     theme_start: int = struct_field(0x5E, sc_uint8)
@@ -150,10 +153,7 @@ class State:
     theme: Theme = struct_field(0x74, sc_uint8)
     theme_next: Theme = struct_field(0x75, sc_uint8)
     win_state: WinState = struct_field(0x76, sc_int8)
-    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32)
     run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32)
     hud_flags: HudFlags = struct_field(0xA10, sc_uint32)
-    # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
-    # If the run ends in a victory, the bonus will be added to this during the score screen.
-    money_shop_total: int = struct_field(0x58, sc_int32)
+    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32)
     items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct))

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -1,11 +1,7 @@
+from dataclasses import dataclass
 import enum
-from typing import List, TYPE_CHECKING
-from struct import unpack
 
-from .entities import EntityMap, Player
-
-if TYPE_CHECKING:
-    from . import Spel2Process
+from modlunky2.mem.memrauder.dsl import struct_field, c_int32, c_uint32, c_int8, c_uint8
 
 
 class RunRecapFlags(enum.IntFlag):
@@ -118,121 +114,26 @@ class FeedcodeNotFound(Exception):
     """Failed to find feedcode within Spelunky2 memory."""
 
 
+@dataclass(frozen=True)
 class State:
-    def __init__(self, proc):
-        self._proc: "Spel2Process" = proc
-        feedcode = proc.get_feedcode()
-        if feedcode is None:
-            raise FeedcodeNotFound("Failed to find feedcode within Spelunky2 memory")
-        self._offset = feedcode - 0x5F
-        self._uid_to_entity = None
-
-    @property
-    def screen_last(self):
-        return self._proc.read_i32(self._offset + 0x08)
-
-    @property
-    def screen(self):
-        return self._proc.read_i32(self._offset + 0x0C)
-
-    @property
-    def screen_next(self):
-        return self._proc.read_i32(self._offset + 0x10)
-
-    @property
-    def quest_flags(self):
-        offset = self._offset + 0x38
-        return QuestFlags(self._proc.read_u32(offset))
-
-    @property
-    def world_start(self):
-        return self._proc.read_u8(self._offset + 0x5C)
-
-    @property
-    def level_start(self):
-        return self._proc.read_u8(self._offset + 0x5D)
-
-    @property
-    def theme_start(self):
-        return Theme(self._proc.read_u8(self._offset + 0x5E))
-
-    @property
-    def time_total(self):
-        return self._proc.read_u32(self._offset + 0x64)
-
-    @property
-    def world(self):
-        return self._proc.read_u8(self._offset + 0x68)
-
-    @property
-    def world_next(self):
-        return self._proc.read_u8(self._offset + 0x69)
-
-    @property
-    def level(self):
-        return self._proc.read_u8(self._offset + 0x6A)
-
-    @property
-    def level_next(self):
-        return self._proc.read_u8(self._offset + 0x6B)
-
-    @property
-    def theme(self):
-        return Theme(self._proc.read_u8(self._offset + 0x74))
-
-    @property
-    def theme_next(self):
-        return Theme(self._proc.read_u8(self._offset + 0x75))
-
-    @property
-    def win_state(self):
-        return WinState(self._proc.read_i8(self._offset + 0x76))
-
-    @property
-    def presence_flags(self):
-        offset = self._offset + 0xA14
-        return PresenceFlags(self._proc.read_u32(offset))
-
-    @property
-    def run_recap_flags(self):
-        offset = self._offset + 0x9F4
-        return RunRecapFlags(self._proc.read_u32(offset))
-
-    @property
-    def hud_flags(self):
-        offset = self._offset + 0xA10
-        return HudFlags(self._proc.read_u32(offset))
-
-    @property
-    def money_shop_total(self):
-        """The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
-        If the run ends in a victory, the bonus will be added to this during the score screen.
-        """
-        offset = self._offset + 0x58
-        return self._proc.read_i32(offset)
-
-    @property
-    def players(self) -> List[Player]:  # items
-        offset = self._offset + 0x12B0
-        items_ptr = self._proc.read_void_p(offset) + 8
-        player_pointers = self._proc.read_memory(items_ptr, 8 * 4)
-
-        players = []
-
-        for idx in range(0, len(player_pointers), 8):
-            player_pointer = player_pointers[idx : idx + 8]
-            if player_pointer == b"\x00\x00\x00\x00\x00\x00\x00\x00":
-                players.append(None)
-                continue
-
-            player_pointer = unpack("P", player_pointer)[0]
-            players.append(Player(self._proc, player_pointer))
-
-        return players
-
-    @property
-    def uid_to_entity(self):
-        if self._uid_to_entity is None:
-            offset = self._offset + 0x1308
-            self._uid_to_entity = EntityMap(self._proc, offset)
-        return self._uid_to_entity
+    screen_last: int = struct_field(0x08, c_int32)
+    screen: int = struct_field(0x0C, c_int32)
+    screen_next: int = struct_field(0x10, c_int32)
+    quest_flags: QuestFlags = struct_field(0x38, c_uint32)
+    world_start: int = struct_field(0x5C, c_uint8)
+    level_start: int = struct_field(0x5D, c_uint8)
+    theme_start: int = struct_field(0x5E, c_uint8)
+    time_total: int = struct_field(0x64, c_uint32)
+    world: int = struct_field(0x68, c_uint8)
+    world_next: int = struct_field(0x69, c_uint8)
+    level: int = struct_field(0x6A, c_uint8)
+    level_next: int = struct_field(0x6B, c_uint8)
+    theme: Theme = struct_field(0x74, c_uint8)
+    theme_next: Theme = struct_field(0x75, c_uint8)
+    win_state: WinState = struct_field(0x76, c_int8)
+    presence_flags: PresenceFlags = struct_field(0xA14, c_uint32)
+    run_recap_flags: RunRecapFlags = struct_field(0x9F4, c_uint32)
+    hud_flags: HudFlags = struct_field(0xA10, c_uint32)
+    # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
+    # If the run ends in a victory, the bonus will be added to this during the score screen.
+    money_shop_total: int = struct_field(0x58, c_int32)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
 import enum
+from typing import Optional, Tuple
+
+from modlunky2.mem.entities import Player
 
 from modlunky2.mem.memrauder.dsl import (
+    array,
+    pointer,
     struct_field,
+    dc_struct,
     sc_int32,
     sc_uint32,
     sc_int8,
@@ -121,6 +127,13 @@ class FeedcodeNotFound(Exception):
 
 
 @dataclass(frozen=True)
+class Items:
+    players: Tuple[Optional[Player], ...] = struct_field(
+        0x08, array(pointer(dc_struct), 4)
+    )
+
+
+@dataclass(frozen=True)
 class State:
     screen_last: int = struct_field(0x08, sc_int32)
     screen: int = struct_field(0x0C, sc_int32)
@@ -143,3 +156,4 @@ class State:
     # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
     # If the run ends in a victory, the bonus will be added to this during the score screen.
     money_shop_total: int = struct_field(0x58, sc_int32)
+    items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct))

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -175,6 +175,7 @@ def _build_allowed_c_types():
         ctypes.c_uint32,
         ctypes.c_int64,
         ctypes.c_uint64,
+        ctypes.c_void_p,
     ]:
         pair_list.append((c_type, int))
     for c_type in [

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -1,0 +1,225 @@
+import array
+import ctypes
+from dataclasses import dataclass, field
+import dataclasses
+from enum import Enum, IntEnum, IntFlag
+from ctypes import c_uint32, c_uint8
+from typing import Any, ClassVar, Tuple, Union
+
+
+class HudFlags(IntFlag):
+    UPBEAT_DWELLING_MUSIC = 1 << 1 - 1
+    RUNNING_TUTORIAL_SPEEDRUN = 1 << 3 - 1
+    ALLOW_PAUSE = 1 << 20 - 1
+    HAVE_CLOVER = 1 << 23 - 1
+
+
+class WinState(IntEnum):
+    UNKNOWN = -1
+    NO_WIN = 0
+    TIAMAT = 1
+    HUNDUN = 2
+    COSMIC_OCEAN = 3
+
+
+class MetadataKey(Enum):
+    OFFSET = "ml2_offset"
+    C_TYPE = "ml2_c_type"
+    COUNT = "ml2_count"
+
+
+# TODO: fallback value for enums?
+def struct_field(
+    offset: int,
+    c_type: type = None,
+    count: int = 1,
+    metadata: dict = None,
+    **kwargs,
+):
+    if metadata is None:
+        metadata = {}
+    metadata[MetadataKey.OFFSET] = offset
+    metadata[MetadataKey.C_TYPE] = c_type
+    metadata[MetadataKey.COUNT] = count
+    return field(metadata=metadata, **kwargs)
+
+
+@dataclass(frozen=True)
+class Player:
+    # Overall struct size, used for computing array element offsets
+    _size_as_element_: ClassVar[int] = 4
+    bombs: int = struct_field(0x0, c_uint8)
+    ropes: int = struct_field(0x1, c_uint8)
+
+
+@dataclass(frozen=True)
+class State:
+    level: int = struct_field(0x0, c_uint8)
+    hud_flags: HudFlags = struct_field(0x1, c_uint32)
+    win_state: WinState = struct_field(0x5, c_uint8)
+    direct_player: Player = struct_field(0x6)
+    nums_list: Tuple[int, ...] = struct_field(0x6, count=2, c_type=c_uint8)
+    enum_list: Tuple[WinState, ...] = struct_field(0xA, count=2, c_type=c_uint8)
+    player_list: Tuple[Player, ...] = struct_field(0x8, count=2)
+
+
+# Unused for now, maybe handy for pointers
+def unwrap_optional(opt_type: type) -> type:
+    if opt_type.__origin__ is not Union:
+        raise ValueError("Not a union type. Can't be Optional")
+    union_args = opt_type.__args__
+    num_args = len(union_args)
+    if num_args != 2:
+        raise ValueError(f"Not an Optional type. Expected 2 union args, got {num_args}")
+    if union_args[1] is not type(None):
+        raise ValueError(
+            f"Not an Optional type. Expected second Union arg to be None, got {union_args[1]}"
+        )
+    return union_args[0]
+
+
+def validate_collection_field_type(a_field: dataclasses.Field):
+    try:
+        collection_type = a_field.type.__origin__
+    except ValueError as err:
+        raise ValueError(
+            f"field {a_field.name} has positive count and must be tuple or frozenset. Got type {a_field.type}"
+        ) from err
+
+    if collection_type is not tuple:
+        raise ValueError(
+            f"field {a_field.name} has positive count and must be tuple or frozenset. Got type {a_field.type}"
+        )
+
+    # For tuples, we need to do some more checks
+    type_args = a_field.type.__args__
+    if len(type_args) != 2:
+        raise ValueError(
+            f"tuple field {a_field.name} must have 2 type parameters. Got {len(type_args)}"
+        )
+    if type_args[1] is not Ellipsis:
+        raise ValueError(
+            f"tuple field {a_field.name} second type parameter must be '...'. Got {type_args[1]}"
+        )
+    c_type = a_field.metadata[MetadataKey.C_TYPE]
+    if c_type is None and not dataclasses.is_dataclass(type_args[0]):
+        raise ValueError(
+            f"tuple field {a_field.name} must either have a c_type, or the first type parameter must be a dataclass. Got {type_args[0]}"
+        )
+
+
+def element_size_for_field(a_field: dataclasses.Field):
+    validate_collection_field_type(a_field)
+    field_name = a_field.name
+    c_type = a_field.metadata.get(MetadataKey.C_TYPE)
+
+    # TODO consider alignment
+
+    if c_type is not None:
+        return ctypes.sizeof(c_type)
+
+    # For both tuple and frozenset, the first type parameter is what we want
+    cls = a_field.type.__args__[0]
+    if not dataclasses.dataclass(cls):
+        raise ValueError(f"{field_name} doesn't have a c_type and isn't a dataclass")
+
+    try:
+        return cls._size_as_element_  # pylint: disable=protected-access
+    except AttributeError:
+        raise ValueError(  # pylint: disable=raise-missing-from
+            f"{field_name} must have _size_as_element_ attribute to be used as a field"
+        )
+
+
+def collection_type_for_field(a_field: dataclasses.Field):
+    validate_collection_field_type(a_field)
+    return a_field.type.__origin__
+
+
+def dataclass_from_buffer(cls: type, buf, offset: int = 0) -> Any:
+    print(f"reading dataclass {cls!r}")
+    field_data = {}
+    field_list = list(dataclasses.fields(cls))
+    for a_field in field_list:
+        if not a_field.init:
+            continue
+        field_data[a_field.name] = field_from_buffer(a_field, buf, offset)
+
+    return cls(**field_data)
+
+
+def field_from_buffer(a_field: dataclasses.Field, buf, base_offset: int = 0) -> Any:
+    print(f"reading field {a_field.name!r} {a_field.type!r} {a_field.metadata!r} ...")
+    field_offset = base_offset + a_field.metadata[MetadataKey.OFFSET]
+    count = a_field.metadata[MetadataKey.COUNT]
+    # Read single values directly
+    if count == 1:
+        return field_element_from_buffer(a_field, buf, field_offset)
+
+    if count <= 0:
+        raise ValueError(f"field {a_field.name} has non-positive count {count}")
+
+    collection_type = collection_type_for_field(a_field)
+    elem_size = 4  # element_size_for_field(a_field)
+    values = []
+    for i in range(0, count):
+        elem_offset = field_offset + elem_size * i
+        values.append(field_element_from_buffer(a_field, buf, elem_offset))
+    return collection_type(values)
+
+
+def field_element_from_buffer(a_field: dataclasses.Field, buf, elem_offset) -> Any:
+    print(
+        f"reading element for field {a_field.name!r} {a_field.type!r} {a_field.metadata!r} ..."
+    )
+    c_type = a_field.metadata.get(MetadataKey.C_TYPE)
+    count = a_field.metadata.get(MetadataKey.COUNT)
+
+    # TODO: Check if type is tuple or frozenset, since those aren't expected for single values.
+    # TODO: Consider whether support array size 1
+    underlying_type = a_field.type
+    if count > 1:
+        validate_collection_field_type(a_field)
+        underlying_type = underlying_type.__args__[0]
+
+    if c_type is not None:
+        val = c_type.from_buffer(buf, elem_offset).value
+        try:
+            return underlying_type(val)
+        except Exception as err:
+            # TODO add this in other places, provide more detail
+            raise Exception(
+                f"failed to construct value for field {a_field.name}"
+            ) from err
+
+    if dataclasses.is_dataclass(underlying_type):
+        return dataclass_from_buffer(underlying_type, buf, elem_offset)
+    else:
+        raise Exception(
+            "Field {a_field.name} isn't a dataclass and doesn't have a c_type"
+        )
+
+
+state_fields = dataclasses.fields(State)
+a_buf = array.array(
+    "B",
+    [
+        0x02,
+        0x00,
+        0x00,
+        0x40,
+        0x00,
+        0x03,
+        0x63,
+        0x2A,
+        0x01,
+        0x02,
+        0x00,
+        0x00,
+        0x03,
+        0x04,
+        0x00,
+        0x00,
+    ],
+)
+print(dataclass_from_buffer(State, a_buf))

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import array
 import ctypes
 from dataclasses import dataclass
 import dataclasses
@@ -89,8 +88,7 @@ class State:
 #     nums_list=(99, 0),
 #     enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
 #     player_list=(Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)))
-DEMO_BUFFER = array.array(
-    "B",
+DEMO_BUFFER = bytearray(
     [
         0x02,
         0x00,
@@ -108,7 +106,7 @@ DEMO_BUFFER = array.array(
         0x04,
         0x00,
         0x00,
-    ],
+    ]
 )
 
 # Unused for now, maybe handy for pointers
@@ -199,7 +197,7 @@ class StructField:
         else:
             return ctypes.sizeof(self.c_type)
 
-    def from_buffer(self, buf: array.array) -> Any:
+    def from_buffer(self, buf: bytearray) -> Any:
         val_offset = 0 + self.offset
         # Read single values directly
         if self.count == 1:
@@ -213,7 +211,7 @@ class StructField:
             values.append(self._value_from_buffer(buf[elem_offset:]))
         return self.collection_type(values)
 
-    def _value_from_buffer(self, buf: array.array) -> Any:
+    def _value_from_buffer(self, buf: bytearray) -> Any:
         # This doesn't use self.offset because the caller is exepceted to compute the position
 
         # TODO: Consider whether support array size 1

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -63,6 +63,37 @@ class State:
     player_list: Tuple[Player, ...] = struct_field(0x8, count=2)
 
 
+# Demo output:
+# State(
+#     level=2,
+#     hud_flags=<HudFlags.HAVE_CLOVER: 4194304>,
+#     win_state=<WinState.COSMIC_OCEAN: 3>,
+#     direct_player=Player(bombs=99, ropes=42),
+#     nums_list=(99, 0),
+#     enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
+#     player_list=(Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)))
+DEMO_BUFFER = array.array(
+    "B",
+    [
+        0x02,
+        0x00,
+        0x00,
+        0x40,
+        0x00,
+        0x03,
+        0x63,
+        0x2A,
+        0x01,
+        0x02,
+        0x00,
+        0x00,
+        0x03,
+        0x04,
+        0x00,
+        0x00,
+    ],
+)
+
 # Unused for now, maybe handy for pointers
 def unwrap_optional(opt_type: type) -> type:
     if opt_type.__origin__ is not Union:
@@ -200,26 +231,4 @@ def field_element_from_buffer(a_field: dataclasses.Field, buf, elem_offset) -> A
         )
 
 
-state_fields = dataclasses.fields(State)
-a_buf = array.array(
-    "B",
-    [
-        0x02,
-        0x00,
-        0x00,
-        0x40,
-        0x00,
-        0x03,
-        0x63,
-        0x2A,
-        0x01,
-        0x02,
-        0x00,
-        0x00,
-        0x03,
-        0x04,
-        0x00,
-        0x00,
-    ],
-)
-print(dataclass_from_buffer(State, a_buf))
+print(dataclass_from_buffer(State, DEMO_BUFFER))

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -4,7 +4,6 @@ import ctypes
 from dataclasses import InitVar, dataclass
 import dataclasses
 from enum import IntEnum, IntFlag
-import functools
 from typing import (
     Callable,
     ClassVar,
@@ -378,7 +377,6 @@ dc_struct = DataclassStruct  # pylint: disable=invalid-name
 
 
 def scalar_c_type(c_type):
-    @functools.wraps(ScalarCType)
     def build(path: FieldPath, py_type: type):
         return ScalarCType(path, py_type, c_type)
 

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -502,9 +502,11 @@ class State:
 #     hud_flags=<HudFlags.HAVE_CLOVER: 4194304>,
 #     win_state=<WinState.COSMIC_OCEAN: 3>,
 #     direct_player=Player(bombs=99, ropes=42),
-#     nums_list=(99, 42),
-#     enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
-#     player_list=(Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)))
+#     nums_list=(99, 42), enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
+#     player_set=frozenset({Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)}),
+#     pointed_player=Player(bombs=99, ropes=42)
+# )
+# Player(bombs=99, ropes=42)
 DEMO_BUFFER = b"\x02\x00\x00\x40\x00\x03\x63\x2a\x01\x02\x00\x00\x03\x04\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00"
 
 state_mt = DataclassStruct(FieldPath(), State)

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -9,21 +9,6 @@ from typing import Any, ClassVar, Generic, List, Optional, Tuple, TypeVar, Union
 import typing
 
 
-class HudFlags(IntFlag):
-    UPBEAT_DWELLING_MUSIC = 1 << 1 - 1
-    RUNNING_TUTORIAL_SPEEDRUN = 1 << 3 - 1
-    ALLOW_PAUSE = 1 << 20 - 1
-    HAVE_CLOVER = 1 << 23 - 1
-
-
-class WinState(IntEnum):
-    UNKNOWN = -1
-    NO_WIN = 0
-    TIAMAT = 1
-    HUNDUN = 2
-    COSMIC_OCEAN = 3
-
-
 # Abstract memory-reader interface
 class MemoryReader(ABC):
     @abstractmethod
@@ -88,55 +73,6 @@ def struct_field(
     field_meta.put_into(metadata)
     return dataclasses.field(metadata=metadata, **kwargs)
 
-
-@dataclass(frozen=True)
-class Player:
-    # Overall struct size, used for computing array element offsets
-    _size_as_element_: ClassVar[int] = 4
-    bombs: int = struct_field(0x0, c_uint8)
-    ropes: int = struct_field(0x1, c_uint8)
-
-
-@dataclass(frozen=True)
-class State:
-    level: int = struct_field(0x0, c_uint8)
-    hud_flags: HudFlags = struct_field(0x1, c_uint32)
-    win_state: WinState = struct_field(0x5, c_uint8)
-    direct_player: Player = struct_field(0x6)
-    nums_list: Tuple[int, ...] = struct_field(0x6, count=2, c_type=c_uint8)
-    enum_list: Tuple[WinState, ...] = struct_field(0xA, count=2, c_type=c_uint8)
-    player_list: Tuple[Player, ...] = struct_field(0x8, count=2)
-
-
-# Demo output:
-# State(
-#     level=2,
-#     hud_flags=<HudFlags.HAVE_CLOVER: 4194304>,
-#     win_state=<WinState.COSMIC_OCEAN: 3>,
-#     direct_player=Player(bombs=99, ropes=42),
-#     nums_list=(99, 0),
-#     enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
-#     player_list=(Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)))
-DEMO_BUFFER = bytearray(
-    [
-        0x02,
-        0x00,
-        0x00,
-        0x40,
-        0x00,
-        0x03,
-        0x63,
-        0x2A,
-        0x01,
-        0x02,
-        0x00,
-        0x00,
-        0x03,
-        0x04,
-        0x00,
-        0x00,
-    ]
-)
 
 # Unused for now, maybe handy for pointers
 def unwrap_optional(opt_type: type) -> type:
@@ -449,7 +385,72 @@ class Pointer(MemType[T]):
         _ = ctypes.c_void_p.from_buffer(buf)
 
 
-### Demo ugliness :)
+### Demo
+
+
+class HudFlags(IntFlag):
+    UPBEAT_DWELLING_MUSIC = 1 << 1 - 1
+    RUNNING_TUTORIAL_SPEEDRUN = 1 << 3 - 1
+    ALLOW_PAUSE = 1 << 20 - 1
+    HAVE_CLOVER = 1 << 23 - 1
+
+
+class WinState(IntEnum):
+    UNKNOWN = -1
+    NO_WIN = 0
+    TIAMAT = 1
+    HUNDUN = 2
+    COSMIC_OCEAN = 3
+
+
+@dataclass(frozen=True)
+class Player:
+    # Overall struct size, used for computing array element offsets
+    _size_as_element_: ClassVar[int] = 4
+    bombs: int = struct_field(0x0, c_uint8)
+    ropes: int = struct_field(0x1, c_uint8)
+
+
+@dataclass(frozen=True)
+class State:
+    level: int = struct_field(0x0, c_uint8)
+    hud_flags: HudFlags = struct_field(0x1, c_uint32)
+    win_state: WinState = struct_field(0x5, c_uint8)
+    direct_player: Player = struct_field(0x6)
+    nums_list: Tuple[int, ...] = struct_field(0x6, count=2, c_type=c_uint8)
+    enum_list: Tuple[WinState, ...] = struct_field(0xA, count=2, c_type=c_uint8)
+    player_list: Tuple[Player, ...] = struct_field(0x8, count=2)
+
+
+# Demo output:
+# State(
+#     level=2,
+#     hud_flags=<HudFlags.HAVE_CLOVER: 4194304>,
+#     win_state=<WinState.COSMIC_OCEAN: 3>,
+#     direct_player=Player(bombs=99, ropes=42),
+#     nums_list=(99, 0),
+#     enum_list=(<WinState.NO_WIN: 0>, <WinState.NO_WIN: 0>),
+#     player_list=(Player(bombs=1, ropes=2), Player(bombs=3, ropes=4)))
+DEMO_BUFFER = bytearray(
+    [
+        0x02,
+        0x00,
+        0x00,
+        0x40,
+        0x00,
+        0x03,
+        0x63,
+        0x2A,
+        0x01,
+        0x02,
+        0x00,
+        0x00,
+        0x03,
+        0x04,
+        0x00,
+        0x00,
+    ]
+)
 
 print(dataclass_from_buffer(State, DEMO_BUFFER))
 print(f"memory range for State is {DataclassType(State).memory_range()}")

--- a/src/modlunky2/mem_demo.py
+++ b/src/modlunky2/mem_demo.py
@@ -79,6 +79,10 @@ class FieldPath:
     def __str__(self):
         return ".".join(self.path_parts)
 
+    def append(self, part):
+        suffix = tuple([str(part)])
+        return FieldPath(self.path_parts + suffix)
+
 
 # Checks that a type is Optional and returns the inner type.
 def unwrap_optional_type(path: FieldPath, py_type: type) -> type:
@@ -256,7 +260,7 @@ class DataclassStruct(MemType[T]):
         struct_fields = {}
         for field in dataclasses.fields(self.dataclass):
             meta = StructFieldMeta.from_field(field)
-            inner_path = FieldPath(self.path.path_parts + tuple([field.name]))
+            inner_path = self.path.append(field.name)
             inner_mem_type = meta.deferred_mem_type(inner_path, type_hints[field.name])
             struct_fields[field.name] = StructField(
                 inner_path, meta.offset, inner_mem_type, inner_mem_type.field_size()

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -8,7 +8,8 @@ from tkinter import PhotoImage
 
 from modlunky2.config import DATA_DIR
 from modlunky2.constants import BASE_DIR
-from modlunky2.mem import find_spelunky2_pid, Spel2Process
+from modlunky2.mem import FeedcodeNotFound, find_spelunky2_pid, Spel2Process
+from modlunky2.mem.memrauder.model import ScalarCValueConstructionError
 from modlunky2.utils import tb_info
 
 logger = logging.getLogger("modlunky2")
@@ -47,6 +48,9 @@ class WatcherThread(threading.Thread):
     def _really_poll(self):
         try:
             self.poll()
+        except (FeedcodeNotFound, ScalarCValueConstructionError):
+            # These exceptions are likely transient
+            return
         except Exception:  # pylint: disable=broad-except
             # If the game is no longer running, we assume that caused the failure
             if self.proc.running():
@@ -77,7 +81,9 @@ class WatcherThread(threading.Thread):
             self.die("Failed to open handle to Spel2.exe")
             return False
 
-        if proc.state is None:
+        try:
+            proc.state
+        except (FeedcodeNotFound, ScalarCValueConstructionError):
             # Game might still be starting, we should try again
             return False
 

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -73,7 +73,9 @@ class PacifistWatcherThread(WatcherThread):
             self.die("Failed to read expected address...")
             self.shutdown()
 
-        player = self.proc.players[0]
+        player = None
+        if self.proc.state.items is not None:
+            player = self.proc.state.items.players[0]
         if player and player.inventory:
             self.kills_total = player.inventory.kills_total
 

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -73,7 +73,7 @@ class PacifistWatcherThread(WatcherThread):
             self.die("Failed to read expected address...")
             self.shutdown()
 
-        player = self.proc.state.players[0]
+        player = self.proc.players[0]
         if player and player.inventory:
             self.kills_total = player.inventory.kills_total
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -658,7 +658,7 @@ class RunState:
         item_types = set()
         entity_map = self._proc.uid_to_entity
         for item in player.items:
-            entity = entity_map.get(item)
+            entity = entity_map.get_as_entity(item, self._proc.mem_reader)
             if entity is None:
                 continue
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -7,6 +7,7 @@ from modlunky2.mem.entities import (
     CHAIN_POWERUP_ENTITIES,
     CharState,
     EntityType,
+    EntityWrapper,
     Inventory,
     LOW_BANNED_ATTACKABLES,
     LOW_BANNED_THROWABLES,
@@ -197,14 +198,17 @@ class RunState:
             self.final_death = True
             return
 
-    def update_has_mounted_tame(self, player_overlay):
+    def update_has_mounted_tame(self, player_overlay: EntityWrapper):
         if not self.is_low_percent:
             return
 
         if not player_overlay:
             return
 
-        entity_type: EntityType = player_overlay.type.id
+        overlay_entity = player_overlay.as_entity(self._proc.mem_reader)
+        if overlay_entity is None:
+            return
+        entity_type: EntityType = overlay_entity.type.id
         # Allowed to ride tamed qilin in tiamats
         if self.theme == Theme.TIAMAT and entity_type == EntityType.MOUNT_QILIN:
             self.lc_has_mounted_qilin = True
@@ -214,8 +218,8 @@ class RunState:
             return
 
         if entity_type in MOUNTS:
-            mount = player_overlay.as_mount()
-            if mount.is_tamed:
+            mount = player_overlay.as_mount(self._proc.mem_reader)
+            if mount is not None and mount.is_tamed:
                 self.has_mounted_tame = True
                 self.fail_low()
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -600,7 +600,7 @@ class RunState:
                 self.fail_low()
 
     def update(self):
-        player = self._proc.state.players[0]
+        player = self._proc.players[0]
         if player is None:
             return
 
@@ -656,7 +656,7 @@ class RunState:
 
     def update_player_item_types(self, player: Player):
         item_types = set()
-        entity_map = self._proc.state.uid_to_entity
+        entity_map = self._proc.uid_to_entity
         for item in player.items:
             entity = entity_map.get(item)
             if entity is None:

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -164,18 +164,12 @@ class RunState:
             elif item_type == EntityType.ITEM_HOUYIBOW and self.world >= 3:
                 self.hou_yis_waddler = True
 
-    def get_critical_state(self, var):
-        result = getattr(self._proc.state, var)
-        if result is None:
-            raise FailedMemoryRead(f"Failed to read critical state for {var}")
-        return result
-
     def update_global_state(self):
-        world = self.get_critical_state("world")
-        level = self.get_critical_state("level")
-        theme = self.get_critical_state("theme")
-        screen = self.get_critical_state("screen")
-        win_state = self.get_critical_state("win_state")
+        world = self._proc.state.world
+        level = self._proc.state.level
+        theme = self._proc.state.theme
+        screen = self._proc.state.screen
+        win_state = self._proc.state.win_state
 
         if (world, level) != (self.world, self.level):
             self.level_started = True
@@ -546,7 +540,7 @@ class RunState:
     def update_millionaire(self, inventory: Inventory):
         collected_this_level = inventory.money
         collected_prev_levels = inventory.collected_money_total
-        shop_and_bonus = self.get_critical_state("money_shop_total")
+        shop_and_bonus = self._proc.state.money_shop_total
         if collected_this_level is not None and collected_prev_levels is not None:
             self.net_score = (
                 collected_this_level + collected_prev_levels + shop_and_bonus
@@ -615,9 +609,9 @@ class RunState:
         self.player_state = state
         self.player_last_state = last_state
 
-        run_recap_flags = self.get_critical_state("run_recap_flags")
-        hud_flags = self.get_critical_state("hud_flags")
-        presence_flags = self.get_critical_state("presence_flags")
+        run_recap_flags = self._proc.state.run_recap_flags
+        hud_flags = self._proc.state.hud_flags
+        presence_flags = self._proc.state.presence_flags
         self.update_global_state()
         self.update_on_level_start()
         self.update_player_item_types(player)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -657,6 +657,8 @@ class RunState:
     def update_player_item_types(self, player: Player):
         item_types = set()
         entity_map = self._proc.uid_to_entity
+        if player.items is None:
+            return
         for item in player.items:
             entity = entity_map.get_as_entity(item, self._proc.mem_reader)
             if entity is None:

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -598,7 +598,9 @@ class RunState:
                 self.fail_low()
 
     def update(self):
-        player = self._proc.players[0]
+        if self._proc.state.items is None:
+            return
+        player = self._proc.state.items.players[0]
         if player is None:
             return
 

--- a/src/tests/mem/memrauder/test_dsl.py
+++ b/src/tests/mem/memrauder/test_dsl.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import ClassVar, FrozenSet, Tuple, Optional
+
+from modlunky2.mem.memrauder.dsl import (
+    array,
+    c_bool,
+    c_uint8,
+    c_uint16,
+    dc_struct,
+    pointer,
+    struct_field,
+)
+from modlunky2.mem.memrauder.model import (
+    BytesReader,
+    DataclassStruct,
+    FieldPath,
+    mem_type_from_bytes,
+)
+
+
+@dataclass(frozen=True)
+class Player:
+    _size_as_element_: ClassVar[int] = 3
+    bombs: int = struct_field(0x0, c_uint8)
+    ropes: int = struct_field(0x1, c_uint8)
+
+
+@dataclass(frozen=True)
+class State:
+    level: int = struct_field(0x0, c_uint8)
+    bool_tuple: Tuple[bool, ...] = struct_field(0x2, array(c_bool, 3))
+    player_set: FrozenSet[Player] = struct_field(0x5, array(dc_struct, 2))
+    pointed_int: Optional[int] = struct_field(0xB, pointer(c_uint16))
+
+
+def test_player():
+    player_mt = DataclassStruct(FieldPath(), Player)
+    state_bytes = b"\x10\x20"
+    assert mem_type_from_bytes(player_mt, state_bytes) == Player(16, 32)
+
+
+def test_state():
+    state_mt = DataclassStruct(FieldPath(), State)
+    state_bytes = (
+        b"\x05\xff\x00\x01\x01\x63\x2a\xff\x08\x01\xff\x02\x00\x00\x00\x00\x00\x00\x00"
+    )
+    bytes_reader = BytesReader(b"\x00\x00\x03\x01")
+    expected = State(
+        5, (False, True, True), frozenset([Player(99, 42), Player(8, 1)]), 259
+    )
+    assert mem_type_from_bytes(state_mt, state_bytes, bytes_reader) == expected

--- a/src/tests/mem/memrauder/test_dsl.py
+++ b/src/tests/mem/memrauder/test_dsl.py
@@ -3,9 +3,9 @@ from typing import ClassVar, FrozenSet, Tuple, Optional
 
 from modlunky2.mem.memrauder.dsl import (
     array,
-    c_bool,
-    c_uint8,
-    c_uint16,
+    sc_bool,
+    sc_uint8,
+    sc_uint16,
     dc_struct,
     pointer,
     struct_field,
@@ -21,16 +21,16 @@ from modlunky2.mem.memrauder.model import (
 @dataclass(frozen=True)
 class Player:
     _size_as_element_: ClassVar[int] = 3
-    bombs: int = struct_field(0x0, c_uint8)
-    ropes: int = struct_field(0x1, c_uint8)
+    bombs: int = struct_field(0x0, sc_uint8)
+    ropes: int = struct_field(0x1, sc_uint8)
 
 
 @dataclass(frozen=True)
 class State:
-    level: int = struct_field(0x0, c_uint8)
-    bool_tuple: Tuple[bool, ...] = struct_field(0x2, array(c_bool, 3))
+    level: int = struct_field(0x0, sc_uint8)
+    bool_tuple: Tuple[bool, ...] = struct_field(0x2, array(sc_bool, 3))
     player_set: FrozenSet[Player] = struct_field(0x5, array(dc_struct, 2))
-    pointed_int: Optional[int] = struct_field(0xB, pointer(c_uint16))
+    pointed_int: Optional[int] = struct_field(0xB, pointer(sc_uint16))
 
 
 def test_player():

--- a/src/tests/mem/memrauder/test_model.py
+++ b/src/tests/mem/memrauder/test_model.py
@@ -1,0 +1,141 @@
+import ctypes
+from dataclasses import dataclass, field
+from enum import IntEnum, IntFlag
+from typing import FrozenSet, Optional, Set, Tuple
+import pytest
+
+from modlunky2.mem.memrauder.model import (
+    Array,
+    BytesReader,
+    DataclassStruct,
+    FieldPath,
+    Pointer,
+    ScalarCType,
+    StructFieldMeta,
+)
+
+EMPTY_BYTES_READER = BytesReader(bytes())
+
+
+def deferred_uint8(path, elm_type):
+    return ScalarCType(path, elm_type, ctypes.c_uint8)
+
+
+class FourEnum(IntEnum):
+    FOUR = 4
+
+
+class SecondBitFlag(IntFlag):
+    SECOND = 1 << 2
+
+
+@pytest.mark.parametrize(
+    "py_type,expected",
+    [(int, 4), (FourEnum, FourEnum.FOUR), (SecondBitFlag, SecondBitFlag.SECOND)],
+)
+def test_scalar_c_type_byte(py_type, expected):
+    sc_type = ScalarCType(FieldPath(), py_type, ctypes.c_uint8)
+    assert sc_type.from_bytes(b"\x04", EMPTY_BYTES_READER) == expected
+
+
+def test_scalar_c_type_mismatch():
+    def build():
+        ScalarCType(FieldPath(), int, ctypes.c_float)
+
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_scalar_c_type_too_small():
+    def read():
+        sc_type = ScalarCType(FieldPath(), int, ctypes.c_uint8)
+        sc_type.from_bytes(b"", EMPTY_BYTES_READER)
+
+    with pytest.raises(ValueError):
+        read()
+
+
+def test_dataclass_struct_simple():
+    meta_0 = {}
+    StructFieldMeta(0x0, deferred_uint8).put_into(meta_0)
+    meta_3 = {}
+    StructFieldMeta(0x3, deferred_uint8).put_into(meta_3)
+
+    @dataclass
+    class MyStruct:
+        field_a: int = field(metadata=meta_0)
+        field_b: int = field(metadata=meta_3)
+
+    dc_struct = DataclassStruct(FieldPath(), MyStruct)
+    assert dc_struct.from_bytes(b"\x00\x01\x02\x03", EMPTY_BYTES_READER) == MyStruct(
+        0, 3
+    )
+
+
+def test_dataclass_struct_nested():
+    meta_0 = {}
+    StructFieldMeta(0x0, deferred_uint8).put_into(meta_0)
+    meta_2 = {}
+    StructFieldMeta(0x2, deferred_uint8).put_into(meta_2)
+
+    @dataclass
+    class Inner:
+        field_a: int = field(metadata=meta_0)
+        field_b: int = field(metadata=meta_2)
+
+    def deferred_inner(path, field_type):
+        return DataclassStruct(path, field_type)
+
+    meta_3_inner = {}
+    StructFieldMeta(0x3, deferred_inner).put_into(meta_3_inner)
+
+    @dataclass
+    class Outer:
+        field_0: int = field(metadata=meta_0)
+        field_2: int = field(metadata=meta_2)
+        inner: Inner = field(metadata=meta_3_inner)
+
+    dc_outer = DataclassStruct(FieldPath(), Outer)
+    assert dc_outer.from_bytes(
+        b"\x00\x01\x02\x03\x04\x05", EMPTY_BYTES_READER
+    ) == Outer(0, 2, Inner(3, 5))
+
+
+@pytest.mark.parametrize(
+    "py_type,expected", [(Tuple[int, ...], (10, 2)), (FrozenSet[int], {10, 2})]
+)
+def test_array_uint8(py_type, expected):
+    arr = Array(FieldPath, py_type, deferred_uint8, count=2)
+    assert arr.from_bytes(b"\x0a\x02", EMPTY_BYTES_READER) == expected
+
+
+@pytest.mark.parametrize("py_type", (Tuple[int, int], Set[int], int, FrozenSet[float]))
+def test_array_type_mismatch(py_type):
+    def build():
+        Array(FieldPath, py_type, deferred_uint8, count=2)
+
+    with pytest.raises(ValueError):
+        build()
+
+
+def test_array_too_small():
+    def read():
+        sc_type = Array(FieldPath, Tuple[int, ...], deferred_uint8, count=2)
+        sc_type.from_bytes(b"", EMPTY_BYTES_READER)
+
+    with pytest.raises(ValueError):
+        read()
+
+
+@pytest.mark.parametrize(
+    "addr_bytes,expected",
+    [
+        (b"\x01\x00\x00\x00\x00\x00\x00\x00", 3),
+        (b"\x02\x00\x00\x00\x00\x00\x00\x00", 16),
+    ],
+)
+def test_pointer_uint8(addr_bytes, expected):
+    # Note that address 0 (aka null) is special-cased by c_void_p
+    bytes_reader = BytesReader(b"\x00\x03\x10")
+    arr = Pointer(FieldPath, Optional[int], deferred_uint8)
+    assert arr.from_bytes(addr_bytes, bytes_reader) == expected

--- a/src/tests/mem/memrauder/test_model.py
+++ b/src/tests/mem/memrauder/test_model.py
@@ -39,6 +39,19 @@ def test_scalar_c_type_byte(py_type, expected):
     assert sc_type.from_bytes(b"\x04", EMPTY_BYTES_READER) == expected
 
 
+@pytest.mark.parametrize(
+    "addr_bytes,expected",
+    [
+        (b"\x00\x00\x00\x00\x00\x00\x00\x00", 0),
+        (b"\x0b\x00\x00\x00\x00\x00\x00\x00", 11),
+        (b"\x00\x01\x00\x00\x00\x00\x00\x00", 256),
+    ],
+)
+def test_scalar_c_type_pointer(addr_bytes, expected):
+    sc_type = ScalarCType(FieldPath(), int, ctypes.c_void_p)
+    assert sc_type.from_bytes(addr_bytes, EMPTY_BYTES_READER) == expected
+
+
 def test_scalar_c_type_mismatch():
     def build():
         ScalarCType(FieldPath(), int, ctypes.c_float)
@@ -181,7 +194,6 @@ def test_array_scalar_c_error_passthrough():
     ],
 )
 def test_pointer_uint8(addr_bytes, expected):
-    # Note that address 0 (aka null) is special-cased by c_void_p
-    bytes_reader = BytesReader(b"\x00\x03\x10")
+    bytes_reader = BytesReader(b"\x0c\x03\x10")
     arr = Pointer(FieldPath, Optional[int], deferred_uint8)
     assert arr.from_bytes(addr_bytes, bytes_reader) == expected

--- a/src/tests/mem/memrauder/test_msvc.py
+++ b/src/tests/mem/memrauder/test_msvc.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+import pytest
+
+from modlunky2.mem.memrauder.dsl import sc_uint8, sc_uint16, struct_field
+from modlunky2.mem.memrauder.model import (
+    BytesReader,
+    DataclassStruct,
+    FieldPath,
+    mem_type_from_bytes,
+)
+from modlunky2.mem.memrauder.msvc import Vector, vector
+
+
+@pytest.mark.parametrize(
+    "vec_buf,expected",
+    [
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00",
+            (11, 12, 13),
+        ),
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00",
+            tuple([12]),
+        ),
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x0a\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00",
+            None,
+        ),
+        (
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x0a\x00\x00\x00",
+            None,
+        ),
+    ],
+)
+def test_vector_model(vec_buf, expected):
+    mem_type = Vector(FieldPath(), Optional[Tuple[int, ...]], sc_uint8)
+    arr_buf = b"\x0a\x0b\x0c\x0d"
+    mem_reader = BytesReader(arr_buf)
+    assert mem_type_from_bytes(mem_type, vec_buf, mem_reader) == expected
+
+
+def test_vesctor_bad_buf():
+    vec_buf = b""
+    arr_buf = b"\xff\x03\x00\x09\x00"
+    mem_type = Vector(FieldPath(), Optional[Tuple[int, ...]], sc_uint8)
+    mem_reader = BytesReader(arr_buf)
+    with pytest.raises(ValueError):
+        mem_type.from_bytes(vec_buf, mem_reader)
+
+
+@dataclass(frozen=True)
+class VecWrap:
+    num_list: Optional[Tuple[int, ...]] = struct_field(0x1, vector(sc_uint16))
+
+
+def test_vector_dsl():
+    vec_wrap_buf = b"\xff\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00"
+    arr_buf = b"\xff\x03\x00\x09\x00"
+    mem_type = DataclassStruct(FieldPath(), VecWrap)
+    mem_reader = BytesReader(arr_buf)
+    assert mem_type_from_bytes(mem_type, vec_wrap_buf, mem_reader) == VecWrap((3, 9))


### PR DESCRIPTION
This converts `mem.entities.*` to use the Memrauder library for declarative structs, continuing the work from PR #141 ([diffs against it](https://github.com/mauvealerts/modlunky2/compare/mem-abstract-read...mauvealerts:memrauder-entity)). With this change, I think on-demand reads are limited to:

- `EntityMap` which traverses the `std::unordered_map` between instance IDs and `Entity*`
- Downcasts facilitated by `EntityWrapper` (which is new)

If we want to do more downcasting in the future, it's probably worth making `EntityWrapper` nicer and more general. Right now, we only cast to `Entity` (which could be done eagerly) and `Mount`.

Notable changes that aren't related to the migration:

- `state.players` is now `state.items.players` to better align with Overlunky. `items` can be None, since it's a pointer. `players` is now a fixed size (4), with any empty player slots being None.
- Deleted `EntityDB` which was unused. `EntityDBEntry` lives on
- Deleted commented-out code that was a start to `std::map`

This PR also includes some changes to Memrauder, mostly prompted by entity migration:
- An implementation of `std::vector`, used for `Entity.items`
- Special casing of NULL, which `c_void_p` stores as `None` instead of `0`
- Cleanup some annotations, which I noticed while adding vector support

There's definitely more cleanup to be done... I believe most of `Spel2Process` is unused and `RunState` has many spurious `None` checks. I'm open to doing that in this PR.