### PR TITLE
Add unit tests for category tracker's RunState

### DIFF
--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -174,42 +174,48 @@ class EntityDBEntry:
 # EntityReduced exists only to break the circular dependency via 'overlay'
 @dataclass(frozen=True)
 class EntityReduced:
-    type: Optional[EntityDBEntry] = struct_field(0x08, pointer(dc_struct))
-    items: Optional[Tuple[int, ...]] = struct_field(0x18, vector(sc_uint32))
-    layer: int = struct_field(0x98, sc_uint8)
+    type: Optional[EntityDBEntry] = struct_field(0x08, pointer(dc_struct), default=None)
+    items: Optional[Tuple[int, ...]] = struct_field(
+        0x18, vector(sc_uint32), default=None
+    )
+    layer: int = struct_field(0x98, sc_uint8, default=Layer.FRONT)
 
 
 @dataclass(frozen=True)
 class Entity(EntityReduced):
-    overlay: PolyPointer[EntityReduced] = struct_field(0x10, poly_pointer(dc_struct))
+    overlay: PolyPointer[EntityReduced] = struct_field(
+        0x10, poly_pointer(dc_struct), default_factory=PolyPointer.make_empty
+    )
 
 
 @dataclass(frozen=True)
 class Movable(Entity):
-    holding_uid: int = struct_field(0x108, sc_int32)
-    state: CharState = struct_field(0x10C, sc_uint8)
-    last_state: CharState = struct_field(0x10D, sc_uint8)
-    health: int = struct_field(0x10F, sc_int8)
+    holding_uid: int = struct_field(0x108, sc_int32, default=-1)
+    state: CharState = struct_field(0x10C, sc_uint8, default=CharState.STANDING)
+    last_state: CharState = struct_field(0x10D, sc_uint8, default=CharState.STANDING)
+    health: int = struct_field(0x10F, sc_int8, default=4)
 
 
 @dataclass(frozen=True)
 class Mount(Movable):
-    is_tamed: bool = struct_field(0x149, sc_bool)
+    is_tamed: bool = struct_field(0x149, sc_bool, default=False)
 
 
 @dataclass(frozen=True)
 class Inventory:
     # Amount of money collected in the current level
-    money: int = struct_field(0x00, sc_uint32)
-    bombs: int = struct_field(0x04, sc_uint8)
-    ropes: int = struct_field(0x05, sc_uint8)
-    poison_tick_timer: int = struct_field(0x06, sc_int16)
-    cursed: bool = struct_field(0x08, sc_bool)
-    kills_level: int = struct_field(0x1424, sc_uint32)
-    kills_total: int = struct_field(0x1428, sc_uint32)
-    collected_money_total: int = struct_field(0x1520, sc_uint32)
+    money: int = struct_field(0x00, sc_uint32, default=0)
+    bombs: int = struct_field(0x04, sc_uint8, default=4)
+    ropes: int = struct_field(0x05, sc_uint8, default=4)
+    poison_tick_timer: int = struct_field(0x06, sc_int16, default=-1)
+    cursed: bool = struct_field(0x08, sc_bool, default=False)
+    kills_level: int = struct_field(0x1424, sc_uint32, default=0)
+    kills_total: int = struct_field(0x1428, sc_uint32, default=0)
+    collected_money_total: int = struct_field(0x1520, sc_uint32, default=0)
 
 
 @dataclass(frozen=True)
 class Player(Movable):
-    inventory: Optional[Inventory] = struct_field(0x138, pointer(dc_struct))
+    inventory: Optional[Inventory] = struct_field(
+        0x138, pointer(dc_struct), default=None
+    )

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -217,5 +217,5 @@ class Inventory:
 @dataclass(frozen=True)
 class Player(Movable):
     inventory: Optional[Inventory] = struct_field(
-        0x138, pointer(dc_struct), default=None
+        0x138, pointer(dc_struct), default_factory=Inventory
     )

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -514,7 +514,7 @@ class PolyPointer(Generic[T]):
         return PolyPointer(self.addr, new_value, self.mem_ctx)
 
     @staticmethod
-    def make_empty(mem_ctx: MemContext) -> PolyPointer:
+    def make_empty(mem_ctx: MemContext = MemContext()) -> PolyPointer:
         return PolyPointer(None, None, mem_ctx)
 
 

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -514,7 +514,9 @@ class PolyPointer(Generic[T]):
         return PolyPointer(self.addr, new_value, self.mem_ctx)
 
     @staticmethod
-    def make_empty(mem_ctx: MemContext = MemContext()) -> PolyPointer:
+    def make_empty(mem_ctx: Optional[MemContext] = None) -> PolyPointer:
+        if mem_ctx is None:
+            mem_ctx = MemContext()
         return PolyPointer(None, None, mem_ctx)
 
 

--- a/src/modlunky2/mem/memrauder/msvc.py
+++ b/src/modlunky2/mem/memrauder/msvc.py
@@ -2,7 +2,7 @@ import ctypes
 import dataclasses
 from dataclasses import InitVar, dataclass
 import math
-from typing import ClassVar, Generic, Optional, Tuple, TypeVar
+from typing import ClassVar, Dict, Generic, Optional, Tuple, TypeVar
 
 import fnvhash
 
@@ -225,6 +225,17 @@ class UnorderedMap(Generic[K, V]):
     def _hash_key(self, key) -> int:
         bytes_ = self.key_mem_type.to_bytes(key)
         return fnvhash.fnv1a_64(bytes_)
+
+
+@dataclass(frozen=True)
+class DictUnorderedMap((Generic[K, V])):
+    dict: Dict[K, V] = dataclasses.field(default_factory=dict)
+
+    def get(self, key: K) -> Optional[V]:
+        if key not in self.dict:
+            return None
+
+        return self.dict[key]
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -138,6 +138,7 @@ class Items:
 
 @dataclass(frozen=True)
 class State:
+    # TODO try using enum, which implies failing on unexpected values
     screen_last: int = struct_field(
         0x08, sc_int32, default=Screen.LEVEL_TRANSITION.value
     )
@@ -151,6 +152,7 @@ class State:
     money_shop_total: int = struct_field(0x58, sc_int32, default=0)
     world_start: int = struct_field(0x5C, sc_uint8, default=1)
     level_start: int = struct_field(0x5D, sc_uint8, default=1)
+    # TODO try using enum, which implies failing on unexpected values
     theme_start: int = struct_field(0x5E, sc_uint8, default=Theme.DWELLING.value)
     time_total: int = struct_field(0x64, sc_uint32, default=1)
     world: int = struct_field(0x68, sc_uint8, default=1)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -16,7 +16,7 @@ from modlunky2.mem.memrauder.dsl import (
     sc_uint8,
 )
 from modlunky2.mem.memrauder.model import PolyPointer
-from modlunky2.mem.memrauder.msvc import UnorderedMap, unordered_map
+from modlunky2.mem.memrauder.msvc import DictUnorderedMap, UnorderedMap, unordered_map
 
 
 class RunRecapFlags(enum.IntFlag):
