### PR TITLE
Abzu/Duat fixes: always hide Chain w/o Low, etc.

### DIFF
--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -153,13 +153,9 @@ class RunLabel:
             if needle in vis and self._set.isdisjoint(need):
                 vis.discard(needle)
 
-        # Handle "Chain Low% Abzu" vs "Sunken City% Abzu",
-        # treating "Death" like "Sunken City".
-        if not self._set.isdisjoint(
-            {Label.DEATH, Label.SUNKEN_CITY}
-        ) and not self._set.isdisjoint({Label.ABZU, Label.DUAT}):
+        # Handle "Chain Low% Abzu" vs "Sunken City% Abzu"
+        if not self._set.isdisjoint({Label.ABZU, Label.DUAT}):
             if Label.LOW in self._set:
-                vis.discard(Label.DEATH)
                 vis.discard(Label.SUNKEN_CITY)
             else:
                 vis.discard(Label.CHAIN)

--- a/src/tests/ui/trackers/label_test.py
+++ b/src/tests/ui/trackers/label_test.py
@@ -255,3 +255,51 @@ def test_mossranking_alignment(labels, expected):
     run_label = RunLabel(labels)
     actual = run_label.text(hide_early=False)
     assert actual == expected
+
+
+ASSORTED_LABELS = [
+    # Intermediate states
+    (
+        {Label.CHAIN, Label.LOW, Label.SUNKEN_CITY},
+        "Chain Low% Sunken City",
+    ),
+    (
+        {Label.CHAIN, Label.SUNKEN_CITY},
+        "Chain Sunken City%",
+    ),
+    # Chain Death%
+    (
+        {Label.CHAIN, Label.ABZU, Label.DEATH},
+        "Death% Abzu",
+    ),
+    (
+        {Label.CHAIN, Label.LOW, Label.ABZU, Label.DEATH},
+        "Chain Low% Death Abzu",
+    ),
+    # Chain CO
+    (
+        {Label.NO_JETPACK, Label.CHAIN, Label.LOW, Label.ABZU, Label.COSMIC_OCEAN},
+        "Chain Low% Cosmic Ocean",
+    ),
+    (
+        {Label.NO_JETPACK, Label.CHAIN, Label.ABZU, Label.COSMIC_OCEAN},
+        "No Jetpack Cosmic Ocean%",
+    ),
+    (
+        {
+            Label.NO_JETPACK,
+            Label.CHAIN,
+            Label.JUNGLE_TEMPLE,
+            Label.DUAT,
+            Label.COSMIC_OCEAN,
+        },
+        "No Jetpack Cosmic Ocean%",
+    ),
+]
+
+
+@mark.parametrize("labels,expected", ASSORTED_LABELS)
+def test_assorted_labels(labels, expected):
+    run_label = RunLabel(labels)
+    actual = run_label.text(hide_early=False)
+    assert actual == expected


### PR DESCRIPTION
- If we have Abzu/Duat, always hide Chain without Low%. This fixes "Chain CO" 
- Show Death% with Abzu/Duat. Sadly, the chain categories require completion
- Add some tests for intermediate chain: we have Chain SC, but don't yet have Abzu/Duat