### PR TITLE
Add support for No%  to cat tracker

### DIFF
--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -30,8 +30,8 @@ class Label(Enum):
     PACIFIST = LabelMetadata("Pacifist", start=True)
     CHAIN = LabelMetadata("Chain")
     LOW = LabelMetadata("Low", start=True, hide_early=False, percent_priority=3)
-    NO = LabelMetadata("No", start=True, hide_early=False, percent_priority=3)
     ICE_CAVES_SHORTCUT = LabelMetadata("Ice Caves Shortcut", percent_priority=0)
+    NO = LabelMetadata("No", start=True, hide_early=False, percent_priority=3)
     ANY = LabelMetadata(
         "Any", start=True, hide_early=False, percent_priority=2, terminus=True
     )

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -115,7 +115,7 @@ class RunState:
 
     def update_no_gold(self, run_recap_flags):
         if not bool(run_recap_flags & RunRecapFlags.NO_GOLD):
-            self.run_label.discard(Label.NO_GOLD)
+            self.run_label.discard(Label.NO_GOLD, Label.NO)
 
     def update_no_tp(
         self,
@@ -327,6 +327,8 @@ class RunState:
         health = player.health
         if (health > self.health and player.state != CharState.DYING) or health > 4:
             self.fail_low()
+        if health < 4:
+            self.run_label.discard(Label.NO)
         self.health = health
 
         bombs = player.inventory.bombs
@@ -607,8 +609,7 @@ class RunState:
 
     def fail_low(self):
         self.is_low_percent = False
-        self.run_label.discard(Label.LOW)
-        self.run_label.discard(Label.ICE_CAVES_SHORTCUT)
+        self.run_label.discard(Label.LOW, Label.NO, Label.ICE_CAVES_SHORTCUT)
 
     def update_on_level_start(self, world: int, theme: Theme, ropes: int):
         if not self.level_started:

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -34,6 +34,7 @@ from modlunky2.ui.trackers.runstate import ChainStatus, PlayerMotion, RunState
     [
         (Label.PACIFIST, RunRecapFlags.PACIFIST, RunState.update_pacifist),
         (Label.NO_GOLD, RunRecapFlags.NO_GOLD, RunState.update_no_gold),
+        (Label.NO, RunRecapFlags.NO_GOLD, RunState.update_no_gold),
     ],
 )
 def test_run_recap(label, recap_flag, method):
@@ -306,18 +307,20 @@ def test_has_mounted_tame(chain_status, theme, mount_type, mount_tamed, expected
 
 
 @pytest.mark.parametrize(
-    "char_state,prev_health,cur_health,expected_low",
+    "char_state,prev_health,cur_health,expected_low,expected_no",
     [
-        (CharState.STANDING, 4, 4, True),
-        (CharState.STANDING, 2, 1, True),
-        (CharState.STANDING, 3, 1, True),
-        (CharState.DYING, 1, 4, True),
-        (CharState.STANDING, 1, 2, False),
-        (CharState.STANDING, 2, 4, False),
-        (CharState.STANDING, 5, 5, False),
+        (CharState.STANDING, 4, 4, True, True),
+        (CharState.STANDING, 2, 1, True, False),
+        (CharState.STANDING, 3, 1, True, False),
+        (CharState.DYING, 1, 4, True, True),
+        (CharState.STANDING, 1, 2, False, False),
+        (CharState.STANDING, 2, 4, False, False),
+        (CharState.STANDING, 5, 5, False, False),
     ],
 )
-def test_starting_resources_health(char_state, prev_health, cur_health, expected_low):
+def test_starting_resources_health_low(
+    char_state, prev_health, cur_health, expected_low, expected_no
+):
     run_state = RunState()
     run_state.health = prev_health
 
@@ -327,6 +330,9 @@ def test_starting_resources_health(char_state, prev_health, cur_health, expected
 
     is_low = Label.LOW in run_state.run_label._set
     assert is_low == expected_low
+
+    is_no = Label.NO in run_state.run_label._set
+    assert is_no == expected_no
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Notably, runs now start as either "No%" or (with early modifiers) "Pacifist No%" at 1-1. From Ice Caves, they now start as "Pacifist Ice Caves Shortcut No%"