@@ -138,28 +138,34 @@ class Items:
 
 @dataclass(frozen=True)
 class State:
-    screen_last: int = struct_field(0x08, sc_int32)
-    screen: int = struct_field(0x0C, sc_int32)
-    screen_next: int = struct_field(0x10, sc_int32)
-    quest_flags: QuestFlags = struct_field(0x38, sc_uint32)
+    screen_last: int = struct_field(
+        0x08, sc_int32, default=Screen.LEVEL_TRANSITION.value
+    )
+    screen: int = struct_field(0x0C, sc_int32, default=Screen.LEVEL.value)
+    screen_next: int = struct_field(
+        0x10, sc_int32, default=Screen.LEVEL_TRANSITION.value
+    )
+    quest_flags: QuestFlags = struct_field(0x38, sc_uint32, default=0)
     # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
     # If the run ends in a victory, the bonus will be added to this during the score screen.
-    money_shop_total: int = struct_field(0x58, sc_int32)
-    world_start: int = struct_field(0x5C, sc_uint8)
-    level_start: int = struct_field(0x5D, sc_uint8)
-    theme_start: int = struct_field(0x5E, sc_uint8)
-    time_total: int = struct_field(0x64, sc_uint32)
-    world: int = struct_field(0x68, sc_uint8)
-    world_next: int = struct_field(0x69, sc_uint8)
-    level: int = struct_field(0x6A, sc_uint8)
-    level_next: int = struct_field(0x6B, sc_uint8)
-    theme: Theme = struct_field(0x74, sc_uint8)
-    theme_next: Theme = struct_field(0x75, sc_uint8)
-    win_state: WinState = struct_field(0x76, sc_int8)
-    run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32)
-    hud_flags: HudFlags = struct_field(0xA10, sc_uint32)
-    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32)
-    items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct))
+    money_shop_total: int = struct_field(0x58, sc_int32, default=0)
+    world_start: int = struct_field(0x5C, sc_uint8, default=1)
+    level_start: int = struct_field(0x5D, sc_uint8, default=1)
+    theme_start: int = struct_field(0x5E, sc_uint8, default=Theme.DWELLING.value)
+    time_total: int = struct_field(0x64, sc_uint32, default=1)
+    world: int = struct_field(0x68, sc_uint8, default=1)
+    world_next: int = struct_field(0x69, sc_uint8, default=1)
+    level: int = struct_field(0x6A, sc_uint8, default=1)
+    level_next: int = struct_field(0x6B, sc_uint8, default=2)
+    theme: Theme = struct_field(0x74, sc_uint8, default=Theme.DWELLING)
+    theme_next: Theme = struct_field(0x75, sc_uint8, default=Theme.DWELLING)
+    win_state: WinState = struct_field(0x76, sc_int8, default=WinState.NO_WIN)
+    run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32, default=0)
+    hud_flags: HudFlags = struct_field(0xA10, sc_uint32, default=0)
+    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32, default=0)
+    items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct), default=None)
     instance_id_to_pointer: UnorderedMap[int, PolyPointer[Entity]] = struct_field(
-        0x1308, unordered_map(sc_uint32, poly_pointer(dc_struct))
+        0x1308,
+        unordered_map(sc_uint32, poly_pointer(dc_struct)),
+        default_factory=DictUnorderedMap,
     )

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -85,7 +85,6 @@ class CategoryWatcherThread(WatcherThread):
     def initialize(self):
         self.time_total = 0
         self.run_state = RunState(
-            self.proc,
             always_show_modifiers=self.always_show_modifiers,
         )
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -158,15 +158,15 @@ class RunState:
                 self.run_label.discard(Label.NO_TELEPORTER)
                 return
 
-    def update_eggplant(self):
+    def update_eggplant(self, world, player_item_types):
         if self.eggplant:
             return
 
         # TODO: Remove if we ever add a better heuristic
-        if self.world < 7:
+        if world < 7:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type == EntityType.ITEM_POWERUP_EGGPLANTCROWN:
                 self.eggplant = True
                 self.run_label.add(Label.EGGPLANT)
@@ -638,7 +638,7 @@ class RunState:
         self.update_pacifist(run_recap_flags)
         self.update_no_gold(run_recap_flags)
         self.update_no_tp(self.player_item_types)
-        self.update_eggplant()
+        self.update_eggplant(self.world, self.player_item_types)
 
         # Check Category Criteria
         overlay = player.overlay

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -321,11 +321,11 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_held_shield(self):
+    def update_held_shield(self, player_item_types):
         if not self.is_low_percent:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in SHIELDS:
                 self.held_shield = True
                 self.fail_low()
@@ -654,7 +654,7 @@ class RunState:
         self.update_status_effects(self.player_state, self.player_item_types)
         self.update_had_clover(hud_flags)
         self.update_wore_backpack(self.player_item_types)
-        self.update_held_shield()
+        self.update_held_shield(self.player_item_types)
         self.update_has_non_chain_powerup()
         self.update_attacked_with(layer, presence_flags)
         self.update_attacked_with_throwables()

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -466,17 +466,17 @@ class RunState:
             elif item_type == EntityType.ITEM_HOUYIBOW:
                 self.hou_yis_bow = True
 
-    def update_world_themes(self):
-        if self.world not in [2, 4]:
+    def update_world_themes(self, world: int, theme: Theme):
+        if world not in [2, 4]:
             return
 
-        if self.theme in [Theme.JUNGLE, Theme.VOLCANA]:
-            self.world2_theme = self.theme
-        elif self.theme in [Theme.TEMPLE, Theme.CITY_OF_GOLD, Theme.DUAT]:
+        if theme in [Theme.JUNGLE, Theme.VOLCANA]:
+            self.world2_theme = theme
+        elif theme in [Theme.TEMPLE, Theme.CITY_OF_GOLD, Theme.DUAT]:
             self.world4_theme = Theme.TEMPLE
             if self.chain_status.in_progress:
                 self.run_label.add(Label.DUAT)
-        elif self.theme in [Theme.TIDE_POOL, Theme.ABZU]:
+        elif theme in [Theme.TIDE_POOL, Theme.ABZU]:
             self.world4_theme = Theme.TIDE_POOL
             if self.chain_status.in_progress:
                 self.run_label.add(Label.ABZU)
@@ -489,7 +489,8 @@ class RunState:
         else:
             self.run_label.discard(Label.JUNGLE_TEMPLE)
 
-        if self.world is Theme.SUNKEN_CITY:
+        # TODO delete this code that can't be reached
+        if world is Theme.SUNKEN_CITY:
             self.run_label.set_terminus(Label.SUNKEN_CITY)
 
     def update_terminus(self):
@@ -614,17 +615,17 @@ class RunState:
         self.is_low_percent = False
         self.run_label.discard(Label.LOW)
 
-    def update_on_level_start(self):
+    def update_on_level_start(self, world: int, theme: Theme):
         if not self.level_started:
             return
 
