### PR TITLE
Tidy RunState a bit

### DIFF
--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -159,16 +159,7 @@ class CharState(IntEnum):
 class EntityDBEntry:
     _size_as_element_: ClassVar[int] = 256  # Size of EntityDB struct
 
-    id: int = struct_field(0x14, sc_uint32)  # pylint: disable=invalid-name
-
-    # TODO try constructing eagerly
-    @property
-    def entity_type(self) -> EntityType:
-        return EntityType(self.id)
-
-    @property
-    def name(self):
-        return self.entity_type.name
+    id: EntityType = struct_field(0x14, sc_uint32)  # pylint: disable=invalid-name
 
 
 # EntityReduced exists only to break the circular dependency via 'overlay'

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -138,22 +138,16 @@ class Items:
 
 @dataclass(frozen=True)
 class State:
-    # TODO try using enum, which implies failing on unexpected values
-    screen_last: int = struct_field(
-        0x08, sc_int32, default=Screen.LEVEL_TRANSITION.value
-    )
-    screen: int = struct_field(0x0C, sc_int32, default=Screen.LEVEL.value)
-    screen_next: int = struct_field(
-        0x10, sc_int32, default=Screen.LEVEL_TRANSITION.value
-    )
+    screen_last: Screen = struct_field(0x08, sc_int32, default=Screen.LEVEL_TRANSITION)
+    screen: Screen = struct_field(0x0C, sc_int32, default=Screen.LEVEL)
+    screen_next: Screen = struct_field(0x10, sc_int32, default=Screen.LEVEL_TRANSITION)
     quest_flags: QuestFlags = struct_field(0x38, sc_uint32, default=0)
     # The total amount spent at shops and stolen by leprechauns. This is non-positive during the run.
     # If the run ends in a victory, the bonus will be added to this during the score screen.
     money_shop_total: int = struct_field(0x58, sc_int32, default=0)
     world_start: int = struct_field(0x5C, sc_uint8, default=1)
     level_start: int = struct_field(0x5D, sc_uint8, default=1)
-    # TODO try using enum, which implies failing on unexpected values
-    theme_start: int = struct_field(0x5E, sc_uint8, default=Theme.DWELLING.value)
+    theme_start: Theme = struct_field(0x5E, sc_uint8, default=Theme.DWELLING)
     time_total: int = struct_field(0x64, sc_uint32, default=1)
     world: int = struct_field(0x68, sc_uint8, default=1)
     world_next: int = struct_field(0x69, sc_uint8, default=1)

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -100,7 +100,7 @@ class CategoryWatcherThread(WatcherThread):
         self.time_total = new_time_total
 
         self.run_state.update(game_state)
-        label = self.run_state.get_display()
+        label = self.run_state.get_display(game_state.screen)
         self.send(Command.LABEL, label)
 
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -61,7 +61,6 @@ class RunState:
         self.always_show_modifiers = always_show_modifiers
         self.run_label = RunLabel()
 
-        # TODO only copy stuff from mem.State if we need to know the previous value
         self.world = 0
         self.level = 0
         self.level_started = False
@@ -437,10 +436,6 @@ class RunState:
             self.run_label.add(Label.JUNGLE_TEMPLE)
         else:
             self.run_label.discard(Label.JUNGLE_TEMPLE)
-
-        # TODO delete this code that can't be reached
-        if world is Theme.SUNKEN_CITY:
-            self.run_label.set_terminus(Label.SUNKEN_CITY)
 
     def update_terminus(self, world: int, theme: Theme, win_state: WinState):
         terminus = Label.ANY

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -142,11 +142,10 @@ class RunState:
         if world < 7:
             return
 
-        for item_type in player_item_types:
-            if item_type == EntityType.ITEM_POWERUP_EGGPLANTCROWN:
-                self.eggplant = True
-                self.run_label.add(Label.EGGPLANT)
-                return
+        if EntityType.ITEM_POWERUP_EGGPLANTCROWN in player_item_types:
+            self.eggplant = True
+            self.run_label.add(Label.EGGPLANT)
+            return
 
     def update_score_items(self, world, player_item_types):
         for item_type in player_item_types:

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -587,11 +587,6 @@ class RunState:
         player = game_state.items.players[0]
         if player is None:
             return
-
-        state = player.state
-        last_state = player.last_state
-        layer = player.layer
-
         if player.inventory is None:
             return
 
@@ -601,7 +596,7 @@ class RunState:
         self.update_global_state(game_state)
         self.update_on_level_start(game_state.world, game_state.theme, self.ropes)
         self.update_player_item_types(game_state.instance_id_to_pointer, player)
