### PR TITLE
Only remove No TP when we detect teleport

### DIFF
--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -16,6 +16,7 @@ from modlunky2.mem.memrauder.dsl import (
     sc_int16,
     sc_int32,
     sc_bool,
+    sc_float,
 )
 from modlunky2.mem.memrauder.model import PolyPointer
 from modlunky2.mem.memrauder.msvc import vector
@@ -171,6 +172,8 @@ class EntityReduced:
         0x18, vector(sc_uint32), default=None
     )
     layer: int = struct_field(0x98, sc_uint8, default=Layer.FRONT)
+    position_x: float = struct_field(0x40, sc_float, default=0.0)
+    position_y: float = struct_field(0x44, sc_float, default=0.0)
 
 
 @dataclass(frozen=True)
@@ -182,6 +185,9 @@ class Entity(EntityReduced):
 
 @dataclass(frozen=True)
 class Movable(Entity):
+    idle_counter: int = struct_field(0xF8, sc_uint32, default=0)
+    velocity_x: float = struct_field(0x100, sc_float, default=0.0)
+    velocity_y: float = struct_field(0x104, sc_float, default=0.0)
     holding_uid: int = struct_field(0x108, sc_int32, default=-1)
     state: CharState = struct_field(0x10C, sc_uint8, default=CharState.STANDING)
     last_state: CharState = struct_field(0x10D, sc_uint8, default=CharState.STANDING)
@@ -213,3 +219,16 @@ class Player(Movable):
     )
     linked_companion_child: int = struct_field(0x148, sc_int32, default=0)
     linked_companion_parent: int = struct_field(0x14C, sc_int32, default=0)
+
+
+@dataclass(frozen=True)
+class Illumination:
+    light_pos_x: float = struct_field(0x48, sc_float)
+    light_pos_y: float = struct_field(0x4C, sc_float)
+
+
+@dataclass(frozen=True)
+class LightEmitter(Movable):
+    emitted_light: Optional[Illumination] = struct_field(
+        0x128, pointer(dc_struct), default=None
+    )

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -223,8 +223,8 @@ class Player(Movable):
 
 @dataclass(frozen=True)
 class Illumination:
-    light_pos_x: float = struct_field(0x48, sc_float)
-    light_pos_y: float = struct_field(0x4C, sc_float)
+    light_pos_x: float = struct_field(0x48, sc_float, default=0.0)
+    light_pos_y: float = struct_field(0x4C, sc_float, default=0.0)
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -162,7 +162,9 @@ class State:
     )
     run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32, default=0)
     hud_flags: HudFlags = struct_field(0xA10, sc_uint32, default=0)
+    time_level: int = struct_field(0xA04, sc_uint32, default=0)
     presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32, default=0)
+    next_entity_uid: int = struct_field(0x12A0, sc_uint32, default=0)
     items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct), default=None)
     instance_id_to_pointer: UnorderedMap[int, PolyPointer[Entity]] = struct_field(
         0x1308,

--- a/src/modlunky2/mem/testing.py
+++ b/src/modlunky2/mem/testing.py
@@ -10,7 +10,7 @@ from modlunky2.mem.memrauder.msvc import DictUnorderedMap
 @dataclass
 class EntityMapBuilder:
     next_uid: int = 1
-    entity_map: Dict[int, Entity] = dataclasses.field(default_factory=dict)
+    entity_map: Dict[int, PolyPointer[Entity]] = dataclasses.field(default_factory=dict)
     mem_ctx: MemContext = dataclasses.field(default_factory=MemContext)
 
     FAKE_ADDR: ClassVar[int] = 1234567

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -23,7 +23,7 @@ class CommonCommand(Enum):
 
 
 class WatcherThread(threading.Thread):
-    POLL_INTERVAL = 0.1
+    POLL_INTERVAL = 0.05
     ATTACH_INTERVAL = 1.0
 
     def __init__(self, queue):

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -135,23 +135,23 @@ class RunState:
             return
 
         found_shadows: List[LightEmitter] = []
-        for shadow_uid in range(prev_next_uid, game_state.next_entity_uid):
-            shadow_poly = game_state.instance_id_to_pointer.get(shadow_uid)
-            if shadow_poly is None or not shadow_poly.present():
+        for entity_uid in range(prev_next_uid, game_state.next_entity_uid):
+            entity_poly = game_state.instance_id_to_pointer.get(entity_uid)
+            if entity_poly is None or not entity_poly.present():
                 continue
-            shadow = shadow_poly.value
-            if shadow.type is None:
+            entity = entity_poly.value
+            if entity.type is None:
                 continue
-            if shadow.type.id is not EntityType.FX_TELEPORTSHADOW:
+            if entity.type.id is not EntityType.FX_TELEPORTSHADOW:
                 continue
             # Now that we know it's the right type, downcast
-            shadow = shadow_poly.as_type(LightEmitter)
-            if shadow is None:
+            entity = entity_poly.as_type(LightEmitter)
+            if entity is None:
                 continue
-            if shadow.emitted_light is None:
+            if entity.emitted_light is None:
                 continue
 
-            found_shadows.append(shadow)
+            found_shadows.append(entity)
 
         # We need pairs to work with
         num_shadows = len(found_shadows)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -126,6 +126,7 @@ class RunState:
         if self.level_started:
             return
 
+        # This is an optimization to skip scanning when the player couldn't have teleported
         if not self.could_tp(player, player_item_set):
             return
 
@@ -148,10 +149,11 @@ class RunState:
 
             found_shadows.append(shadow)
 
-        num_shadows = len(found_shadows)
         # We need pairs to work with
+        num_shadows = len(found_shadows)
         if num_shadows < 2:
             return
+
         shadow_pairs: List[Tuple[LightEmitter, LightEmitter]] = []
         for i in range(0, num_shadows, 2):
             shadow_pairs.append((found_shadows[i], found_shadows[i + 1]))
@@ -170,7 +172,7 @@ class RunState:
             )
             delta_x = x - cur_shadow.emitted_light.light_pos_x
             delta_y = y - cur_shadow.emitted_light.light_pos_y
