### PR TITLE
Tracker updates for version 1.23x

### DIFF
--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -171,9 +171,9 @@ class EntityReduced:
     items: Optional[Tuple[int, ...]] = struct_field(
         0x18, vector(sc_uint32), default=None
     )
-    layer: int = struct_field(0x98, sc_uint8, default=Layer.FRONT)
     position_x: float = struct_field(0x40, sc_float, default=0.0)
     position_y: float = struct_field(0x44, sc_float, default=0.0)
+    layer: int = struct_field(0xA0, sc_uint8, default=Layer.FRONT)
 
 
 @dataclass(frozen=True)
@@ -185,18 +185,18 @@ class Entity(EntityReduced):
 
 @dataclass(frozen=True)
 class Movable(Entity):
-    idle_counter: int = struct_field(0xF8, sc_uint32, default=0)
-    velocity_x: float = struct_field(0x100, sc_float, default=0.0)
-    velocity_y: float = struct_field(0x104, sc_float, default=0.0)
-    holding_uid: int = struct_field(0x108, sc_int32, default=-1)
-    state: CharState = struct_field(0x10C, sc_uint8, default=CharState.STANDING)
-    last_state: CharState = struct_field(0x10D, sc_uint8, default=CharState.STANDING)
-    health: int = struct_field(0x10F, sc_int8, default=4)
+    idle_counter: int = struct_field(0x100, sc_uint32, default=0)
+    velocity_x: float = struct_field(0x108, sc_float, default=0.0)
+    velocity_y: float = struct_field(0x10C, sc_float, default=0.0)
+    holding_uid: int = struct_field(0x110, sc_int32, default=-1)
+    state: CharState = struct_field(0x114, sc_uint8, default=CharState.STANDING)
+    last_state: CharState = struct_field(0x115, sc_uint8, default=CharState.STANDING)
+    health: int = struct_field(0x117, sc_int8, default=4)
 
 
 @dataclass(frozen=True)
 class Mount(Movable):
-    is_tamed: bool = struct_field(0x149, sc_bool, default=False)
+    is_tamed: bool = struct_field(0x151, sc_bool, default=False)
 
 
 @dataclass(frozen=True)
@@ -215,10 +215,10 @@ class Inventory:
 @dataclass(frozen=True)
 class Player(Movable):
     inventory: Optional[Inventory] = struct_field(
-        0x138, pointer(dc_struct), default_factory=Inventory
+        0x140, pointer(dc_struct), default_factory=Inventory
     )
-    linked_companion_child: int = struct_field(0x148, sc_int32, default=0)
-    linked_companion_parent: int = struct_field(0x14C, sc_int32, default=0)
+    linked_companion_child: int = struct_field(0x150, sc_int32, default=0)
+    linked_companion_parent: int = struct_field(0x154, sc_int32, default=0)
 
 
 @dataclass(frozen=True)
@@ -230,5 +230,5 @@ class Illumination:
 @dataclass(frozen=True)
 class LightEmitter(Movable):
     emitted_light: Optional[Illumination] = struct_field(
-        0x128, pointer(dc_struct), default=None
+        0x130, pointer(dc_struct), default=None
     )

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -171,6 +171,7 @@ class EntityReduced:
     items: Optional[Tuple[int, ...]] = struct_field(
         0x18, vector(sc_uint32), default=None
     )
+    # TODO: Consider using abs_x and abs_y
     position_x: float = struct_field(0x40, sc_float, default=0.0)
     position_y: float = struct_field(0x44, sc_float, default=0.0)
     layer: int = struct_field(0xA0, sc_uint8, default=Layer.FRONT)

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -171,7 +171,6 @@ class EntityReduced:
     items: Optional[Tuple[int, ...]] = struct_field(
         0x18, vector(sc_uint32), default=None
     )
-    # TODO: Consider using abs_x and abs_y
     position_x: float = struct_field(0x40, sc_float, default=0.0)
     position_y: float = struct_field(0x44, sc_float, default=0.0)
     layer: int = struct_field(0xA0, sc_uint8, default=Layer.FRONT)

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -17,7 +17,7 @@ from typing import (
 )
 import typing
 
