### PR TITLE
Preserve save files when updating a mod through the Modlunky UI

### DIFF
--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -371,9 +371,16 @@ def install_fyi_mod(
     mods_dir = install_dir / "Mods"
     packs_dir = mods_dir / "Packs"
     metadata_dir = mods_dir / ".ml/pack-metadata"
-
+    print("here installing: " + install_code)
     pack_dir = packs_dir / f"fyi.{install_code}"
+    tmp_dir = packs_dir / f"temp_fyi.{install_code}"
+
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    save_path = pack_dir / "save.dat"
+    tmp_save_path = tmp_dir / "save.dat"
     if pack_dir.exists():
+        if save_path.exists():
+            shutil.copy(save_path, tmp_save_path)
         if overwrite:
             logger.debug("Removing previous installation at %s", pack_dir)
             shutil.rmtree(pack_dir)
@@ -419,6 +426,10 @@ def install_fyi_mod(
         logo_name = download_logo(call, logo_url, pack_metadata_dir)
 
     write_manifest(pack_metadata_dir, mod_details, mod_file, logo_name)
+
+    if tmp_save_path.exists():
+        shutil.copy(tmp_save_path, save_path)
+        shutil.rmtree(tmp_dir)
 
     logger.info("Finished installing %s to %s", install_code, pack_dir)
     if channel_name is not None:

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -374,11 +374,12 @@ def install_fyi_mod(
     pack_dir = packs_dir / f"fyi.{install_code}"
     tmp_dir = packs_dir / f"temp_fyi.{install_code}"
 
-    tmp_dir.mkdir(parents=True, exist_ok=True)
     save_path = pack_dir / "save.dat"
     tmp_save_path = tmp_dir / "save.dat"
     if pack_dir.exists():
         if save_path.exists():
+            # Store the save file into a temp directory while downloading the new version.
+            tmp_dir.mkdir(parents=True, exist_ok=True)
             shutil.copy(save_path, tmp_save_path)
         if overwrite:
             logger.debug("Removing previous installation at %s", pack_dir)
@@ -427,6 +428,7 @@ def install_fyi_mod(
     write_manifest(pack_metadata_dir, mod_details, mod_file, logo_name)
 
     if tmp_save_path.exists():
+        # If there was a save file, move it into the new pack.
         shutil.copy(tmp_save_path, save_path)
         shutil.rmtree(tmp_dir)
 

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -371,7 +371,6 @@ def install_fyi_mod(
     mods_dir = install_dir / "Mods"
     packs_dir = mods_dir / "Packs"
     metadata_dir = mods_dir / ".ml/pack-metadata"
-    print("here installing: " + install_code)
     pack_dir = packs_dir / f"fyi.{install_code}"
     tmp_dir = packs_dir / f"temp_fyi.{install_code}"
 

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -371,6 +371,7 @@ def install_fyi_mod(
     mods_dir = install_dir / "Mods"
     packs_dir = mods_dir / "Packs"
     metadata_dir = mods_dir / ".ml/pack-metadata"
+
     pack_dir = packs_dir / f"fyi.{install_code}"
     tmp_dir = packs_dir / f"temp_fyi.{install_code}"
 


### PR DESCRIPTION
If the mod has a save.dat file, it will be copied to a temporary directory (named temp_fyi.{install_code}) and copied back into the pack directory after the new version of the pack has been downloaded.