-        self.update_world_themes()
+        self.update_world_themes(world, theme)
 
         self.level_start_ropes = self.ropes
-        if self.theme == Theme.DUAT:
+        if theme == Theme.DUAT:
             self.health = 4
 
-        if self.theme == Theme.OLMEC:
+        if theme == Theme.OLMEC:
             # TODO fail if we leave the bow behind, or win w/o CO
             if self.mc_has_swung_mattock and not self.hou_yis_bow:
                 self.fail_low()
@@ -651,7 +652,7 @@ class RunState:
         hud_flags = game_state.hud_flags
         presence_flags = game_state.presence_flags
         self.update_global_state(game_state)
-        self.update_on_level_start()
+        self.update_on_level_start(self.world, self.theme)
         self.update_player_item_types(game_state.instance_id_to_pointer, player)
         self.update_final_death(state, self.player_item_types)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -206,13 +206,15 @@ class RunState:
             self.screen = Screen.UNKNOWN
         self.win_state = win_state
 
-    def update_final_death(self):
+    def update_final_death(
+        self, player_state: CharState, player_item_types: Set[EntityType]
+    ):
         if self.final_death:
             return
 
         if (
-            self.player_state is CharState.DYING
-            and EntityType.ITEM_POWERUP_ANKH not in self.player_item_types
+            player_state is CharState.DYING
+            and EntityType.ITEM_POWERUP_ANKH not in player_item_types
         ):
             self.final_death = True
             return
@@ -651,7 +653,7 @@ class RunState:
         self.update_global_state(game_state)
         self.update_on_level_start()
         self.update_player_item_types(game_state.instance_id_to_pointer, player)
-        self.update_final_death()
+        self.update_final_death(state, self.player_item_types)
 
         self.update_score_items(self.world, self.player_item_types)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -331,20 +331,22 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_has_chain_powerup(self):
+    def update_has_chain_powerup(
+        self, chain_status: ChainStatus, player_item_types: Set[EntityType]
+    ):
         if self.has_chain_powerup:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in CHAIN_POWERUP_ENTITIES:
                 self.has_chain_powerup = True
                 self.failed_low_if_not_chain = True
 