-# Abstract memory-reader interface, used if pointers are derefrenced.
+# Abstract memory-reader interface, used if pointers are dereferenced.
 class MemoryReader(ABC):
     @abstractmethod
     def read(self, addr: int, size: int) -> Optional[bytes]:
@@ -229,7 +229,7 @@ class StructFieldMeta:
     @classmethod
     def from_field(cls, field: dataclasses.Field) -> StructFieldMeta:
         if cls._METADATA_KEY not in field.metadata:
-            raise ValueError(f"field {field.name} has no stuct_field() metadata")
+            raise ValueError(f"field {field.name} has no struct_field() metadata")
         return field.metadata[cls._METADATA_KEY]
 
 

--- a/src/modlunky2/mem/memrauder/msvc.py
+++ b/src/modlunky2/mem/memrauder/msvc.py
@@ -2,8 +2,7 @@ import ctypes
 import dataclasses
 from dataclasses import InitVar, dataclass
 import math
-from types import MappingProxyType
-from typing import ClassVar, Dict, Generic, Mapping, Optional, Tuple, TypeVar
+from typing import ClassVar, Generic, Optional, Tuple, TypeVar
 
 import fnvhash
 
@@ -226,25 +225,6 @@ class UnorderedMap(Generic[K, V]):
     def _hash_key(self, key) -> int:
         bytes_ = self.key_mem_type.to_bytes(key)
         return fnvhash.fnv1a_64(bytes_)
