### PR TITLE
Move from unmaintained appdirs to platformdirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pillow==8.4.0
-appdirs==1.4.4
+platformdirs==2.4.0
 fnvhash==0.1.0
 packaging==21.0
 pyperclip==1.8.2

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from shutil import copyfile
 from urllib.parse import urlparse, urlunparse
 
-from appdirs import user_config_dir, user_data_dir, user_cache_dir
+from platformdirs import user_config_dir, user_data_dir, user_cache_dir
 
 PROGRAMS_KEY = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
 DEFAULT_PATH = Path("C:/Program Files (x86)/Steam/steamapps/common/Spelunky 2")


### PR DESCRIPTION
Note: there's an undocumented change in behavior on macOS: `user_config_dir()` returns a path under `Library/Preferences` instead of `Library/Application Support`.

I noticed this fork via `black`'s changelog.