### PR TITLE
Add the new coffin_frog room's size to the list of room sizes.

### DIFF
--- a/src/modlunky2/ui/levels.py
+++ b/src/modlunky2/ui/levels.py
@@ -4111,6 +4111,7 @@ ROOM_TYPES = {
         RoomType("machine_wideroom", 20, 8),
         RoomType("machine_tallroom", 10, 16),
         RoomType("machine_bigroom", 20, 16),
+        RoomType("coffin_frog", 10, 16),
         RoomType("ghistroom", 5, 5),
         RoomType("feeling", 20, 16),
         RoomType("chunk_ground", 5, 3),


### PR DESCRIPTION
This makes sure new rooms created in the template are created with the correct size.