-
-
-@dataclass(frozen=True)
-class DictUnorderedMap((Generic[K, V])):
-    a_dict: InitVar[Dict[K, V]] = None
-    mapping: Mapping[K, V] = dataclasses.field(init=False)
-
-    def __post_init__(self, a_dict=None):
-        if a_dict is None:
-            a_dict = {}
-
-        mapping = MappingProxyType(dict(a_dict.items()))
-        object.__setattr__(self, "mapping", mapping)
-
-    def get(self, key: K) -> Optional[V]:
-        if key not in self.mapping:
-            return None
-
-        return self.mapping[key]
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/mem/memrauder/spelunky2.py
+++ b/src/modlunky2/mem/memrauder/spelunky2.py
@@ -1,0 +1,170 @@
+from dataclasses import InitVar, dataclass
+import dataclasses
+import logging
+from typing import ClassVar, Optional
+
+from modlunky2.mem.entities import Entity
+from modlunky2.mem.memrauder.model import (
+    DataclassStruct,
+    FieldPath,
+    MemContext,
+    MemType,
+    PolyPointer,
+    PolyPointerType,
+)
+from modlunky2.mem.memrauder.dsl import (
+    dc_struct,
+    struct_field,
+    sc_uint32,
+    sc_void_p,
+    sc_uint64,
+)
+
+logger = logging.getLogger("modlunky2")
+
+
+@dataclass(frozen=True)
+class _RobinHoodTableMeta:
+    mask: int = struct_field(0x0, sc_uint64)
+    table_ptr: int = struct_field(0x8, sc_void_p)
+
+
+@dataclass(frozen=True)
+class _RobinHoodTableEntry:
+    uid_plus1: int = struct_field(0x0, sc_uint32)
+    # We intentionally don't use PolyPointer, to defer reading the Entity until
+    # we know we have the right entry.
+    entity_addr: int = struct_field(0x8, sc_void_p)
+
+    SIZE: ClassVar[int] = 16
+
+
+@dataclass(frozen=True)
+class UidEntityMap:
+    meta: _RobinHoodTableMeta
+    table_entry_mem_type: MemType[_RobinHoodTableEntry]
+    mem_ctx: MemContext
+
+    empty_poly: PolyPointer[Entity] = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        if self.meta.mask < 1:
+            raise ValueError(f"invalid mask value {self.meta.mask}")
+
+        empty_poly = PolyPointer.make_empty(self.mem_ctx)
+
+        object.__setattr__(self, "empty_poly", empty_poly)
+
+    def _get_table_entry(self, index: int) -> Optional[_RobinHoodTableEntry]:
+        entry_size = _RobinHoodTableEntry.SIZE
+
+        entry_addr = self.meta.table_ptr + index * entry_size
+        entry_buf = self.mem_ctx.mem_reader.read(entry_addr, entry_size)
+        if entry_buf is None:
+            return None
+
+        try:
+            return self.table_entry_mem_type.from_bytes(entry_buf, self.mem_ctx)
+        except Exception as err:
+            raise ValueError(
+                f"failed to get table index {index} at {entry_addr:x}"
+            ) from err
+
+    def _get_addr_fast(self, uid):
+        target_uid_plus1 = uid + 1
+
+        cur_index = target_uid_plus1 & self.meta.mask
+        while True:
+            entry = self._get_table_entry(cur_index)
+            if entry is None:
+                # Reading the bytes for the entry failed.
+                return 0
+
+            if entry.uid_plus1 == target_uid_plus1:
+                return entry.entity_addr
+
+            if entry.uid_plus1 == 0:
+                # We found an 'empty' entry before our target. It must not exist.
+                return 0
+
+            mask = self.meta.mask
+            if (target_uid_plus1 & mask) > (entry.uid_plus1 & mask):
+                # We've found an entry that, if our entry existed, would be further away than our target
+                return 0
+
+            cur_index = (cur_index + 1) & self.meta.mask
+        # The above loop only terminates via return
+
+    def _get_addr_slow(self, uid):
+        target_uid_plus1 = uid + 1
+        for index in range(0, self.meta.mask + 1):
+            entry = self._get_table_entry(index)
+            if entry is None:
+                # Reading the bytes for the entry failed.
+                return 0
+
+            if entry.uid_plus1 == target_uid_plus1:
+                return entry.entity_addr
+
+        return 0
+
+    def get(self, uid: int) -> PolyPointer[Entity]:
+        if self.meta.table_ptr == 0:
+            return self.empty_poly
+
+        addr_fast = self._get_addr_fast(uid)
+        addr_slow = self._get_addr_slow(uid)
+        if addr_fast != addr_slow:
+            logger.warning(
+                "Entity lookup mismatch! ID %d Fast %x Slow %x",
+                uid,
+                addr_fast,
+                addr_slow,
+            )
+
+        if addr_slow == 0:
+            return self.empty_poly
+
+        entity = self.mem_ctx.type_at_addr(Entity, addr_slow)
+        if entity is None:
+            return self.empty_poly
+
+        return PolyPointer(addr_slow, entity, self.mem_ctx)
+
+
+@dataclass(frozen=True)
+class UidEntityMapType(MemType[UidEntityMap]):
+    path: InitVar[FieldPath]
+    py_type: InitVar[type]
+
+    meta_mem_type: MemType[_RobinHoodTableMeta] = dataclasses.field(init=False)
+    table_entry_mem_type: MemType[_RobinHoodTableEntry] = dataclasses.field(init=False)
+
+    def __post_init__(self, path, py_type):
+        if py_type is not UidEntityMap:
+            raise ValueError(f"field {path} must be UnorderedMap, got {py_type}")
+
+        meta_mem_type = DataclassStruct(path, _RobinHoodTableMeta)
+        poly_entity_mem_type = PolyPointerType(path, PolyPointer[Entity], dc_struct)
+        table_entry_mem_type = DataclassStruct(path, _RobinHoodTableEntry)
+
+        object.__setattr__(self, "meta_mem_type", meta_mem_type)
+        object.__setattr__(self, "poly_entity_mem_type", poly_entity_mem_type)
+        object.__setattr__(self, "table_entry_mem_type", table_entry_mem_type)
+
+    def field_size(self) -> int:
+        return self.meta_mem_type.field_size()
+
+    def element_size(self) -> int:
+        return self.meta_mem_type.element_size()
+
+    def from_bytes(self, buf: bytes, mem_ctx: MemContext) -> UidEntityMap:
+        meta = self.meta_mem_type.from_bytes(buf, mem_ctx)
+        try:
+            return UidEntityMap(meta, self.table_entry_mem_type, mem_ctx)
+        except Exception as err:
+            raise ValueError("failed to construct map for field {self.path}") from err
+
+
+def uid_entity_map(path: FieldPath, py_type: type):
+    return UidEntityMapType(path, py_type)