-        self.update_final_death(state, self.player_item_types)
+        self.update_final_death(player.state, self.player_item_types)
 
         self.update_score_items(game_state.world, self.player_item_types)
 
@@ -617,15 +612,15 @@ class RunState:
         # Low%
         self.update_has_mounted_tame(game_state.theme, overlay)
         self.update_starting_resources(player)
-        self.update_status_effects(state, self.player_item_types)
+        self.update_status_effects(player.state, self.player_item_types)
         self.update_had_clover(hud_flags)
         self.update_wore_backpack(self.player_item_types)
         self.update_held_shield(self.player_item_types)
         self.update_has_non_chain_powerup(self.player_item_types)
         self.update_attacked_with(
-            last_state,
-            state,
-            layer,
+            player.last_state,
+            player.state,
+            player.layer,
             game_state.world,
             self.level,
             game_state.theme,
@@ -633,8 +628,8 @@ class RunState:
             self.player_item_types,
         )
         self.update_attacked_with_throwables(
-            last_state,
-            state,
+            player.last_state,
+            player.state,
             self.player_last_item_types,
             self.player_item_types,
         )

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -540,7 +540,6 @@ class RunState:
         # We drop millionaire if either:
         # * You used to have enough money, but no longer do
         # * You picked up the clone gun, but won without enough money
-        # TODO fix clone gun case
         if net_score < 900_000 and (
             not self.clone_gun_wo_bow or game_state.win_state is not WinState.NO_WIN
         ):

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -207,24 +207,21 @@ class RunState:
             if mount is not None and mount.is_tamed:
                 self.fail_low()
 
-    # TODO access player.state instead of passing it separately
-    def update_starting_resources(
-        self, player: Player, player_state: CharState, inventory: Inventory
-    ):
+    def update_starting_resources(self, player: Player):
         if not self.is_low_percent:
             return
 
         health = player.health
-        if (health > self.health and player_state != CharState.DYING) or health > 4:
+        if (health > self.health and player.state != CharState.DYING) or health > 4:
             self.fail_low()
         self.health = health
 
-        bombs = inventory.bombs
+        bombs = player.inventory.bombs
         if bombs > self.bombs or bombs > 4:
             self.fail_low()
         self.bombs = bombs
 
-        ropes = inventory.ropes
+        ropes = player.inventory.ropes
         if ropes > self.level_start_ropes or ropes > 4:
             self.fail_low()
         self.ropes = ropes
@@ -597,12 +594,11 @@ class RunState:
         if player is None:
             return
 
-        inventory = player.inventory
         state = player.state
         last_state = player.last_state
         layer = player.layer
 
-        if inventory is None:
+        if player.inventory is None:
             return
 
         run_recap_flags = game_state.run_recap_flags
@@ -626,7 +622,7 @@ class RunState:
 
         # Low%
         self.update_has_mounted_tame(game_state.theme, overlay)
-        self.update_starting_resources(player, state, inventory)
+        self.update_starting_resources(player)
         self.update_status_effects(state, self.player_item_types)
         self.update_had_clover(hud_flags)
         self.update_wore_backpack(self.player_item_types)
@@ -656,7 +652,7 @@ class RunState:
             game_state.world, self.level, game_state.theme, game_state.win_state
         )
 
-        self.update_millionaire(game_state, inventory, self.player_item_types)
+        self.update_millionaire(game_state, player.inventory, self.player_item_types)
 
         self.update_terminus(game_state.world, game_state.theme, game_state.win_state)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -64,7 +64,6 @@ class RunState:
         # TODO only copy stuff from mem.State if we need to know the previous value
         self.world = 0
         self.level = 0
-        self.screen = Screen.UNKNOWN
         self.level_started = False
 
         self.player_item_types: Set[EntityType] = set()
@@ -162,7 +161,6 @@ class RunState:
     def update_global_state(self, game_state: State):
         world = game_state.world
         level = game_state.level
-        screen = game_state.screen
 
         if (world, level) != (self.world, self.level):
             self.level_started = True
@@ -171,11 +169,6 @@ class RunState:
 
         self.world = world
         self.level = level
