### PR TITLE
Cleanup some pylint messages

### DIFF
--- a/src/modlunky2/api.py
+++ b/src/modlunky2/api.py
@@ -49,7 +49,7 @@ class SpelunkyFYIClient:
     def get_mod_file_from_details(details, mod_file_id=None):
         if not details["mod_files"]:
             logger.critical("Mod `%s` has no files to download.", details["slug"])
-            return
+            return None
 
         mod_files = details["mod_files"]
         if mod_file_id is None:

--- a/src/modlunky2/assets/assets.py
+++ b/src/modlunky2/assets/assets.py
@@ -90,7 +90,7 @@ class ExeAssetBlock:
         data_len, filepath_len = unpack(b"<II", exe_handle.read(8))
 
         if (data_len, filepath_len) == (0, 0):
-            return
+            return None
 
         if data_len <= 0:
             raise RuntimeError(f"Expected data length > 0, found {data_len}")
@@ -182,7 +182,7 @@ class ExeAsset:
 
             except Exception:  # pylint: disable=broad-except
                 logger.exception("Failed compression")
-                return None
+                return
 
         if self.filepath in KNOWN_TEXTURES_V1:
             self.data = rgba_to_png(self.data)

--- a/src/modlunky2/assets/assets.py
+++ b/src/modlunky2/assets/assets.py
@@ -21,8 +21,8 @@ from modlunky2.sprites.sprite_loaders import get_all_sprite_loaders
 from modlunky2.sprites.sprite_mergers import get_all_sprite_mergers
 from modlunky2.constants import BASE_DIR
 