-            logger.info("deltas %.3f %.3f", delta_x, delta_y)
+            logger.debug("TP shadow deltas %.3f, %.3f", delta_x, delta_y)
 
             # We might want to make these different because:
             # 1) Uncertainty in Y axis is higher, due to ground/edges
@@ -178,7 +180,6 @@ class RunState:
             x_tol = 0.5
             y_tol = 0.5
             if abs(delta_x) < x_tol and abs(delta_y) < y_tol:
-                logger.info("TP detected!")
                 self.run_label.discard(Label.NO_TELEPORTER)
 
     def could_tp(self, player: Player, player_item_set: Set[EntityType]):

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -196,8 +196,8 @@ class RunState:
                 cur_delta_x - cur_delta_x_pred,
                 cur_delta_y - cur_delta_y_pred,
             ]
-            logger.info("diffs %s", diffs)
-            if all([abs(discrepency) < 0.5 for discrepency in diffs]):
+            logger.info("diffs %s", [f"{x:.3f}" for x in diffs])
+            if all(abs(discrepency) < 0.5 for discrepency in diffs):
                 logger.info("TP detected!")
                 self.run_label.discard(Label.NO_TELEPORTER)
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -117,7 +117,11 @@ class RunState:
             self.run_label.discard(Label.NO_GOLD)
 
     def update_no_tp(
-        self, game_state: State, player: Player, player_item_set: Set[EntityType]
+        self,
+        game_state: State,
+        player: Player,
+        player_item_set: Set[EntityType],
+        prev_player_item_set: Set[EntityType],
     ):
         prev_next_uid = self.prev_next_uid
         self.prev_next_uid = game_state.next_entity_uid
@@ -127,7 +131,7 @@ class RunState:
             return
 
         # This is an optimization to skip scanning when the player couldn't have teleported
-        if not self.could_tp(player, player_item_set):
+        if not self.could_tp(player, player_item_set, prev_player_item_set):
             return
 
         found_shadows: List[LightEmitter] = []
@@ -182,8 +186,15 @@ class RunState:
             if abs(delta_x) < x_tol and abs(delta_y) < y_tol:
                 self.run_label.discard(Label.NO_TELEPORTER)
 
-    def could_tp(self, player: Player, player_item_set: Set[EntityType]):
+    def could_tp(
+        self,
+        player: Player,
+        player_item_set: Set[EntityType],
+        prev_player_item_set: Set[EntityType],
+    ):
         if not TELEPORT_ENTITIES.isdisjoint(player_item_set):
+            return True
+        if not TELEPORT_ENTITIES.isdisjoint(prev_player_item_set):
             return True
 
         if not player.overlay.present():
@@ -629,7 +640,9 @@ class RunState:
         # Check Modifiers
         self.update_pacifist(run_recap_flags)
         self.update_no_gold(run_recap_flags)
-        self.update_no_tp(game_state, player, self.player_item_types)
+        self.update_no_tp(
+            game_state, player, self.player_item_types, self.player_last_item_types
+        )
         self.update_eggplant()
         self.update_low_cosmic()
 

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -43,18 +43,32 @@ def test_run_recap(label, recap_flag, method):
 
 
 @pytest.mark.parametrize(
-    "item_set,expected_no_tp",
+    "item_set,expected_could_tp",
     [
-        ({EntityType.ITEM_TELEPORTER}, False),
-        ({EntityType.ITEM_POWERUP_COMPASS}, True),
-        (set(), True),
+        ({EntityType.ITEM_TELEPORTER}, True),
+        ({EntityType.ITEM_POWERUP_COMPASS}, False),
+        (set(), False),
     ],
 )