-        # Cope with weird screen value during shutdown
-        try:
-            self.screen = Screen(screen)
-        except ValueError:
-            self.screen = Screen.UNKNOWN
 
     def update_final_death(
         self, player_state: CharState, player_item_types: Set[EntityType]
@@ -684,16 +677,16 @@ class RunState:
             if entity_type is None:
                 continue
 
-            item_types.add(entity_type.entity_type)
+            item_types.add(entity_type.id)
 
         self.player_last_item_types = self.player_item_types
         self.player_item_types = item_types
 
-    def should_show_modifiers(self):
+    def should_show_modifiers(self, screen: Screen):
         if self.always_show_modifiers:
             return True
 
-        if self.screen == Screen.SCORES:
+        if screen == Screen.SCORES:
             return True
 
         if self.world > 1:
@@ -707,5 +700,5 @@ class RunState:
 
         return False
 
-    def get_display(self):
-        return self.run_label.text(not self.should_show_modifiers())
+    def get_display(self, screen: Screen):
+        return self.run_label.text(not self.should_show_modifiers(screen))

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -170,7 +170,7 @@ def test_starting_resources_health(char_state, prev_health, cur_health, expected
     run_state.health = prev_health
 
     player = Player(state=char_state, health=cur_health)
-    run_state.update_starting_resources(player, char_state, player.inventory)
+    run_state.update_starting_resources(player)
     assert run_state.health == cur_health
 
     is_low = Label.LOW in run_state.run_label._set
@@ -193,7 +193,7 @@ def test_starting_resources_bombs(prev_bombs, cur_bombs, expected_low):
 
     inventory = Inventory(bombs=cur_bombs)
     player = Player(inventory=inventory)
-    run_state.update_starting_resources(player, player.state, inventory)
+    run_state.update_starting_resources(player)
 
     assert run_state.bombs == cur_bombs
 
@@ -221,7 +221,7 @@ def test_starting_resources_ropes(
 
     inventory = Inventory(ropes=cur_ropes)
     player = Player(inventory=inventory)
-    run_state.update_starting_resources(player, player.state, inventory)
+    run_state.update_starting_resources(player)
 
     assert run_state.ropes == cur_ropes
 

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -430,7 +430,7 @@ def test_attacked_with_simple(prev_state, cur_state, item_set, expected_low):
 
 
 @pytest.mark.parametrize(
-    "layer,theme,presence_flags,chain_status,expected_lc_has_swung_excalibur,expected_low",
+    "layer,theme,presence_flags,chain_status,expected_failed_low_if_not_chain,expected_low",
     [
         # Not OK to swing in Tide Pool, regardless of chain or presence
         (
@@ -522,7 +522,7 @@ def test_attacked_with_excalibur(
     theme,
     presence_flags,
     chain_status,
-    expected_lc_has_swung_excalibur,
+    expected_failed_low_if_not_chain,
     expected_low,
 ):
     prev_state = CharState.PUSHING
@@ -538,8 +538,7 @@ def test_attacked_with_excalibur(
     )
 
     # We only expect these to be set together
-    assert run_state.failed_low_if_not_chain == expected_lc_has_swung_excalibur
-    assert run_state.lc_has_swung_excalibur == expected_lc_has_swung_excalibur
+    assert run_state.failed_low_if_not_chain == expected_failed_low_if_not_chain
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -1402,9 +1402,9 @@ def test_millionaire_clone_gun_wo_bow(
         (-2_500, WinState.NO_WIN, 900_000, 10, False, False),
         (-2_500, WinState.NO_WIN, 900_000, 2_500, False, True),
         # With the clone gun, money amounts don't matter before winning
-        (0, WinState.NO_WIN, 0, 0, True, False),  # bug
+        (0, WinState.NO_WIN, 0, 0, True, True),
         (0, WinState.NO_WIN, 900_000, 0, True, True),
-        (-5_000, WinState.NO_WIN, 900_000, 0, True, False),  # bug
+        (-5_000, WinState.NO_WIN, 900_000, 0, True, True),
         # Before statue drops on score screen we don't have the bonus, and that's OK
         (0, WinState.TIAMAT, 900_000, 0, False, True),
         (100_000, WinState.TIAMAT, 900_000, 0, False, True),
@@ -1424,6 +1424,9 @@ def test_millionaire_(
 ):
     run_state = RunState()
     run_state.clone_gun_wo_bow = clone_gun_wo_bow
+    if clone_gun_wo_bow:
+        # This would have been added on a previous update
+        run_state.run_label.add(Label.MILLIONAIRE)
 
     game_state = State(money_shop_total=money_shop_total, win_state=win_state)
     inventory = Inventory(money=money, collected_money_total=collected_money_total)


### PR DESCRIPTION
This is  a hodge-podge of cleanup changes:

- Use enums consistently in dataclasses
- Pass dataclasses instead of individual values
- Remove unnecessary copying of fields into RunState
- Remove write-only fields
- Remove some attempts to skip operations that are cheap now
- Use `in` when checking for a single set element
- Fix oversight in Millionaire test