-from .chacha import Key, chacha, hash_filepath
-from .constants import (
+from modlunky2.assets.chacha import Key, chacha, hash_filepath
+from modlunky2.assets.constants import (
     BANK_ALIGNMENT,
     DDS_PNGS,
     DEFAULT_COMPRESSION_LEVEL,
@@ -30,11 +30,11 @@ from .constants import (
     KNOWN_FILEPATHS,
     PNG_NAMES_TO_DDS_NAMES,
 )
-from .soundbank import extract_soundbank
-from .converters import dds_to_png, png_to_dds, rgba_to_png
-from .exc import FileConflict, MissingAsset, MultipleMatchingAssets
-from .string_hashing import StringHashes
-from .hashing import md5sum_path
+from modlunky2.assets.soundbank import extract_soundbank
+from modlunky2.assets.converters import dds_to_png, png_to_dds, rgba_to_png
+from modlunky2.assets.exc import FileConflict, MissingAsset, MultipleMatchingAssets
+from modlunky2.assets.string_hashing import StringHashes
+from modlunky2.assets.hashing import md5sum_path
 
 
 logger = logging.getLogger("modlunky2")

--- a/src/modlunky2/assets/chacha.py
+++ b/src/modlunky2/assets/chacha.py
@@ -87,7 +87,7 @@ def mix_in(h, s):
         assert len(partial) <= 0x40
         b = bytearray(h)
         for i, c in enumerate(partial[::-1]):
-            b[i] ^= ord("%c" % c)
+            b[i] ^= ord(f"{c:c}")
         return quad_rounds(bytes(b))
 
     while s != b"":

--- a/src/modlunky2/assets/packer.py
+++ b/src/modlunky2/assets/packer.py
@@ -4,10 +4,10 @@ import shutil
 import sys
 from pathlib import Path
 
-from .assets import AssetStore
-from .constants import DEFAULT_COMPRESSION_LEVEL, EXTRACTED_DIR
-from .exc import MissingAsset
-from .patcher import Patcher
+from modlunky2.assets.assets import AssetStore
+from modlunky2.assets.constants import DEFAULT_COMPRESSION_LEVEL, EXTRACTED_DIR
+from modlunky2.assets.exc import MissingAsset
+from modlunky2.assets.patcher import Patcher
 
 DEFAULT_MODS_DIR = "Mods"
 

--- a/src/modlunky2/assets/patcher.py
+++ b/src/modlunky2/assets/patcher.py
@@ -75,13 +75,11 @@ class Patcher:
                 "to be updated for the current game version."
             )
             logger.warning(
-                "(Expected 0x{:02x}, found 0x{:02x})".format(
-                    CHECKSUM_PATCH_END, ops[-1]
-                )
+                f"(Expected 0x{CHECKSUM_PATCH_END:02x}, found 0x{ops[-1]:02x})"
             )
             return False
 
-        logger.info("Found check at 0x{:08x}, replacing with NOPs".format(index))
+        logger.info(f"Found check at 0x{index:08x}, replacing with NOPs")
         self.exe_handle.seek(index)
         self.exe_handle.write(CHECKSUM_PATCH_REPLACE)
 

--- a/src/modlunky2/assets/patcher.py
+++ b/src/modlunky2/assets/patcher.py
@@ -82,6 +82,7 @@ class Patcher:
         logger.info(f"Found check at 0x{index:08x}, replacing with NOPs")
         self.exe_handle.seek(index)
         self.exe_handle.write(CHECKSUM_PATCH_REPLACE)
+        return True
 
     def patch_release(self):
         self.exe_handle.seek(0)
@@ -94,3 +95,4 @@ class Patcher:
 
         self.exe_handle.seek(index)
         self.exe_handle.write(RELEASE_AOB_REPLACE)
+        return True

--- a/src/modlunky2/assets/string_hashing.py
+++ b/src/modlunky2/assets/string_hashing.py
@@ -26,7 +26,7 @@ class StringHashes:
                 if current_comment_section is not None:
                     str_to_hash += current_comment_section
 
-                string_hash = "0x{:08x}".format(zlib.crc32(str_to_hash.encode()))
+                string_hash = f"0x{zlib.crc32(str_to_hash.encode()):08x}"
 
             hashes.append(string_hash)
 

--- a/src/modlunky2/cli.py
+++ b/src/modlunky2/cli.py
@@ -2,9 +2,9 @@ import argparse
 import logging
 from pathlib import Path
 
-from .ui import ModlunkyUI
-from .config import Config, make_user_dirs
-from .utils import tb_info
+from modlunky2.ui import ModlunkyUI
+from modlunky2.config import Config, make_user_dirs
+from modlunky2.utils import tb_info
 
 logger = logging.getLogger("modlunky2")
 

--- a/src/modlunky2/levels/level_chances.py
+++ b/src/modlunky2/levels/level_chances.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from collections import OrderedDict
 from typing import ClassVar, Optional, TextIO, Tuple, Union
 
-from .utils import (
+from modlunky2.levels.utils import (
     DirectivePrefixes,
     parse_chance_values,
     split_comment,

--- a/src/modlunky2/levels/level_file.py
+++ b/src/modlunky2/levels/level_file.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Optional
 from typing import TextIO
 
-from .level_chances import LevelChances, LevelChance
-from .level_settings import LevelSettings, LevelSetting
-from .level_templates import LevelTemplates, LevelTemplate
-from .monster_chances import MonsterChances, MonsterChance
-from .tile_codes import TileCodes, TileCode
-from .utils import DirectivePrefixes, Peekable, format_comment
+from modlunky2.levels.level_chances import LevelChances, LevelChance
+from modlunky2.levels.level_settings import LevelSettings, LevelSetting
+from modlunky2.levels.level_templates import LevelTemplates, LevelTemplate
+from modlunky2.levels.monster_chances import MonsterChances, MonsterChance
+from modlunky2.levels.tile_codes import TileCodes, TileCode
+from modlunky2.levels.utils import DirectivePrefixes, Peekable, format_comment
 
 SECTION_COMMENT = "// ------------------------------"
 

--- a/src/modlunky2/levels/level_settings.py
+++ b/src/modlunky2/levels/level_settings.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from collections import OrderedDict
 from typing import ClassVar, Generic, Optional, TextIO, TypeVar
 
-from .utils import DirectivePrefixes, split_comment, to_line, format_comment
+from modlunky2.levels.utils import (
+    DirectivePrefixes,
+    split_comment,
+    to_line,
+    format_comment,
+)
 
 T = TypeVar("T")  # pylint: disable=invalid-name
 

--- a/src/modlunky2/levels/level_templates.py
+++ b/src/modlunky2/levels/level_templates.py
@@ -7,7 +7,7 @@ from typing import ClassVar, List, Optional, TextIO, Tuple
 
 from modlunky2.levels.utils import split_comment, format_comment
 
-from .utils import DirectivePrefixes
+from modlunky2.levels.utils import DirectivePrefixes
 
 VALID_LEVEL_TEMPLATES = set(
     [

--- a/src/modlunky2/levels/monster_chances.py
+++ b/src/modlunky2/levels/monster_chances.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from collections import OrderedDict
 from typing import ClassVar, Optional, TextIO, Tuple, Union
 
-from .utils import (
+from modlunky2.levels.utils import (
     DirectivePrefixes,
     parse_chance_values,
     split_comment,

--- a/src/modlunky2/levels/tile_codes.py
+++ b/src/modlunky2/levels/tile_codes.py
@@ -3,7 +3,12 @@ from dataclasses import dataclass
 from collections import OrderedDict
 from typing import ClassVar, Optional, TextIO
 
-from .utils import DirectivePrefixes, split_comment, to_line, format_comment
+from modlunky2.levels.utils import (
+    DirectivePrefixes,
+    split_comment,
+    to_line,
+    format_comment,
+)
 
 VALID_TILE_CODES = set(
     [

--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -11,8 +11,8 @@ import win32api
 import win32con
 import win32process
 
-from .state import State
-from .memrauder.model import (
+from modlunky2.mem.state import State
+from modlunky2.mem.memrauder.model import (
     MemoryReader,
     MemContext,
 )

--- a/src/modlunky2/mem/__init__.py
+++ b/src/modlunky2/mem/__init__.py
@@ -61,7 +61,7 @@ def process_list():
         ctypes.sizeof(PROCESSENTRY32)
     )
     if Process32First(processes, ctypes.byref(pe32)) == win32con.FALSE:
-        return None
+        return
 
     while True:
         yield pe32
@@ -75,6 +75,7 @@ def find_spelunky2_pid() -> Optional[DWORD]:
     for proc in process_list():
         if proc.szExeFile == b"Spel2.exe":
             return proc.th32ProcessID
+    return None
 
 
 class _MEMORY_BASIC_INFORMATION64(ctypes.Structure):  # pylint: disable=invalid-name
@@ -145,7 +146,7 @@ class Spel2Process:
             win32con.PROCESS_QUERY_INFORMATION | win32con.PROCESS_VM_READ, False, pid
         )
         if not handle:
-            return
+            return None
 
         return cls(handle)
 
@@ -230,6 +231,7 @@ class Spel2Process:
 
             if module_filename.name == "Spel2.exe":
                 return module_handle
+        return None
 
     def get_offset_past_bundle(self):
         exe = self.get_spel2_module()

--- a/src/modlunky2/sprites/base_classes/base_biome.py
+++ b/src/modlunky2/sprites/base_classes/base_biome.py
@@ -92,6 +92,6 @@ class AbstractBiome(ABC):
         # early if we don't
         get_func = self._sheet_map.get(name)
         if get_func is None:
-            return
+            return None
         # this will either be the `get` method of the floor or deco sheet object
         return get_func(name)

--- a/src/modlunky2/sprites/base_classes/base_biome.py
+++ b/src/modlunky2/sprites/base_classes/base_biome.py
@@ -4,8 +4,8 @@ from typing import Dict, Optional, Type
 
 from PIL import Image
 
-from .base_deco_sheet import AbstractDecoSheet
-from .base_floor_sheet import AbstractFloorSheet
+from modlunky2.sprites.base_classes.base_deco_sheet import AbstractDecoSheet
+from modlunky2.sprites.base_classes.base_floor_sheet import AbstractFloorSheet
 
 DEFAULT_BASE_PATH = Path(
     r"C:\Program Files (x86)\Steam\steamapps\common\Spelunky 2\Mods\Extracted"

--- a/src/modlunky2/sprites/base_classes/base_deco_sheet.py
+++ b/src/modlunky2/sprites/base_classes/base_deco_sheet.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from .base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
 
 
 class AbstractDecoSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/base_classes/base_floor_sheet.py
+++ b/src/modlunky2/sprites/base_classes/base_floor_sheet.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from pathlib import Path
 
-from .base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
 
 
 class AbstractFloorSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/base_classes/base_floorstyled_sheet.py
+++ b/src/modlunky2/sprites/base_classes/base_floorstyled_sheet.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from pathlib import Path
 
-from .base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
 
 
 class AbstractFloorStyledSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/base_classes/base_json_sprite_loader.py
+++ b/src/modlunky2/sprites/base_classes/base_json_sprite_loader.py
@@ -1,8 +1,8 @@
 from abc import abstractmethod
 from typing import List
 
-from .base_sprite_loader import BaseSpriteLoader
-from ..util import chunks_from_json
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.util import chunks_from_json
 
 
 class BaseJsonSpriteLoader(BaseSpriteLoader):

--- a/src/modlunky2/sprites/base_classes/base_json_sprite_merger.py
+++ b/src/modlunky2/sprites/base_classes/base_json_sprite_merger.py
@@ -1,9 +1,9 @@
 from abc import abstractmethod
 from typing import List, Dict, Type
 
-from .base_sprite_loader import BaseSpriteLoader
-from .base_sprite_merger import BaseSpriteMerger
-from ..util import target_chunks_from_json
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.base_classes.base_sprite_merger import BaseSpriteMerger
+from modlunky2.sprites.util import target_chunks_from_json
 
 
 class BaseJsonSpriteMerger(BaseSpriteMerger):

--- a/src/modlunky2/sprites/base_classes/base_sprite_loader.py
+++ b/src/modlunky2/sprites/base_classes/base_sprite_loader.py
@@ -6,7 +6,7 @@ from threading import Lock
 
 from PIL import Image
 
-from .types import chunk_map_type
+from modlunky2.sprites.base_classes.types import chunk_map_type
 
 _DEFAULT_BASE_PATH = Path(
     r"C:\Program Files (x86)\Steam\steamapps\common\Spelunky 2\Mods\Extracted"

--- a/src/modlunky2/sprites/base_classes/base_sprite_loader.py
+++ b/src/modlunky2/sprites/base_classes/base_sprite_loader.py
@@ -86,6 +86,7 @@ class BaseSpriteLoader(ABC):
         coords = self._chunk_map.get(name)
         if coords:
             return self._get_block(*coords)
+        return None
 
     def key_map(self) -> Dict[str, Callable]:
         return {k: self.get for k in self._chunk_map}

--- a/src/modlunky2/sprites/base_classes/base_sprite_merger.py
+++ b/src/modlunky2/sprites/base_classes/base_sprite_merger.py
@@ -4,8 +4,11 @@ from typing import Dict, List, Type, Tuple
 from logging import getLogger
 from PIL import Image, ImageDraw, ImageFont
 
-from .types import image_crop_tuple_whole_number, chunk_map_type
-from .base_sprite_loader import BaseSpriteLoader
+from modlunky2.sprites.base_classes.types import (
+    image_crop_tuple_whole_number,
+    chunk_map_type,
+)
+from modlunky2.sprites.base_classes.base_sprite_loader import BaseSpriteLoader
 
 _DEFAULT_BASE_PATH = Path(
     r"C:\Program Files (x86)\Steam\steamapps\common\Spelunky 2\Mods\Extracted"

--- a/src/modlunky2/sprites/base_eggship2.py
+++ b/src/modlunky2/sprites/base_eggship2.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class EggShip2Sheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/biomes.py
+++ b/src/modlunky2/sprites/biomes.py
@@ -3,10 +3,10 @@ Biomes bring together the floor sheet, deco sheet, and background sprites for ea
 environment.
 """
 
-from .base_classes import AbstractBiome
-from .deco_sheet import *
-from .floor_sheet import *
-from .floorstyled_sheet import *
+from modlunky2.sprites.base_classes import AbstractBiome
+from modlunky2.sprites.deco_sheet import *
+from modlunky2.sprites.floor_sheet import *
+from modlunky2.sprites.floorstyled_sheet import *
 
 __all__ = [
     "SurfaceBiome",

--- a/src/modlunky2/sprites/character.py
+++ b/src/modlunky2/sprites/character.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
-from .util import chunks_from_animation
+from modlunky2.sprites.base_classes import BaseSpriteLoader
+from modlunky2.sprites.util import chunks_from_animation
 
 
 class CharacterSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/coffins.py
+++ b/src/modlunky2/sprites/coffins.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class CoffinSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/deco_extra.py
+++ b/src/modlunky2/sprites/deco_extra.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class DecoExtraSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/deco_sheet.py
+++ b/src/modlunky2/sprites/deco_sheet.py
@@ -1,4 +1,4 @@
-from .base_classes.base_deco_sheet import AbstractDecoSheet
+from modlunky2.sprites.base_classes.base_deco_sheet import AbstractDecoSheet
 
 __all__ = [
     "CaveDecoSheet",

--- a/src/modlunky2/sprites/floor_sheet.py
+++ b/src/modlunky2/sprites/floor_sheet.py
@@ -1,4 +1,4 @@
-from .base_classes import AbstractFloorSheet
+from modlunky2.sprites.base_classes import AbstractFloorSheet
 
 __all__ = [
     "CaveFloorSheet",

--- a/src/modlunky2/sprites/floormisc.py
+++ b/src/modlunky2/sprites/floormisc.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class FloorMiscSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/floorstyled_sheet.py
+++ b/src/modlunky2/sprites/floorstyled_sheet.py
@@ -1,4 +1,6 @@
-from .base_classes.base_floorstyled_sheet import AbstractFloorStyledSheet
+from modlunky2.sprites.base_classes.base_floorstyled_sheet import (
+    AbstractFloorStyledSheet,
+)
 
 __all__ = [
     "HiveStyledFloorSheet",

--- a/src/modlunky2/sprites/full_sheets/__init__.py
+++ b/src/modlunky2/sprites/full_sheets/__init__.py
@@ -1,4 +1,4 @@
-from .character import (
+from modlunky2.sprites.full_sheets.character import (
     CharacterBlackSpriteMerger,
     CharacterLimeSpriteMerger,
     CharacterMagentaSpriteMerger,
@@ -22,16 +22,20 @@ from .character import (
     CharacterEggChildSpriteMerger,
     CharacterHiredHandSpriteMerger,
 )
-from .mounts import (
+from modlunky2.sprites.full_sheets.mounts import (
     TurkeySpriteMerger,
     RockdogSpriteMerger,
     AxolotlSpriteMerger,
     QilinSpriteMerger,
 )
-from .pets import MontySpriteMerger, PercySpriteMerger, PoochiSpriteMerger
-from .ghost import *
-from .monsters.basic import *
-from .monsters.big import *
+from modlunky2.sprites.full_sheets.pets import (
+    MontySpriteMerger,
+    PercySpriteMerger,
+    PoochiSpriteMerger,
+)
+from modlunky2.sprites.full_sheets.ghost import *
+from modlunky2.sprites.full_sheets.monsters.basic import *
+from modlunky2.sprites.full_sheets.monsters.big import *
 
 __all__ = [
     "CharacterBlackSpriteMerger",

--- a/src/modlunky2/sprites/full_sheets/character.py
+++ b/src/modlunky2/sprites/full_sheets/character.py
@@ -10,14 +10,14 @@ from ..menu_leader import MenuLeaderSheet
 def _create_class_for_character(color: str, character_sheet_type: type):
     class CharacterSpriteMerger(BaseSpriteMerger):
         _target_sprite_sheet_path = Path(
-            "Data/Textures/Entities/char_{}_full.png".format(color)
+            f"Data/Textures/Entities/char_{color}_full.png"
         )
         _grid_hint_size = 8
         _origin_map = {
             character_sheet_type: character_sheet_type._chunk_map,
-            JournalPeopleSheet: {"journal_char_{}".format(color): (0, 0, 1, 1)},
-            StickerSheet: {"sticker_char_{}".format(color): (0, 0, 1, 1)},
-            MenuLeaderSheet: {"leader_char_{}".format(color): (0, 0, 2, 1)},
+            JournalPeopleSheet: {f"journal_char_{color}": (0, 0, 1, 1)},
+            StickerSheet: {f"sticker_char_{color}": (0, 0, 1, 1)},
+            MenuLeaderSheet: {f"leader_char_{color}": (0, 0, 2, 1)},
         }
 
     return CharacterSpriteMerger

--- a/src/modlunky2/sprites/full_sheets/ghost.py
+++ b/src/modlunky2/sprites/full_sheets/ghost.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-from ..base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
-from ..util import chunks_from_animation
-from ..monsters.ghost import Ghost
-from ..journal_people import JournalPeopleSheet
-from ..journal_mons_big import JournalBigMonsterSheet
+from modlunky2.sprites.base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
+from modlunky2.sprites.util import chunks_from_animation
+from modlunky2.sprites.monsters.ghost import Ghost
+from modlunky2.sprites.journal_people import JournalPeopleSheet
+from modlunky2.sprites.journal_mons_big import JournalBigMonsterSheet
 
 
 class GhistSpriteMerger(BaseJsonSpriteMerger):

--- a/src/modlunky2/sprites/full_sheets/mounts.py
+++ b/src/modlunky2/sprites/full_sheets/mounts.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
-from ..base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
-from ..monsters.mounts import Mounts
-from ..journal_mons import JournalMonsterSheet
-from ..journal_items import JournalItemSheet
-from ..items import ItemSheet
-from ..util import chunks_from_animation
+from modlunky2.sprites.base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
+from modlunky2.sprites.monsters.mounts import Mounts
+from modlunky2.sprites.journal_mons import JournalMonsterSheet
+from modlunky2.sprites.journal_items import JournalItemSheet
+from modlunky2.sprites.items import ItemSheet
+from modlunky2.sprites.util import chunks_from_animation
 
 
 class TurkeySpriteMerger(BaseJsonSpriteMerger):

--- a/src/modlunky2/sprites/full_sheets/pets.py
+++ b/src/modlunky2/sprites/full_sheets/pets.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from ..base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
-from ..monsters.pets import Pets
-from ..journal_mons import JournalMonsterSheet
-from ..menu_basic import MenuBasicSheet, PetHeadsSheet
+from modlunky2.sprites.base_classes.base_json_sprite_merger import BaseJsonSpriteMerger
+from modlunky2.sprites.monsters.pets import Pets
+from modlunky2.sprites.journal_mons import JournalMonsterSheet
+from modlunky2.sprites.menu_basic import MenuBasicSheet, PetHeadsSheet
 
 
 class MontySpriteMerger(BaseJsonSpriteMerger):

--- a/src/modlunky2/sprites/hud.py
+++ b/src/modlunky2/sprites/hud.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class HudSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/items.py
+++ b/src/modlunky2/sprites/items.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
-from .util import chunks_from_animation
+from modlunky2.sprites.base_classes import BaseSpriteLoader
+from modlunky2.sprites.util import chunks_from_animation
 
 
 class ItemSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_items.py
+++ b/src/modlunky2/sprites/journal_items.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalItemSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_mons.py
+++ b/src/modlunky2/sprites/journal_mons.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalMonsterSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_mons_big.py
+++ b/src/modlunky2/sprites/journal_mons_big.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalBigMonsterSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_people.py
+++ b/src/modlunky2/sprites/journal_people.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalPeopleSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_place.py
+++ b/src/modlunky2/sprites/journal_place.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalPlaceSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_stickers.py
+++ b/src/modlunky2/sprites/journal_stickers.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class StickerSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/journal_traps.py
+++ b/src/modlunky2/sprites/journal_traps.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class JournalTrapSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/menu_basic.py
+++ b/src/modlunky2/sprites/menu_basic.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class MenuBasicSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/menu_leader.py
+++ b/src/modlunky2/sprites/menu_leader.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 class MenuLeaderSheet(BaseSpriteLoader):

--- a/src/modlunky2/sprites/merger_factory.py
+++ b/src/modlunky2/sprites/merger_factory.py
@@ -20,7 +20,7 @@ def create_merger_factory_for_source_sheet(
     ):
         class SpriteMerger(BaseJsonSpriteMerger):
             _target_sprite_sheet_path = Path(
-                "Data/Textures/Entities/{}.png".format(target_file_name)
+                f"Data/Textures/Entities/{target_file_name}.png"
             )
             _grid_hint_size = 8
             _origin_map = {

--- a/src/modlunky2/sprites/sprite_fetcher.py
+++ b/src/modlunky2/sprites/sprite_fetcher.py
@@ -4,7 +4,7 @@ from modlunky2.constants import BASE_DIR
 
 from PIL import Image
 
-from .base_classes import (
+from modlunky2.sprites.base_classes import (
     AbstractBiome,
     BaseSpriteLoader,
     BaseJsonSpriteLoader,
@@ -22,7 +22,7 @@ class SpelunkySpriteFetcher:
         self._biome_map = {k: v.get for k, v in self._biome_dict.items()}
 
     def _init_biomes(self) -> Dict[str, AbstractBiome]:
-        from . import biomes
+        from modlunky2.sprites import biomes
 
         return {
             getattr(biomes, b).biome_name: getattr(biomes, b)(self.base_path)
@@ -30,14 +30,14 @@ class SpelunkySpriteFetcher:
         }
 
     def _make_non_biome_map(self) -> Tuple[List[BaseSpriteLoader], Dict[str, Callable]]:
-        from . import monsters
-        from .items import ItemSheet
-        from .coffins import CoffinSheet
-        from .deco_extra import DecoExtraSheet
-        from .base_eggship2 import EggShip2Sheet
-        from .hud import HudSheet
-        from .floormisc import FloorMiscSheet
-        from .tilecode_extras import TilecodeExtras
+        from modlunky2.sprites import monsters
+        from modlunky2.sprites.items import ItemSheet
+        from modlunky2.sprites.coffins import CoffinSheet
+        from modlunky2.sprites.deco_extra import DecoExtraSheet
+        from modlunky2.sprites.base_eggship2 import EggShip2Sheet
+        from modlunky2.sprites.hud import HudSheet
+        from modlunky2.sprites.floormisc import FloorMiscSheet
+        from modlunky2.sprites.tilecode_extras import TilecodeExtras
 
         # Gather all of the sheets in a list, these are the classes, not instances yet
         _sheets = [getattr(monsters, m) for m in monsters.__all__]

--- a/src/modlunky2/sprites/sprite_loaders.py
+++ b/src/modlunky2/sprites/sprite_loaders.py
@@ -2,23 +2,30 @@ from typing import Optional
 
 from modlunky2.constants import BASE_DIR
 
-from .items import ItemSheet
-from .coffins import CoffinSheet
-from .deco_extra import DecoExtraSheet
-from .base_eggship2 import EggShip2Sheet
-from .journal_stickers import StickerSheet
-from .journal_items import JournalItemSheet
-from .journal_people import JournalPeopleSheet
-from .journal_mons import JournalMonsterSheet
-from .journal_mons_big import JournalBigMonsterSheet
-from .journal_place import JournalPlaceSheet
-from .journal_traps import JournalTrapSheet
-from .character import *
-from .monsters.mounts import Mounts
-from .monsters.pets import Pets
-from .monsters.ghost import Ghost
-from .monsters.basic import Basic1, Basic2, Basic3, Monsters1, Monsters2, Monsters3
-from .monsters.big import (
+from modlunky2.sprites.items import ItemSheet
+from modlunky2.sprites.coffins import CoffinSheet
+from modlunky2.sprites.deco_extra import DecoExtraSheet
+from modlunky2.sprites.base_eggship2 import EggShip2Sheet
+from modlunky2.sprites.journal_stickers import StickerSheet
+from modlunky2.sprites.journal_items import JournalItemSheet
+from modlunky2.sprites.journal_people import JournalPeopleSheet
+from modlunky2.sprites.journal_mons import JournalMonsterSheet
+from modlunky2.sprites.journal_mons_big import JournalBigMonsterSheet
+from modlunky2.sprites.journal_place import JournalPlaceSheet
+from modlunky2.sprites.journal_traps import JournalTrapSheet
+from modlunky2.sprites.character import *
+from modlunky2.sprites.monsters.mounts import Mounts
+from modlunky2.sprites.monsters.pets import Pets
+from modlunky2.sprites.monsters.ghost import Ghost
+from modlunky2.sprites.monsters.basic import (
+    Basic1,
+    Basic2,
+    Basic3,
+    Monsters1,
+    Monsters2,
+    Monsters3,
+)
+from modlunky2.sprites.monsters.big import (
     Big1,
     Big2,
     Big3,
@@ -28,9 +35,9 @@ from .monsters.big import (
     OsirisAndAlienQueen,
     OlmecAndMech,
 )
-from .tilecode_extras import TilecodeExtras
-from .menu_leader import MenuLeaderSheet
-from .menu_basic import MenuBasicSheet, PetHeadsSheet
+from modlunky2.sprites.tilecode_extras import TilecodeExtras
+from modlunky2.sprites.menu_leader import MenuLeaderSheet
+from modlunky2.sprites.menu_basic import MenuBasicSheet, PetHeadsSheet
 
 
 def get_all_sprite_loaders(

--- a/src/modlunky2/sprites/sprite_mergers.py
+++ b/src/modlunky2/sprites/sprite_mergers.py
@@ -1,4 +1,4 @@
-from .full_sheets import *
+from modlunky2.sprites.full_sheets import *
 
 
 def get_all_sprite_mergers(entities_json: dict, textures_json: dict, base_path: str):

--- a/src/modlunky2/sprites/tilecode_extras.py
+++ b/src/modlunky2/sprites/tilecode_extras.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .base_classes import BaseSpriteLoader
+from modlunky2.sprites.base_classes import BaseSpriteLoader
 
 
 TILENAMES = [

--- a/src/modlunky2/sprites/util.py
+++ b/src/modlunky2/sprites/util.py
@@ -19,7 +19,7 @@ def chunks_from_animation(
             start_chunk[2] + i * chunk_width,
             start_chunk[3],
         )
-        chunks["{}_{}".format(base_name, off + i + 1)] = coords
+        chunks[f"{base_name}_{off + i + 1}"] = coords
 
     return chunks
 
@@ -62,7 +62,7 @@ def chunks_from_json(
                 for i in range(0, animation_data["count"]):
                     chunk_x = (first_chunk + i) % num_chunks_width
                     chunk_y = (first_chunk + i) // num_chunks_width
-                    chunks["{}_{}_{}".format(entity_name, animation_id, i)] = (
+                    chunks[f"{entity_name}_{animation_id}_{i}"] = (
                         offset_width + chunk_x * chunk_width_scaling,
                         offset_height + chunk_y * chunk_height_scaling,
                         offset_width + (chunk_x + 1) * chunk_width_scaling,

--- a/src/modlunky2/ui/__init__.py
+++ b/src/modlunky2/ui/__init__.py
@@ -12,22 +12,22 @@ from modlunky2.version import current_version, latest_version
 from modlunky2.config import Config, MIN_WIDTH, MIN_HEIGHT
 from modlunky2.utils import is_windows, tb_info, temp_chdir
 
-from .tasks import TaskManager, PING_INTERVAL
-from .settings import SettingsTab
-from .extract import ExtractTab
-from .levels import LevelsTab
-from .play import PlayTab
-from .overlunky import OverlunkyTab
-from .pack import PackTab
-from .widgets import ConsoleWindow
-from .install import InstallTab
-from .logs import QueueHandler, register_queue_handler
-from .error import ErrorTab
-from .websocket import WebSocketThread
-from .s99 import S99Tab
+from modlunky2.ui.tasks import TaskManager, PING_INTERVAL
+from modlunky2.ui.settings import SettingsTab
+from modlunky2.ui.extract import ExtractTab
+from modlunky2.ui.levels import LevelsTab
+from modlunky2.ui.play import PlayTab
+from modlunky2.ui.overlunky import OverlunkyTab
+from modlunky2.ui.pack import PackTab
+from modlunky2.ui.widgets import ConsoleWindow
+from modlunky2.ui.install import InstallTab
+from modlunky2.ui.logs import QueueHandler, register_queue_handler
+from modlunky2.ui.error import ErrorTab
+from modlunky2.ui.websocket import WebSocketThread
+from modlunky2.ui.s99 import S99Tab
 
 if is_windows():
-    from .trackers import TrackersTab
+    from modlunky2.ui.trackers import TrackersTab
 
 
 logger = logging.getLogger("modlunky2")

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -273,7 +273,7 @@ def download_contents(_call, url):
 
     except Exception:  # pylint: disable=broad-except
         logger.critical("Failed to download %s: %s", url, tb_info())
-        return
+        return None
 
     contents.seek(0)
     return contents

--- a/src/modlunky2/ui/levels.py
+++ b/src/modlunky2/ui/levels.py
@@ -1609,7 +1609,7 @@ class LevelsTab(Tab):
             file_count = len(files)
             logger.debug("This mod has %s backups.", file_count)
             list_of_files = os.listdir(backup_dir)
-            full_path = [backup_dir + "/{0}".format(x) for x in list_of_files]
+            full_path = [backup_dir + f"/{x}" for x in list_of_files]
             if len(list_of_files) >= 50:
                 logger.debug("Deleting oldest backup")
                 oldest_file = min(full_path, key=os.path.getctime)

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -11,17 +11,17 @@ from modlunky2.ui.widgets import (
 )
 from modlunky2.utils import is_patched
 
-from .constants import (
+from modlunky2.ui.play.constants import (
     PLAYLUNKY_DATA_DIR,
     PLAYLUNKY_EXE,
     PLAYLUNKY_VERSION_FILENAME,
 )
-from .controls import ControlsFrame
-from .filters import FiltersFrame
-from .load_order import LoadOrderFrame
-from .options import OptionsFrame
-from .packs import PacksFrame
-from .releases import VersionFrame, parse_download_url
+from modlunky2.ui.play.controls import ControlsFrame
+from modlunky2.ui.play.filters import FiltersFrame
+from modlunky2.ui.play.load_order import LoadOrderFrame
+from modlunky2.ui.play.options import OptionsFrame
+from modlunky2.ui.play.packs import PacksFrame
+from modlunky2.ui.play.releases import VersionFrame, parse_download_url
 
 logger = logging.getLogger("modlunky2")
 

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -10,8 +10,8 @@ from PIL import Image, ImageTk
 from modlunky2.config import Config
 from modlunky2.constants import BASE_DIR
 
-from .common import TrackerWindow, WatcherThread, CommonCommand
-from .runstate import RunState
+from modlunky2.ui.trackers.common import TrackerWindow, WatcherThread, CommonCommand
+from modlunky2.ui.trackers.runstate import RunState
 
 logger = logging.getLogger("modlunky2")
 

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -165,7 +165,7 @@ class TrackerWindow(tk.Toplevel):
     def dragwin(self, _event):
         x_coord = self.winfo_pointerx() - self._offsetx
         y_coord = self.winfo_pointery() - self._offsety
-        self.geometry("+{x}+{y}".format(x=x_coord, y=y_coord))
+        self.geometry(f"+{x_coord}+{y_coord}")
 
     def clickwin(self, event):
         self._offsetx = event.x

--- a/src/modlunky2/ui/trackers/options.py
+++ b/src/modlunky2/ui/trackers/options.py
@@ -6,8 +6,8 @@ from modlunky2.config import Config
 from modlunky2.ui.widgets import PopupWindow
 from modlunky2.utils import open_directory
 
-from .utils import get_text_color
-from .common import TRACKERS_DIR
+from modlunky2.ui.trackers.utils import get_text_color
+from modlunky2.ui.trackers.common import TRACKERS_DIR
 
 logger = logging.getLogger("modlunky2")
 

--- a/src/modlunky2/ui/widgets.py
+++ b/src/modlunky2/ui/widgets.py
@@ -295,12 +295,7 @@ class PopupWindow(ttk.Frame):
             map(int, re.split(r"[+x]", self.modlunky_config.config_file.geometry))
         )
 
-        self.win.geometry(
-            "+{}+{}".format(
-                main_geometry[2] + 400,
-                main_geometry[3] + 200,
-            )
-        )
+        self.win.geometry(f"+{main_geometry[2] + 400}+{main_geometry[3] + 200}")
         self.win.resizable(False, False)
 
         self.columnconfigure(0, weight=1)

--- a/src/modlunky2/utils.py
+++ b/src/modlunky2/utils.py
@@ -19,17 +19,6 @@ def is_patched(exe_filename):
         return Patcher(exe).is_checksum_patched()
 
 
-def log_exception(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("Unexpected failure")
-
-    return wrapper
-
-
 def tb_info():
     return "".join(traceback.format_exception(*sys.exc_info())).strip()
 


### PR DESCRIPTION
The conversion to f-strings was done automatically via [flynt](https://github.com/ikamensh/flynt). This was prompted by pylint 2.11 implementing `consider-using-f-string` as a 'convention' message.

`return` cleanup was manual. I believe there are no behavior changes. The common cases were:
* Using `return` without a value (i.e. implicit `None`) when some cases return a no`None` value
* Explicitly returning a value from a loop, and implicitly returning `None` if nothing was found
An odd case was `log_exception`. I think it would probably make sense to return `None` if there was a exception, but it's kind of weird and the function is unused.