--- a/src/modlunky2/mem/memrauder/spelunky2.py
+++ b/src/modlunky2/mem/memrauder/spelunky2.py
@@ -96,43 +96,6 @@ class UidEntityMap:
             cur_index = (cur_index + 1) & self.meta.mask
         # The above loop only terminates via return
 
-    def check_lookup(self):
-        checked_count = 0
-        non_empty_count = 0
-        requires_probe_count = 0
-        mismatch_count = 0
-        for index in range(0, self.meta.mask + 1):
-            entry = self._get_table_entry(index)
-            if entry is None:
-                # Reading the bytes for the entry failed.
-                continue
-            checked_count += 1
-
-            if entry.uid_plus1 == 0:
-                continue
-            non_empty_count += 1
-
-            if entry.uid_plus1 == index:
-                # _get_addr() isn't worth exercising
-                continue
-            requires_probe_count += 1
-
-            get_addr_result = self._get_addr(entry.uid_plus1 - 1)
-            if entry.entity_addr == get_addr_result:
-                continue
-            mismatch_count += 1
-            logger.warning("Mismatch for index %d (uid %d). Expected %X, got %X")
-
-        # Make status more prominent if we exercised non-trivial cases
-        if requires_probe_count:
-            logger.info(
-                "Checked uid-entity mapping: Checked %d, Non-empty %d, Requires probe %d, Mismatch %d",
-                checked_count,
-                non_empty_count,
-                requires_probe_count,
-                mismatch_count,
-            )
-
     def get(self, uid: int) -> PolyPointer[Entity]:
         if self.meta.table_ptr == 0:
             return self.empty_poly

--- a/src/modlunky2/mem/memrauder/spelunky2.py
+++ b/src/modlunky2/mem/memrauder/spelunky2.py
@@ -101,7 +101,7 @@ class UidEntityMap:
             entry = self._get_table_entry(index)
             if entry is None:
                 # Reading the bytes for the entry failed.
-                return 0
+                continue
 
             if entry.uid_plus1 == target_uid_plus1:
                 return entry.entity_addr

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -170,14 +170,14 @@ class State:
     waddler_storage: FrozenSet[EntityType] = struct_field(
         0x8C, array(sc_uint32, 99), default=frozenset()
     )
-    run_recap_flags: RunRecapFlags = struct_field(0x9F4, sc_uint32, default=0)
-    hud_flags: HudFlags = struct_field(0xA10, sc_uint32, default=0)
-    time_level: int = struct_field(0xA04, sc_uint32, default=0)
-    presence_flags: PresenceFlags = struct_field(0xA14, sc_uint32, default=0)
-    next_entity_uid: int = struct_field(0x12A0, sc_uint32, default=0)
-    items: Optional[Items] = struct_field(0x12B0, pointer(dc_struct), default=None)
+    run_recap_flags: RunRecapFlags = struct_field(0xA34, sc_uint32, default=0)
+    hud_flags: HudFlags = struct_field(0xA50, sc_uint32, default=0)
+    time_level: int = struct_field(0xA44, sc_uint32, default=0)
+    presence_flags: PresenceFlags = struct_field(0xA54, sc_uint32, default=0)
+    next_entity_uid: int = struct_field(0x12E0, sc_uint32, default=0)
+    items: Optional[Items] = struct_field(0x12F0, pointer(dc_struct), default=None)
     instance_id_to_pointer: UnorderedMap[int, PolyPointer[Entity]] = struct_field(
-        0x1308,
+        0x1348,
         unordered_map(sc_uint32, poly_pointer(dc_struct)),
         default_factory=DictUnorderedMap,
     )

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -2,12 +2,11 @@ from dataclasses import dataclass
 import enum
 from typing import FrozenSet, Optional, Tuple
 
