### PR TITLE
Fix "waiting for game..." before first run

### DIFF
--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -97,6 +97,7 @@ class Screen(enum.IntEnum):
 
 
 class Theme(enum.IntEnum):
+    BEFORE_FIRST_RUN = 0
     DWELLING = 1
     JUNGLE = 2
     VOLCANA = 3


### PR DESCRIPTION
Prior to the first run in a session, the theme_start field is set to 0. There was no `Theme` enum value for 0. So, the tracker failed to update and "waiting for game..." was still displayed.