-        if self.chain_status.in_progress:
+        if chain_status.in_progress:
             return
 
         # Fail low if we've failed the chain and pick up a non-starting powerup
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in {
                 EntityType.ITEM_POWERUP_ANKH,
                 EntityType.ITEM_POWERUP_TABLETOFDESTINY,
@@ -661,7 +663,7 @@ class RunState:
 
         # Chain
         self.update_chain()
-        self.update_has_chain_powerup()
+        self.update_has_chain_powerup(self.chain_status, self.player_item_types)
         self.update_is_chain()
 
         self.update_millionaire(game_state, inventory)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -268,12 +268,12 @@ class RunState:
             self.fail_low()
         self.ropes = ropes
 
-    def update_status_effects(self):
+    def update_status_effects(self, player_state, player_item_types):
         if not self.is_low_percent:
             return
 
         # Logical effects disappear sometimes...
-        if self.player_state in {
+        if player_state in {
             CharState.ENTERING,
             CharState.LOADING,
             CharState.EXITING,
@@ -283,17 +283,17 @@ class RunState:
         is_poisoned = False
         is_cursed = False
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type == EntityType.LOGICAL_POISONED_EFFECT:
                 is_poisoned = True
             elif item_type == EntityType.LOGICAL_CURSED_EFFECT:
                 is_cursed = True
 
-        if self.poisoned and not is_poisoned and self.player_state != CharState.DYING:
+        if self.poisoned and not is_poisoned and player_state != CharState.DYING:
             self.cured_status = True
             self.fail_low()
 
-        if self.cursed and not is_cursed and self.player_state != CharState.DYING:
+        if self.cursed and not is_cursed and player_state != CharState.DYING:
             self.cured_status = True
             self.fail_low()
 
@@ -651,7 +651,7 @@ class RunState:
         # Low%
         self.update_has_mounted_tame(self.chain_status, self.theme, overlay)
         self.update_starting_resources(player, self.player_state, inventory)
-        self.update_status_effects()
+        self.update_status_effects(self.player_state, self.player_item_types)
         self.update_had_clover(hud_flags)
         self.update_wore_backpack()
         self.update_held_shield()

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -353,11 +353,11 @@ class RunState:
             }:
                 self.fail_low()
 
-    def update_has_non_chain_powerup(self):
+    def update_has_non_chain_powerup(self, player_item_types):
         if not self.is_low_percent:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in NON_CHAIN_POWERUP_ENTITIES:
                 self.has_non_chain_powerup = True
                 self.fail_low()
@@ -657,7 +657,7 @@ class RunState:
         self.update_had_clover(hud_flags)
         self.update_wore_backpack(self.player_item_types)
         self.update_held_shield(self.player_item_types)
-        self.update_has_non_chain_powerup()
+        self.update_has_non_chain_powerup(self.player_item_types)
         self.update_attacked_with(layer, presence_flags)
         self.update_attacked_with_throwables()
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -494,21 +494,21 @@ class RunState:
         if world is Theme.SUNKEN_CITY:
             self.run_label.set_terminus(Label.SUNKEN_CITY)
 
-    def update_terminus(self):
+    def update_terminus(self, world: int, theme: Theme, win_state: WinState):
         terminus = Label.ANY
-        if self.theme is Theme.COSMIC_OCEAN:
+        if theme is Theme.COSMIC_OCEAN:
             terminus = Label.COSMIC_OCEAN
         elif self.final_death:
             terminus = Label.DEATH
-        elif self.win_state is WinState.TIAMAT:
+        elif win_state is WinState.TIAMAT:
             terminus = Label.ANY
-        elif self.win_state is WinState.HUNDUN:
+        elif win_state is WinState.HUNDUN:
             terminus = Label.SUNKEN_CITY
         elif self.hou_yis_waddler:
             terminus = Label.COSMIC_OCEAN
         elif self.hou_yis_bow and not self.is_score_run:
             terminus = Label.COSMIC_OCEAN
-        elif self.had_ankh or self.chain_status.in_progress or self.world == 7:
+        elif self.had_ankh or self.chain_status.in_progress or world == 7:
             terminus = Label.SUNKEN_CITY
 
         if terminus is Label.COSMIC_OCEAN:
@@ -700,7 +700,7 @@ class RunState:
 
         self.update_millionaire(game_state, inventory)
 
-        self.update_terminus()
+        self.update_terminus(self.world, self.theme, self.win_state)
 
     def update_player_item_types(
         self,

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -61,6 +61,7 @@ class RunState:
         self.always_show_modifiers = always_show_modifiers
         self.run_label = RunLabel()
 
+        # TODO only copy stuff from mem.State if we need to know the previous value
         self.world = 0
         self.level = 0
         self.theme = 0
@@ -245,6 +246,7 @@ class RunState:
                 self.has_mounted_tame = True
                 self.fail_low()
 
+    # TODO access player.state instead of passing it separately
     def update_starting_resources(
         self, player: Player, player_state: CharState, inventory: Inventory
     ):

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -624,13 +624,13 @@ class RunState:
         self.is_low_percent = False
         self.run_label.discard(Label.LOW)
 
-    def update_on_level_start(self, world: int, theme: Theme):
+    def update_on_level_start(self, world: int, theme: Theme, ropes: int):
         if not self.level_started:
             return
 
         self.update_world_themes(world, theme)
 
-        self.level_start_ropes = self.ropes
+        self.level_start_ropes = ropes
         if theme == Theme.DUAT:
             self.health = 4
 
@@ -661,7 +661,7 @@ class RunState:
         hud_flags = game_state.hud_flags
         presence_flags = game_state.presence_flags
         self.update_global_state(game_state)
-        self.update_on_level_start(self.world, self.theme)
+        self.update_on_level_start(self.world, self.theme, self.ropes)
         self.update_player_item_types(game_state.instance_id_to_pointer, player)
         self.update_final_death(state, self.player_item_types)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -517,7 +517,9 @@ class RunState:
             self.run_label.add(Label.NO_CO)
         self.run_label.set_terminus(terminus)
 
-    def update_is_chain(self):
+    def update_is_chain(
+        self, world: int, level: int, theme: Theme, win_state: WinState
+    ):
         if self.chain_status.failed:
             return
 
@@ -525,33 +527,33 @@ class RunState:
             if any([self.had_udjat_eye, self.had_world2_chain_headwear]):
                 self.start_chain()
 
-        if self.world == 3:
+        if world == 3:
             if not self.had_world2_chain_headwear:
                 self.fail_chain()
 
-        elif self.world == 4:
+        elif world == 4:
             if not all([self.had_world2_chain_headwear, self.had_ankh]):
                 self.fail_chain()
 
-            if self.theme == Theme.TIDE_POOL:
+            if theme == Theme.TIDE_POOL:
                 # Didn't go to Abzu
-                if self.level == 4:
+                if level == 4:
                     self.fail_chain()
 
                 # Didn't pick up excalibur
-                if self.level > 2 and not self.held_world4_chain_item:
+                if level > 2 and not self.held_world4_chain_item:
                     self.fail_chain()
 
-            elif self.theme == Theme.TEMPLE:
+            elif theme == Theme.TEMPLE:
                 # Didn't go to City of Gold or Duat
-                if self.level in (3, 4):
+                if level in (3, 4):
                     self.fail_chain()
 
                 # Didn't pick up scepter
-                if self.level > 1 and not self.held_world4_chain_item:
+                if level > 1 and not self.held_world4_chain_item:
                     self.fail_chain()
 
-        elif self.world == 5:
+        elif world == 5:
             if not all(
                 [
                     self.had_world2_chain_headwear,
@@ -562,7 +564,7 @@ class RunState:
             ):
                 self.fail_chain()
 
-        elif self.world == 6 and self.level > 2:
+        elif world == 6 and level > 2:
             if not all(
                 [
                     self.had_world2_chain_headwear,
@@ -574,7 +576,7 @@ class RunState:
             ):
                 self.fail_chain()
 
-        if self.win_state is WinState.TIAMAT:
+        if win_state is WinState.TIAMAT:
             self.fail_chain()
 
     def update_millionaire(self, game_state: State, inventory: Inventory):
@@ -696,7 +698,7 @@ class RunState:
         # Chain
         self.update_chain(self.player_item_types)
         self.update_has_chain_powerup(self.chain_status, self.player_item_types)
-        self.update_is_chain()
+        self.update_is_chain(self.world, self.level, self.theme, self.win_state)
 
         self.update_millionaire(game_state, inventory)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -217,7 +217,12 @@ class RunState:
             self.final_death = True
             return
 
-    def update_has_mounted_tame(self, player_overlay: PolyPointer[Entity]):
+    def update_has_mounted_tame(
+        self,
+        chain_status: ChainStatus,
+        theme: Theme,
+        player_overlay: PolyPointer[Entity],
+    ):
         if not self.is_low_percent:
             return
 
@@ -226,10 +231,10 @@ class RunState:
 
         entity_type: EntityType = player_overlay.value.type.id
         # Allowed to ride tamed qilin in tiamats
-        if self.theme == Theme.TIAMAT and entity_type == EntityType.MOUNT_QILIN:
+        if theme == Theme.TIAMAT and entity_type == EntityType.MOUNT_QILIN:
             self.lc_has_mounted_qilin = True
             self.failed_low_if_not_chain = True
-            if not self.chain_status.in_progress:
+            if not chain_status.in_progress:
                 self.fail_low()
             return
 
@@ -644,7 +649,7 @@ class RunState:
         overlay = player.overlay
 
         # Low%
-        self.update_has_mounted_tame(overlay)
+        self.update_has_mounted_tame(self.chain_status, self.theme, overlay)
         self.update_starting_resources(player, inventory)
         self.update_status_effects()
         self.update_had_clover(hud_flags)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -244,14 +244,14 @@ class RunState:
                 self.has_mounted_tame = True
                 self.fail_low()
 
-    def update_starting_resources(self, player: Player, inventory: Inventory):
+    def update_starting_resources(
+        self, player: Player, player_state: CharState, inventory: Inventory
+    ):
         if not self.is_low_percent:
             return
 
         health = player.health
-        if (
-            health > self.health and self.player_state != CharState.DYING
-        ) or health > 4:
+        if (health > self.health and player_state != CharState.DYING) or health > 4:
             self.increased_starting_items = True
             self.fail_low()
         self.health = health
@@ -650,7 +650,7 @@ class RunState:
 
         # Low%
         self.update_has_mounted_tame(self.chain_status, self.theme, overlay)
-        self.update_starting_resources(player, inventory)
+        self.update_starting_resources(player, self.player_state, inventory)
         self.update_status_effects()
         self.update_had_clover(hud_flags)
         self.update_wore_backpack()

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -148,11 +148,11 @@ class RunState:
         if not self.no_gold:
             self.run_label.discard(Label.NO_GOLD)
 
-    def update_no_tp(self):
+    def update_no_tp(self, player_item_types):
         if not self.no_tp:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in TELEPORT_ENTITIES:
                 self.no_tp = False
                 self.run_label.discard(Label.NO_TELEPORTER)
@@ -637,7 +637,7 @@ class RunState:
         # Check Modifiers
         self.update_pacifist(run_recap_flags)
         self.update_no_gold(run_recap_flags)
-        self.update_no_tp()
+        self.update_no_tp(self.player_item_types)
         self.update_eggplant()
 
         # Check Category Criteria

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -579,7 +579,12 @@ class RunState:
         if win_state is WinState.TIAMAT:
             self.fail_chain()
 
-    def update_millionaire(self, game_state: State, inventory: Inventory):
+    def update_millionaire(
+        self,
+        game_state: State,
+        inventory: Inventory,
+        player_item_types: Set[EntityType],
+    ):
         collected_this_level = inventory.money
         collected_prev_levels = inventory.collected_money_total
         shop_and_bonus = game_state.money_shop_total
@@ -592,15 +597,16 @@ class RunState:
         # We drop millionaire if either:
         # * You used to have enough money, but no longer do
         # * You picked up the clone gun, but won without enough money
+        # TODO fix clone gun case
         if self.net_score < 900_000 and (
-            not self.clone_gun_wo_bow or self.win_state is not WinState.NO_WIN
+            not self.clone_gun_wo_bow or game_state.win_state is not WinState.NO_WIN
         ):
             self.run_label.discard(Label.MILLIONAIRE)
 
         if self.clone_gun_wo_bow or self.hou_yis_bow:
             return
         # If the clone gun is picked up, without picking up the bow, we assume this is a millionaire attempt.
-        if EntityType.ITEM_CLONEGUN in self.player_item_types:
+        if EntityType.ITEM_CLONEGUN in player_item_types:
             self.clone_gun_wo_bow = True
             self.run_label.add(Label.MILLIONAIRE)
 
@@ -700,7 +706,7 @@ class RunState:
         self.update_has_chain_powerup(self.chain_status, self.player_item_types)
         self.update_is_chain(self.world, self.level, self.theme, self.win_state)
 
-        self.update_millionaire(game_state, inventory)
+        self.update_millionaire(game_state, inventory, self.player_item_types)
 
         self.update_terminus(self.world, self.theme, self.win_state)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -221,7 +221,6 @@ class RunState:
 
     def update_has_mounted_tame(
         self,
-        chain_status: ChainStatus,
         theme: Theme,
         player_overlay: PolyPointer[Entity],
     ):
@@ -236,7 +235,7 @@ class RunState:
         if theme == Theme.TIAMAT and entity_type == EntityType.MOUNT_QILIN:
             self.lc_has_mounted_qilin = True
             self.failed_low_if_not_chain = True
-            if not chain_status.in_progress:
+            if not self.chain_status.in_progress:
                 self.fail_low()
             return
 
@@ -670,7 +669,7 @@ class RunState:
         overlay = player.overlay
 
         # Low%
-        self.update_has_mounted_tame(self.chain_status, self.theme, overlay)
+        self.update_has_mounted_tame(self.theme, overlay)
         self.update_starting_resources(player, self.player_state, inventory)
         self.update_status_effects(self.player_state, self.player_item_types)
         self.update_had_clover(hud_flags)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -419,17 +419,23 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_attacked_with_throwables(self):
+    def update_attacked_with_throwables(
+        self,
+        player_state: CharState,
+        player_last_state: CharState,
+        player_last_item_types: Set[EntityType],
+        player_item_types: Set[EntityType],
+    ):
         if not self.is_low_percent:
             return
 
         if (
-            self.player_state != CharState.THROWING
-            and self.player_last_state != CharState.THROWING
+            player_state != CharState.THROWING
+            and player_last_state != CharState.THROWING
         ):
             return
 
-        for item_type in self.player_item_types | self.player_last_item_types:
+        for item_type in player_item_types | player_last_item_types:
             if item_type in LOW_BANNED_THROWABLES:
                 self.attacked_with = True
                 self.fail_low()
@@ -676,7 +682,12 @@ class RunState:
             presence_flags,
             self.player_item_types,
         )
-        self.update_attacked_with_throwables()
+        self.update_attacked_with_throwables(
+            self.player_last_state,
+            self.player_state,
+            self.player_last_item_types,
+            self.player_item_types,
+        )
 
         # Chain
         self.update_chain()

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -2,7 +2,6 @@ from enum import IntEnum
 import logging
 from typing import Optional, Set
 
-from modlunky2.mem import Spel2Process
 from modlunky2.mem.entities import (
     BACKPACKS,
     CHAIN_POWERUP_ENTITIES,
@@ -58,8 +57,7 @@ class ChainStatus(IntEnum):
 
 
 class RunState:
-    def __init__(self, proc: Spel2Process, always_show_modifiers=False):
-        self._proc = proc
+    def __init__(self, always_show_modifiers=False):
         self.always_show_modifiers = always_show_modifiers
         self.run_label = RunLabel()
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -172,8 +172,8 @@ class RunState:
                 self.run_label.add(Label.EGGPLANT)
                 return
 
-    def update_score_items(self):
-        for item_type in self.player_item_types:
+    def update_score_items(self, world, player_item_types):
+        for item_type in player_item_types:
             if item_type in [
                 EntityType.ITEM_PLASMACANNON,
                 EntityType.ITEM_POWERUP_TRUECROWN,
@@ -181,7 +181,7 @@ class RunState:
                 self.is_score_run = True
                 self.run_label.add(Label.SCORE)
 
-            elif item_type == EntityType.ITEM_HOUYIBOW and self.world >= 3:
+            elif item_type == EntityType.ITEM_HOUYIBOW and world >= 3:
                 self.hou_yis_waddler = True
 
     def update_global_state(self, game_state: State):
@@ -632,7 +632,7 @@ class RunState:
         self.update_player_item_types(game_state.instance_id_to_pointer, player)
         self.update_final_death()
 
-        self.update_score_items()
+        self.update_score_items(self.world, self.player_item_types)
 
         # Check Modifiers
         self.update_pacifist(run_recap_flags)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -308,14 +308,14 @@ class RunState:
         if self.had_clover:
             self.fail_low()
 
-    def update_wore_backpack(self):
-        if EntityType.ITEM_JETPACK in self.player_item_types:
+    def update_wore_backpack(self, player_item_types):
+        if EntityType.ITEM_JETPACK in player_item_types:
             self.run_label.discard(Label.NO_JETPACK)
 
         if not self.is_low_percent:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type in BACKPACKS:
                 self.wore_backpack = True
                 self.fail_low()
@@ -653,7 +653,7 @@ class RunState:
         self.update_starting_resources(player, self.player_state, inventory)
         self.update_status_effects(self.player_state, self.player_item_types)
         self.update_had_clover(hud_flags)
-        self.update_wore_backpack()
+        self.update_wore_backpack(self.player_item_types)
         self.update_held_shield()
         self.update_has_non_chain_powerup()
         self.update_attacked_with(layer, presence_flags)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -441,11 +441,11 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_chain(self):
+    def update_chain(self, player_item_types):
         if self.chain_status.failed:
             return
 
-        for item_type in self.player_item_types:
+        for item_type in player_item_types:
             if item_type == EntityType.ITEM_POWERUP_UDJATEYE:
                 self.had_udjat_eye = True
             elif item_type in [
@@ -690,7 +690,7 @@ class RunState:
         )
 
         # Chain
-        self.update_chain()
+        self.update_chain(self.player_item_types)
         self.update_has_chain_powerup(self.chain_status, self.player_item_types)
         self.update_is_chain()
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -270,7 +270,9 @@ class RunState:
             self.fail_low()
         self.ropes = ropes
 
-    def update_status_effects(self, player_state, player_item_types):
+    def update_status_effects(
+        self, player_state: CharState, player_item_types: Set[EntityType]
+    ):
         if not self.is_low_percent:
             return
 
@@ -310,7 +312,7 @@ class RunState:
         if self.had_clover:
             self.fail_low()
 
-    def update_wore_backpack(self, player_item_types):
+    def update_wore_backpack(self, player_item_types: Set[EntityType]):
         if EntityType.ITEM_JETPACK in player_item_types:
             self.run_label.discard(Label.NO_JETPACK)
 
@@ -323,7 +325,7 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_held_shield(self, player_item_types):
+    def update_held_shield(self, player_item_types: Set[EntityType]):
         if not self.is_low_percent:
             return
 
@@ -355,7 +357,7 @@ class RunState:
             }:
                 self.fail_low()
 
-    def update_has_non_chain_powerup(self, player_item_types):
+    def update_has_non_chain_powerup(self, player_item_types: Set[EntityType]):
         if not self.is_low_percent:
             return
 
@@ -443,7 +445,7 @@ class RunState:
                 self.fail_low()
                 return
 
-    def update_chain(self, player_item_types):
+    def update_chain(self, player_item_types: Set[EntityType]):
         if self.chain_status.failed:
             return
 

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -342,3 +342,30 @@ def test_has_chain_powerup(
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "item_set,expected_low",
+    [
+        # Exercise the most common power-ups
+        ({EntityType.ITEM_POWERUP_COMPASS}, False),
+        ({EntityType.ITEM_POWERUP_PARACHUTE}, False),
+        ({EntityType.ITEM_POWERUP_SKELETON_KEY}, False),
+        ({EntityType.ITEM_POWERUP_SPIKE_SHOES}, False),
+        ({EntityType.ITEM_POWERUP_SPRING_SHOES}, False),
+        # Having more than one isn't OK eithere
+        (
+            {EntityType.ITEM_POWERUP_PARACHUTE, EntityType.ITEM_POWERUP_SPRING_SHOES},
+            False,
+        ),
+        # Just holding the arrow of light is OK
+        ({EntityType.ITEM_LIGHT_ARROW}, True),
+        (set(), True),
+    ],
+)
+def test_has_non_chain_powerup(item_set, expected_low):
+    run_state = RunState()
+    run_state.update_has_non_chain_powerup(item_set)
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -147,6 +147,7 @@ def test_starting_resources_health(char_state, prev_health, cur_health, expected
 
     player = Player(state=char_state, health=cur_health)
     run_state.update_starting_resources(player, char_state, player.inventory)
+    assert run_state.health == cur_health
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
@@ -169,6 +170,8 @@ def test_starting_resources_bombs(prev_bombs, cur_bombs, expected_low):
     inventory = Inventory(bombs=cur_bombs)
     player = Player(inventory=inventory)
     run_state.update_starting_resources(player, player.state, inventory)
+
+    assert run_state.bombs == cur_bombs
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
@@ -195,6 +198,8 @@ def test_starting_resources_ropes(
     inventory = Inventory(ropes=cur_ropes)
     player = Player(inventory=inventory)
     run_state.update_starting_resources(player, player.state, inventory)
+
+    assert run_state.ropes == cur_ropes
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1433,3 +1433,56 @@ def test_millionaire_(
 
     is_millionaire = Label.MILLIONAIRE in run_state.run_label._set
     assert is_millionaire == expected_millionaire
+
+
+@pytest.mark.parametrize(
+    "world,theme,ropes,prev_health,expected_level_start_ropes,expected_health",
+    [
+        # Level start ropes
+        (2, Theme.JUNGLE, 4, 4, 4, 4),
+        (2, Theme.VOLCANA, 2, 3, 2, 3),
+        # Duat health adjustment
+        (4, Theme.DUAT, 5, 2, 5, 4),
+        (4, Theme.DUAT, 5, 4, 5, 4),
+        (4, Theme.DUAT, 5, 10, 5, 4),
+    ],
+)
+def test_on_level_start_state(
+    world, theme, ropes, prev_health, expected_level_start_ropes, expected_health
+):
+    run_state = RunState()
+    run_state.level_started = True
+    run_state.health = prev_health
+
+    run_state.update_on_level_start(world, theme, ropes)
+
+    assert run_state.level_start_ropes == expected_level_start_ropes
+    assert run_state.health == expected_health
+
+
+@pytest.mark.parametrize(
+    "world,theme,mc_has_swung_mattock,hou_yis_bow,expected_low",
+    [
+        # Bow isn't needed in world 2
+        (2, Theme.VOLCANA, False, False, True),
+        (2, Theme.VOLCANA, True, False, True),
+        (2, Theme.VOLCANA, True, True, True),
+        # Bow required if mattock was swung in Moon Challenge
+        (3, Theme.OLMEC, False, False, True),
+        (3, Theme.OLMEC, True, False, False),
+        (3, Theme.OLMEC, True, True, True),
+    ],
+)
+def test_on_level_start_low(
+    world, theme, mc_has_swung_mattock, hou_yis_bow, expected_low
+):
+    run_state = RunState()
+    run_state.level_started = True
+    run_state.mc_has_swung_mattock = mc_has_swung_mattock
+    run_state.hou_yis_bow = hou_yis_bow
+
+    ropes = 4
+    run_state.update_on_level_start(world, theme, ropes)
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1,4 +1,5 @@
 import pytest
+from modlunky2.mem.entities import EntityType
 
 from modlunky2.mem.state import RunRecapFlags
 from modlunky2.ui.trackers.label import Label
@@ -22,3 +23,18 @@ def test_run_recap(label, recap_flag, method):
     run_state = RunState()
     method(run_state, RunRecapFlags(0))
     assert label not in run_state.run_label._set
+
+
+@pytest.mark.parametrize(
+    "item_set,expected_no_tp",
+    [
+        ({EntityType.ITEM_TELEPORTER}, False),
+        ({EntityType.ITEM_POWERUP_COMPASS}, True),
+        (set(), True),
+    ],
+)
+def test_no_tp(item_set, expected_no_tp):
+    run_state = RunState()
+    run_state.update_no_tp(item_set)
+    is_no_tp = Label.NO_TELEPORTER in run_state.run_label._set
+    assert is_no_tp == expected_no_tp

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -89,6 +89,21 @@ def test_score_items(world, item_set, expected_score, expected_hou_yi):
 
 
 @pytest.mark.parametrize(
+    "player_state,item_set,expected_final_death",
+    [
+        (CharState.STANDING, set(), False),
+        (CharState.DYING, {EntityType.ITEM_POWERUP_ANKH}, False),
+        (CharState.DYING, set(), True),
+        (CharState.DYING, {EntityType.ITEM_POWERUP_PASTE}, True),
+    ],
+)
+def test_final_death(player_state, item_set, expected_final_death):
+    run_state = RunState()
+    run_state.update_final_death(player_state, item_set)
+    assert run_state.final_death == expected_final_death
+
+
+@pytest.mark.parametrize(
     "chain_status,theme,mount_type,mount_tamed,expected_low",
     [
         # Mounting Qilin in Neo-Bab is never allowed

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -313,3 +313,32 @@ def test_held_shield(item_set, expected_low):
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "chain_status,item_set,expected_failed_low_if_not_chain,expected_low",
+    [
+        # All of  these are fine while the chain is in-progress
+        (ChainStatus.IN_PROGRESS, {EntityType.ITEM_POWERUP_UDJATEYE}, True, True),
+        (ChainStatus.IN_PROGRESS, {EntityType.ITEM_POWERUP_CROWN}, True, True),
+        (ChainStatus.IN_PROGRESS, {EntityType.ITEM_POWERUP_HEDJET}, True, True),
+        # Starting points are OK even if we haven't updated chain status
+        (ChainStatus.UNSTARTED, {EntityType.ITEM_POWERUP_UDJATEYE}, True, True),
+        (ChainStatus.UNSTARTED, {EntityType.ITEM_POWERUP_CROWN}, True, True),
+        (ChainStatus.UNSTARTED, {EntityType.ITEM_POWERUP_HEDJET}, True, True),
+        # If it's not a starting point for the chain, and chain isn't in progress, we should fail immediately
+        (ChainStatus.UNSTARTED, {EntityType.ITEM_POWERUP_ANKH}, True, False),
+        (ChainStatus.UNSTARTED, {EntityType.ITEM_POWERUP_TABLETOFDESTINY}, True, False),
+        (ChainStatus.FAILED, {EntityType.ITEM_POWERUP_ANKH}, True, False),
+        (ChainStatus.FAILED, {EntityType.ITEM_POWERUP_TABLETOFDESTINY}, True, False),
+    ],
+)
+def test_has_chain_powerup(
+    chain_status, item_set, expected_failed_low_if_not_chain, expected_low
+):
+    run_state = RunState()
+    run_state.update_has_chain_powerup(chain_status, item_set)
+    assert run_state.failed_low_if_not_chain == expected_failed_low_if_not_chain
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -139,7 +139,8 @@ def test_has_mounted_tame(chain_status, theme, mount_type, mount_tamed, expected
     poly_mount = PolyPointer(101, mount, MemContext())
 
     run_state = RunState()
-    run_state.update_has_mounted_tame(chain_status, theme, poly_mount)
+    run_state.chain_status = chain_status
+    run_state.update_has_mounted_tame(theme, poly_mount)
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -55,3 +55,25 @@ def test_eggplant(world, item_set, expected_eggplant):
     run_state.update_eggplant(world, item_set)
     is_eggplant = Label.EGGPLANT in run_state.run_label._set
     assert is_eggplant == expected_eggplant
+
+
+@pytest.mark.parametrize(
+    "world,item_set,expected_score,expected_hou_yi",
+    [
+        (7, {EntityType.ITEM_POWERUP_EGGPLANTCROWN}, False, False),
+        (3, {EntityType.ITEM_HOUYIBOW}, False, True),
+        (2, {EntityType.ITEM_HOUYIBOW}, False, False),
+        (1, {EntityType.ITEM_PLASMACANNON}, True, False),
+        (5, {EntityType.ITEM_PLASMACANNON}, True, False),
+        (1, set(), False, False),
+        (6, set(), False, False),
+    ],
+)
+def test_score_items(world, item_set, expected_score, expected_hou_yi):
+    run_state = RunState()
+    run_state.update_score_items(world, item_set)
+
+    is_score = Label.SCORE in run_state.run_label._set
+    assert is_score == expected_score
+
+    assert run_state.hou_yis_waddler == expected_hou_yi

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -632,3 +632,50 @@ def test_attacked_with_hou_yi(layer, world, level, presence_flags, expected_low)
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "prev_state,cur_state,prev_item_set,cur_item_set,expected_low",
+    [
+        (
+            CharState.THROWING,
+            CharState.STANDING,
+            {EntityType.ITEM_LIGHT_ARROW},
+            set(),
+            False,
+        ),
+        (
+            CharState.STANDING,
+            CharState.THROWING,
+            set(),
+            {EntityType.ITEM_LIGHT_ARROW},
+            False,
+        ),
+        (
+            CharState.THROWING,
+            CharState.STANDING,
+            {EntityType.ITEM_WOODEN_ARROW},
+            set(),
+            True,
+        ),
+        (
+            CharState.STANDING,
+            CharState.THROWING,
+            set(),
+            {EntityType.ITEM_WOODEN_ARROW},
+            True,
+        ),
+        # Sometimes the throwing state was a while ago
+        (CharState.THROWING, CharState.STANDING, set(), set(), True),
+    ],
+)
+def test_attacked_with_throwables(
+    prev_state, cur_state, prev_item_set, cur_item_set, expected_low
+):
+    run_state = RunState()
+    run_state.update_attacked_with_throwables(
+        prev_state, cur_state, prev_item_set, cur_item_set
+    )
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -295,3 +295,21 @@ def test_wore_backpack(item_set, expected_no_jp, expected_low):
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "item_set,expected_low",
+    [
+        ({EntityType.ITEM_METAL_SHIELD}, False),
+        ({EntityType.ITEM_WOODEN_SHIELD}, False),
+        # Just holding a camera is OK
+        ({EntityType.ITEM_CAMERA}, True),
+        (set(), True),
+    ],
+)
+def test_held_shield(item_set, expected_low):
+    run_state = RunState()
+    run_state.update_held_shield(item_set)
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1,5 +1,11 @@
 import pytest
-from modlunky2.mem.entities import EntityDBEntry, EntityType, Mount
+from modlunky2.mem.entities import (
+    EntityDBEntry,
+    EntityType,
+    Inventory,
+    Mount,
+    Player,
+)
 from modlunky2.mem.memrauder.model import MemContext, PolyPointer
 
 from modlunky2.mem.state import RunRecapFlags, Theme
@@ -117,6 +123,28 @@ def test_has_mounted_tame(chain_status, theme, mount_type, mount_tamed, expected
 
     run_state = RunState()
     run_state.update_has_mounted_tame(chain_status, theme, poly_mount)
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "prev_bombs,cur_bombs,expected_low",
+    [
+        (4, 4, True),
+        (4, 3, True),
+        (3, 1, True),
+        (7, 7, False),
+        (1, 4, False),
+    ],
+)
+def test_starting_resources_bombs(prev_bombs, cur_bombs, expected_low):
+    run_state = RunState()
+    run_state.bombs = prev_bombs
+
+    inventory = Inventory(bombs=cur_bombs)
+    player = Player(inventory=inventory)
+    run_state.update_starting_resources(player, inventory)
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -266,3 +266,27 @@ def test_had_clover(hud_flags, expected_low):
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "item_set,expected_no_jp,expected_low",
+    [
+        ({EntityType.ITEM_JETPACK}, False, False),
+        # We exercise the most popular backpacks
+        ({EntityType.ITEM_HOVERPACK}, True, False),
+        ({EntityType.ITEM_VLADS_CAPE}, True, False),
+        ({EntityType.ITEM_TELEPORTER_BACKPACK}, True, False),
+        # Not a backpack
+        ({EntityType.ITEM_SHOTGUN}, True, True),
+        (set(), True, True),
+    ],
+)
+def test_wore_backpack(item_set, expected_no_jp, expected_low):
+    run_state = RunState()
+    run_state.update_wore_backpack(item_set)
+
+    is_no_jp = Label.NO_JETPACK in run_state.run_label._set
+    assert is_no_jp == expected_no_jp
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from modlunky2.mem.state import RunRecapFlags
+from modlunky2.ui.trackers.label import Label
+from modlunky2.ui.trackers.runstate import RunState
+
+# pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "label,recap_flag,method",
+    [
+        (Label.PACIFIST, RunRecapFlags.PACIFIST, RunState.update_pacifist),
+        (Label.NO_GOLD, RunRecapFlags.NO_GOLD, RunState.update_no_gold),
+    ],
+)
+def test_run_recap(label, recap_flag, method):
+    run_state = RunState()
+    method(run_state, recap_flag)
+    assert label in run_state.run_label._set
+
+    run_state = RunState()
+    method(run_state, RunRecapFlags(0))
+    assert label not in run_state.run_label._set

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -172,3 +172,29 @@ def test_starting_resources_bombs(prev_bombs, cur_bombs, expected_low):
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "level_start_ropes,prev_ropes,cur_ropes,expected_low",
+    [
+        (4, 4, 4, True),
+        (4, 4, 3, True),
+        (3, 3, 1, True),
+        (3, 2, 3, True),
+        (7, 7, 7, False),
+        (1, 1, 4, False),
+    ],
+)
+def test_starting_resources_ropes(
+    level_start_ropes, prev_ropes, cur_ropes, expected_low
+):
+    run_state = RunState()
+    run_state.level_start_ropes = level_start_ropes
+    run_state.ropes = prev_ropes
+
+    inventory = Inventory(ropes=cur_ropes)
+    player = Player(inventory=inventory)
+    run_state.update_starting_resources(player, player.state, inventory)
+
+    is_low = Label.LOW in run_state.run_label._set
+    assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1,5 +1,5 @@
 import pytest
-from modlunky2.mem.entities import CharState, EntityDBEntry, EntityType, Mount
+from modlunky2.mem.entities import EntityDBEntry, EntityType, Mount
 from modlunky2.mem.memrauder.model import MemContext, PolyPointer
 
 from modlunky2.mem.state import RunRecapFlags, Theme
@@ -112,28 +112,11 @@ def test_score_items(world, item_set, expected_score, expected_hou_yi):
     ],
 )
 def test_has_mounted_tame(chain_status, theme, mount_type, mount_tamed, expected_low):
-    mount = make_mount(mount_type, mount_tamed)
+    mount = Mount(type=EntityDBEntry(id=mount_type), is_tamed=mount_tamed)
+    poly_mount = PolyPointer(101, mount, MemContext())
 
     run_state = RunState()
-    run_state.update_has_mounted_tame(chain_status, theme, mount)
+    run_state.update_has_mounted_tame(chain_status, theme, poly_mount)
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
-
-
-def make_mount(mount_type: EntityType, tamed: bool):
-    if mount_type is None:
-        return PolyPointer.make_empty(MemContext())
-
-    mount = Mount(
-        type=EntityDBEntry(id=mount_type),
-        items=None,
-        layer=1,
-        overlay=PolyPointer.make_empty(MemContext()),
-        holding_uid=0,
-        state=CharState.SITTING,
-        last_state=CharState.STANDING,
-        health=2,
-        is_tamed=tamed,
-    )
-    return PolyPointer(101, mount, MemContext())

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -38,3 +38,20 @@ def test_no_tp(item_set, expected_no_tp):
     run_state.update_no_tp(item_set)
     is_no_tp = Label.NO_TELEPORTER in run_state.run_label._set
     assert is_no_tp == expected_no_tp
+
+
+@pytest.mark.parametrize(
+    "world,item_set,expected_eggplant",
+    [
+        # Eggplant crown can only be collected in Sunken City
+        (7, {EntityType.ITEM_POWERUP_EGGPLANTCROWN}, True),
+        (6, set(), False),
+        (7, set(), False),
+        (8, set(), False),
+    ],
+)
+def test_eggplant(world, item_set, expected_eggplant):
+    run_state = RunState()
+    run_state.update_eggplant(world, item_set)
+    is_eggplant = Label.EGGPLANT in run_state.run_label._set
+    assert is_eggplant == expected_eggplant

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -679,3 +679,24 @@ def test_attacked_with_throwables(
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+
+@pytest.mark.parametrize(
+    "item_type, property_name",
+    [
+        (EntityType.ITEM_POWERUP_UDJATEYE, "had_udjat_eye"),
+        (EntityType.ITEM_POWERUP_CROWN, "had_world2_chain_headwear"),
+        (EntityType.ITEM_POWERUP_HEDJET, "had_world2_chain_headwear"),
+        (EntityType.ITEM_POWERUP_ANKH, "had_ankh"),
+        (EntityType.ITEM_EXCALIBUR, "held_world4_chain_item"),
+        (EntityType.ITEM_SCEPTER, "held_world4_chain_item"),
+        (EntityType.ITEM_POWERUP_TABLETOFDESTINY, "had_tablet_of_destiny"),
+        (EntityType.ITEM_USHABTI, "held_ushabti"),
+        (EntityType.ITEM_HOUYIBOW, "hou_yis_bow"),
+    ],
+)
+def test_chain(item_type, property_name):
+    run_state = RunState()
+    assert run_state.__getattribute__(property_name) is False
+    run_state.update_chain({item_type})
+    assert run_state.__getattribute__(property_name) is True


### PR DESCRIPTION
This adds `runstate_test.py`, which is ~1.5K lines and adds 295 test cases.

A few principles for the tests I wrote, to keep them manageable:

- Only test inputs that are realistic in an unmodded game
- Minimize duplication/repetition
- If a method has more than ~5 inputs, split the `test_foo` into several `test_foo_bar`, `test_foo_bat`
- Avoid lots of primitives of the same type

This PR includes some changes that aren't test cases

- Making all game state arguments of the method, to better separate it from `RunState`'s computed stuff
- Adding default values for structs, to ease test construction
- Added a `DictUnorderedMap` for use in tests
- Annotate `update_foo` method params, mostly to help me keep track of `int` vs `IntEnum`
- TODOs for bugs I noticed
- Cutting out `Spel2Proceess`, which was unused anyway

For some consistency with test case values, I used the order:

1. Game state
2. `RunState` field values
3. Expected values