-from modlunky2.mem.entities import Entity, EntityType, Player
+from modlunky2.mem.entities import EntityType, Player
 
 from modlunky2.mem.memrauder.dsl import (
     array,
     pointer,
-    poly_pointer,
     struct_field,
     dc_struct,
     sc_int32,
@@ -15,8 +14,8 @@ from modlunky2.mem.memrauder.dsl import (
     sc_int8,
     sc_uint8,
 )
-from modlunky2.mem.memrauder.model import PolyPointer
-from modlunky2.mem.memrauder.msvc import DictUnorderedMap, UnorderedMap, unordered_map
+from modlunky2.mem.memrauder.msvc import DictUnorderedMap
+from modlunky2.mem.memrauder.spelunky2 import UidEntityMap, uid_entity_map
 
 
 class RunRecapFlags(enum.IntFlag):
@@ -176,8 +175,6 @@ class State:
     presence_flags: PresenceFlags = struct_field(0xA54, sc_uint32, default=0)
     next_entity_uid: int = struct_field(0x12E0, sc_uint32, default=0)
     items: Optional[Items] = struct_field(0x12F0, pointer(dc_struct), default=None)
-    instance_id_to_pointer: UnorderedMap[int, PolyPointer[Entity]] = struct_field(
-        0x1348,
-        unordered_map(sc_uint32, poly_pointer(dc_struct)),
-        default_factory=DictUnorderedMap,
+    instance_id_to_pointer: UidEntityMap = struct_field(
+        0x1348, uid_entity_map, default_factory=DictUnorderedMap
     )

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -14,7 +14,7 @@ from modlunky2.mem.memrauder.dsl import (
     sc_int8,
     sc_uint8,
 )
-from modlunky2.mem.memrauder.msvc import DictUnorderedMap
+from modlunky2.mem.memrauder.model import DictMap
 from modlunky2.mem.memrauder.spelunky2 import UidEntityMap, uid_entity_map
 
 
@@ -176,5 +176,5 @@ class State:
     next_entity_uid: int = struct_field(0x12E0, sc_uint32, default=0)
     items: Optional[Items] = struct_field(0x12F0, pointer(dc_struct), default=None)
     instance_id_to_pointer: UidEntityMap = struct_field(
-        0x1348, uid_entity_map, default_factory=DictUnorderedMap
+        0x1348, uid_entity_map, default_factory=DictMap
     )

--- a/src/modlunky2/mem/testing.py
+++ b/src/modlunky2/mem/testing.py
@@ -3,8 +3,7 @@ import dataclasses
 from typing import ClassVar, Dict, Iterable, Tuple
 
 from modlunky2.mem.entities import Entity, EntityDBEntry, EntityType
-from modlunky2.mem.memrauder.model import MemContext, PolyPointer
-from modlunky2.mem.memrauder.msvc import DictUnorderedMap
+from modlunky2.mem.memrauder.model import DictMap, MemContext, PolyPointer
 
 
 @dataclass
@@ -39,4 +38,4 @@ class EntityMapBuilder:
         return item_uid
 
     def build(self):
-        return DictUnorderedMap(self.entity_map)
+        return DictMap(self.entity_map)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -632,6 +632,10 @@ class RunState:
         if player.inventory is None:
             return
 
+        check_mapping_frames_interval = 120
+        if (game_state.time_total % check_mapping_frames_interval) == 0:
+            game_state.instance_id_to_pointer.check_lookup()
+
         run_recap_flags = game_state.run_recap_flags
         hud_flags = game_state.hud_flags
         presence_flags = game_state.presence_flags

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -632,10 +632,6 @@ class RunState:
         if player.inventory is None:
             return
 
-        check_mapping_frames_interval = 120
-        if (game_state.time_total % check_mapping_frames_interval) == 0:
-            game_state.instance_id_to_pointer.check_lookup()
-
         run_recap_flags = game_state.run_recap_flags
         hud_flags = game_state.hud_flags
         presence_flags = game_state.presence_flags


### PR DESCRIPTION
As far as I know, there are two things preventing this from being releasable
* Updating entity type IDs
* More thoroughly testing entity lookup

For entity lookup testing, I currently have it both do the lookup the hash way, and also a full table scan. Mismatches are logged. My other ideas are:
* Check if we actually probe multiple entries in the hash version
* Do a full scan and do the fast lookup for every entry