-def test_no_tp(item_set, expected_no_tp):
+def test_could_tp_items(item_set, expected_could_tp):
     run_state = RunState()
-    run_state.update_no_tp(item_set)
-    is_no_tp = Label.NO_TELEPORTER in run_state.run_label._set
-    assert is_no_tp == expected_no_tp
+    assert run_state.could_tp(Player(), item_set) == expected_could_tp
+
+
+@pytest.mark.parametrize(
+    "mount_type,expected_could_tp",
+    [
+        (EntityType.MOUNT_QILIN, False),
+        (EntityType.MOUNT_AXOLOTL, True),
+    ],
+)
+def test_could_tp_mount(mount_type, expected_could_tp):
+    mount = Mount(type=EntityDBEntry(id=mount_type))
+    poly_mount = PolyPointer(101, mount, MemContext())
+    player = Player(overlay=poly_mount)
+
+    run_state = RunState()
+    assert run_state.could_tp(player, set()) == expected_could_tp
 
 
 @pytest.mark.parametrize(

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -47,16 +47,18 @@ def test_run_recap(label, recap_flag, method):
 
 
 @pytest.mark.parametrize(
-    "item_set,expected_could_tp",
+    "item_set,prev_item_set,expected_could_tp",
     [
-        ({EntityType.ITEM_TELEPORTER}, True),
-        ({EntityType.ITEM_POWERUP_COMPASS}, False),
-        (set(), False),
+        ({EntityType.ITEM_TELEPORTER}, set(), True),
+        # Telepack may have exploded
+        (set(), {EntityType.ITEM_TELEPORTER_BACKPACK}, True),
+        ({EntityType.ITEM_POWERUP_COMPASS}, set(), False),
+        (set(), set(), False),
     ],
 )
-def test_could_tp_items(item_set, expected_could_tp):
+def test_could_tp_items(item_set, prev_item_set, expected_could_tp):
     run_state = RunState()
-    assert run_state.could_tp(Player(), item_set) == expected_could_tp
+    assert run_state.could_tp(Player(), item_set, prev_item_set) == expected_could_tp
 
 
 @pytest.mark.parametrize(
@@ -72,7 +74,7 @@ def test_could_tp_mount(mount_type, expected_could_tp):
     player = Player(overlay=poly_mount)
 
     run_state = RunState()
-    assert run_state.could_tp(player, set()) == expected_could_tp
+    assert run_state.could_tp(player, set(), set()) == expected_could_tp
 
 
 def test_compute_player_motion_wo_overlay():
@@ -197,10 +199,11 @@ def test_no_tp(
         velocity_y=player_vy,
     )
     item_set = {EntityType.ITEM_TELEPORTER_BACKPACK}
+    prev_item_set = set()
 
     run_state = RunState()
     run_state.prev_next_uid = 0
-    run_state.update_no_tp(game_state, player, item_set)
+    run_state.update_no_tp(game_state, player, item_set, prev_item_set)
 
     is_no_tp = Label.NO_TELEPORTER in run_state.run_label._set
     assert is_no_tp == expected_no_tp


### PR DESCRIPTION
This detects whether the player teleported using the TP "shadow" effects, and only discards No TP in that case.

This detection takes advantage of several details:

- We can use `next_entity_uid` to examine only new entities
- TP shadows are created in pairs: first the "source" shadow, then the "destination" shadow
- TP shadows have an `idle_counter`, like any Movable, which is 0 on the frame of teleporting
- Combined with the above, we can use the player's velocity to extrapolate their position

There are some complications

- The shadow is always grid-aligned. However, the light is at the player's position
- ... except if the player is on a mount. Then the mount's location is used
- on active floors like Neo-Bab elevators, position and velocity are relative to the floor

False positives require something to TP into the player's predicted hitbox. I've never seen one without a telefrag.  We can get false negatives if

- There's a large acceleration/deceleration
- The player TPs into a wall
- The player TP very close to CO borders (< 0.5 tiles)

Practically, the main way to get large deceleration is TPing just above a floor, or grabbing an edge. However, that needs to happen within the ~6 frames between polls **and** early in the poll cycle. If it's within a couple frames of the poll, they don't move far enough. We could mitigate this by polling more often, or increasing Y-axis tolerance; the max delta I've seen is 1 tile. OTOH, I can't imagine missing every TP in a real TP run.

The only large X-axis acceleration change I've thought of is being thrown/exploded. Those are uncommon and stun the player (i.e. they can't manually TP). I've done some testing with telepack and standing on a bomb. The detection usually works in that case.

For some context on the current tolerance tuninig... Max velocity is ~0.4 . Here's a friendly local crocman positioned 0.5 tiles above and 0.5 tiles to the right of the player.
![Screenshot 2021-08-16 17-40-19_cropped](https://user-images.githubusercontent.com/51870303/129637578-56d2498e-7ad6-4d53-a949-48c039a74dc8.png)
