### PR TITLE
Adjust Eggplant% position to match new MossRanking

### DIFF
--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -34,12 +34,12 @@ class Label(Enum):
         "Any", start=True, hide_early=False, percent_priority=2, terminus=True
     )
     SUNKEN_CITY = LabelMetadata("Sunken City", percent_priority=2, terminus=True)
+    EGGPLANT = LabelMetadata("Eggplant", percent_priority=1)
     DEATH = LabelMetadata("Death", percent_priority=2, terminus=True)
     JUNGLE_TEMPLE = LabelMetadata("Jungle/Temple")
     DUAT = LabelMetadata("Duat")
     ABZU = LabelMetadata("Abzu")
     MILLIONAIRE = LabelMetadata("Millionaire")
-    EGGPLANT = LabelMetadata("Eggplant", percent_priority=1)
     TRUE_CROWN = LabelMetadata("True Crown")
     COSMIC_OCEAN = LabelMetadata("Cosmic Ocean", percent_priority=2, terminus=True)
     SCORE = LabelMetadata("Score")

--- a/src/tests/ui/trackers/label_test.py
+++ b/src/tests/ui/trackers/label_test.py
@@ -35,7 +35,6 @@ MOSSRANKING_CATEGORIES = [
     ({Label.SCORE, Label.ANY}, "Score"),
     ({Label.SCORE, Label.NO_CO, Label.ANY}, "Score No CO"),
     # Misc tab
-    ({Label.NO_GOLD, Label.COSMIC_OCEAN}, "No Gold Cosmic Ocean%"),
     ({Label.EGGPLANT, Label.COSMIC_OCEAN}, "Eggplant Cosmic Ocean%"),
     ({Label.TRUE_CROWN, Label.COSMIC_OCEAN}, "True Crown Cosmic Ocean%"),
     (
@@ -43,22 +42,20 @@ MOSSRANKING_CATEGORIES = [
         "Eggplant True Crown Cosmic Ocean%",
     ),
     ({Label.NO_JETPACK, Label.COSMIC_OCEAN}, "No Jetpack Cosmic Ocean%"),
+    ({Label.NO_GOLD, Label.COSMIC_OCEAN}, "No Gold Cosmic Ocean%"),
     ({Label.LOW, Label.COSMIC_OCEAN}, "Low% Cosmic Ocean"),
     (
         {Label.CHAIN, Label.LOW, Label.ABZU, Label.COSMIC_OCEAN},
         "Chain Low% Cosmic Ocean",
     ),
-    (
-        {Label.CHAIN, Label.LOW, Label.DUAT, Label.COSMIC_OCEAN},
-        "Chain Low% Cosmic Ocean",
-    ),
+    ({Label.LOW, Label.SUNKEN_CITY}, "Low% Sunken City"),
+    ({Label.NO_GOLD, Label.LOW, Label.SUNKEN_CITY}, "No Gold Low% Sunken City"),
+    ({Label.NO_TELEPORTER, Label.NO_GOLD, Label.ANY}, "No TP No Gold"),
+    ({Label.NO_GOLD, Label.SUNKEN_CITY}, "No Gold Sunken City%"),
     (
         {Label.NO_TELEPORTER, Label.NO_GOLD, Label.SUNKEN_CITY},
         "No TP No Gold Sunken City%",
     ),
-    ({Label.NO_TELEPORTER, Label.NO_GOLD, Label.ANY}, "No TP No Gold"),
-    ({Label.LOW, Label.SUNKEN_CITY}, "Low% Sunken City"),
-    ({Label.NO_GOLD, Label.SUNKEN_CITY}, "No Gold Sunken City%"),
     (
         {Label.NO_GOLD, Label.CHAIN, Label.ABZU, Label.SUNKEN_CITY},
         "No Gold Sunken City% Abzu",
@@ -67,7 +64,6 @@ MOSSRANKING_CATEGORIES = [
         {Label.NO_GOLD, Label.CHAIN, Label.DUAT, Label.SUNKEN_CITY},
         "No Gold Sunken City% Duat",
     ),
-    ({Label.NO_GOLD, Label.LOW, Label.SUNKEN_CITY}, "No Gold Low% Sunken City"),
     (
         {
             Label.NO_GOLD,
@@ -89,6 +85,13 @@ MOSSRANKING_CATEGORIES = [
         "No Gold Chain Low% Duat",
     ),
     ({Label.EGGPLANT, Label.SUNKEN_CITY}, "Eggplant%"),
+    ({Label.NO_TELEPORTER, Label.EGGPLANT, Label.SUNKEN_CITY}, "No TP Eggplant%"),
+    ({Label.LOW, Label.EGGPLANT, Label.SUNKEN_CITY}, "Low% Eggplant"),
+    ({Label.NO_GOLD, Label.EGGPLANT, Label.SUNKEN_CITY}, "No Gold Eggplant%"),
+    (
+        {Label.NO_GOLD, Label.LOW, Label.EGGPLANT, Label.SUNKEN_CITY},
+        "No Gold Low% Eggplant",
+    ),
     (
         {Label.EGGPLANT, Label.CHAIN, Label.ABZU, Label.SUNKEN_CITY},
         "Eggplant% Abzu",
@@ -97,7 +100,6 @@ MOSSRANKING_CATEGORIES = [
         {Label.EGGPLANT, Label.CHAIN, Label.DUAT, Label.SUNKEN_CITY},
         "Eggplant% Duat",
     ),
-    ({Label.LOW, Label.EGGPLANT, Label.SUNKEN_CITY}, "Low% Eggplant"),
     (
         {
             Label.CHAIN,
@@ -117,11 +119,6 @@ MOSSRANKING_CATEGORIES = [
             Label.SUNKEN_CITY,
         },
         "Chain Low% Eggplant Duat",
-    ),
-    ({Label.NO_GOLD, Label.EGGPLANT, Label.SUNKEN_CITY}, "No Gold Eggplant%"),
-    (
-        {Label.NO_GOLD, Label.LOW, Label.EGGPLANT, Label.SUNKEN_CITY},
-        "No Gold Low% Eggplant",
     ),
     (
         {
@@ -146,10 +143,10 @@ MOSSRANKING_CATEGORIES = [
         "No Gold Chain Low% Eggplant Duat",
     ),
     ({Label.MILLIONAIRE, Label.ANY}, "Millionaire"),
-    ({Label.LOW, Label.MILLIONAIRE, Label.ANY}, "Low% Millionaire"),
     ({Label.NO_TELEPORTER, Label.MILLIONAIRE, Label.ANY}, "No TP Millionaire"),
-    ({Label.PACIFIST, Label.ANY}, "Pacifist Any%"),
+    ({Label.LOW, Label.MILLIONAIRE, Label.ANY}, "Low% Millionaire"),
     # Pacifist tab
+    ({Label.PACIFIST, Label.ANY}, "Pacifist Any%"),
     ({Label.PACIFIST, Label.SUNKEN_CITY}, "Pacifist Sunken City%"),
     ({Label.PACIFIST, Label.LOW, Label.ANY}, "Pacifist Low%"),
     ({Label.PACIFIST, Label.COSMIC_OCEAN}, "Pacifist Cosmic Ocean%"),
@@ -175,22 +172,22 @@ MOSSRANKING_CATEGORIES = [
         "Pacifist Chain Low% Duat",
     ),
     ({Label.PACIFIST, Label.EGGPLANT, Label.SUNKEN_CITY}, "Pacifist Eggplant%"),
-    ({Label.NO_GOLD, Label.PACIFIST, Label.ANY}, "No Gold Pacifist"),
     (
-        {Label.NO_GOLD, Label.PACIFIST, Label.SUNKEN_CITY},
-        "No Gold Pacifist Sunken City%",
+        {Label.NO_GOLD, Label.PACIFIST, Label.EGGPLANT, Label.SUNKEN_CITY},
+        "No Gold Pacifist Eggplant%",
     ),
+    ({Label.NO_GOLD, Label.PACIFIST, Label.ANY}, "No Gold Pacifist"),
     (
         {Label.NO_GOLD, Label.PACIFIST, Label.LOW, Label.ANY},
         "No Gold Pacifist Low%",
     ),
     (
-        {Label.NO_GOLD, Label.PACIFIST, Label.LOW, Label.SUNKEN_CITY},
-        "No Gold Pacifist Low% Sunken City",
+        {Label.NO_GOLD, Label.PACIFIST, Label.SUNKEN_CITY},
+        "No Gold Pacifist Sunken City%",
     ),
     (
-        {Label.NO_GOLD, Label.PACIFIST, Label.EGGPLANT, Label.SUNKEN_CITY},
-        "No Gold Pacifist Eggplant%",
+        {Label.NO_GOLD, Label.PACIFIST, Label.LOW, Label.SUNKEN_CITY},
+        "No Gold Pacifist Low% Sunken City",
     ),
 ]
 

--- a/src/tests/ui/trackers/label_test.py
+++ b/src/tests/ui/trackers/label_test.py
@@ -52,7 +52,6 @@ MOSSRANKING_CATEGORIES = [
         {Label.CHAIN, Label.LOW, Label.DUAT, Label.COSMIC_OCEAN},
         "Chain Low% Cosmic Ocean",
     ),
-    # We accept % after SC even though it doesn't really align
     (
         {Label.NO_TELEPORTER, Label.NO_GOLD, Label.SUNKEN_CITY},
         "No TP No Gold Sunken City%",
@@ -92,11 +91,11 @@ MOSSRANKING_CATEGORIES = [
     ({Label.EGGPLANT, Label.SUNKEN_CITY}, "Eggplant%"),
     (
         {Label.EGGPLANT, Label.CHAIN, Label.ABZU, Label.SUNKEN_CITY},
-        "Abzu Eggplant%",
+        "Eggplant% Abzu",
     ),
     (
         {Label.EGGPLANT, Label.CHAIN, Label.DUAT, Label.SUNKEN_CITY},
-        "Duat Eggplant%",
+        "Eggplant% Duat",
     ),
     ({Label.LOW, Label.EGGPLANT, Label.SUNKEN_CITY}, "Low% Eggplant"),
     (
@@ -107,7 +106,7 @@ MOSSRANKING_CATEGORIES = [
             Label.ABZU,
             Label.SUNKEN_CITY,
         },
-        "Chain Low% Abzu Eggplant",
+        "Chain Low% Eggplant Abzu",
     ),
     (
         {
@@ -117,7 +116,7 @@ MOSSRANKING_CATEGORIES = [
             Label.DUAT,
             Label.SUNKEN_CITY,
         },
-        "Chain Low% Duat Eggplant",
+        "Chain Low% Eggplant Duat",
     ),
     ({Label.NO_GOLD, Label.EGGPLANT, Label.SUNKEN_CITY}, "No Gold Eggplant%"),
     (
@@ -133,7 +132,7 @@ MOSSRANKING_CATEGORIES = [
             Label.EGGPLANT,
             Label.SUNKEN_CITY,
         },
-        "No Gold Chain Low% Abzu Eggplant",
+        "No Gold Chain Low% Eggplant Abzu",
     ),
     (
         {
@@ -144,7 +143,7 @@ MOSSRANKING_CATEGORIES = [
             Label.EGGPLANT,
             Label.SUNKEN_CITY,
         },
-        "No Gold Chain Low% Duat Eggplant",
+        "No Gold Chain Low% Eggplant Duat",
     ),
     ({Label.MILLIONAIRE, Label.ANY}, "Millionaire"),
     ({Label.LOW, Label.MILLIONAIRE, Label.ANY}, "Low% Millionaire"),
@@ -153,6 +152,7 @@ MOSSRANKING_CATEGORIES = [
     # Pacifist tab
     ({Label.PACIFIST, Label.SUNKEN_CITY}, "Pacifist Sunken City%"),
     ({Label.PACIFIST, Label.LOW, Label.ANY}, "Pacifist Low%"),
+    ({Label.PACIFIST, Label.COSMIC_OCEAN}, "Pacifist Cosmic Ocean%"),
     ({Label.PACIFIST, Label.LOW, Label.SUNKEN_CITY}, "Pacifist Low% Sunken City"),
     (
         {


### PR DESCRIPTION
The only functional change is moving Eggplant relative to Abzu/Duat. There are some updates to the unit test:

- Add Pacifist CO
- Pacifist Any% to pacifist section
- Reorder tests to match their respective pages

This PR doesn't interact with the memory-reading changes at all.