### PR TITLE
Persist per-tracker configs and apply them immediately

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -129,6 +129,32 @@ def skip_default_field(default, metadata: Optional[Dict] = None, **kwargs):
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass
+class CategoryTrackerConfig:
+    always_show_modifiers: bool = skip_default_field(default=False)
+
+
+@serialize(rename_all="spinalcase")
+@deserialize(rename_all="spinalcase")
+@dataclass
+class PacifistTrackerConfig:
+    show_kill_count: bool = skip_default_field(default=False)
+
+
+@serialize(rename_all="spinalcase")
+@deserialize(rename_all="spinalcase")
+@dataclass
+class TrackersConfig:
+    category: CategoryTrackerConfig = dataclasses.field(
+        default_factory=CategoryTrackerConfig
+    )
+    pacifist: PacifistTrackerConfig = dataclasses.field(
+        default_factory=PacifistTrackerConfig
+    )
+
+
+@serialize(rename_all="spinalcase")
+@deserialize(rename_all="spinalcase")
+@dataclass
 class Config:
     config_path: Optional[Path] = dataclasses.field(
         default=None, metadata={"serde_skip": True}
@@ -159,6 +185,7 @@ class Config:
     )
     last_tab: Optional[str] = skip_default_field(default=None)
     tracker_color_key: str = skip_default_field(default=DEFAULT_COLOR_KEY)
+    trackers: TrackersConfig = dataclasses.field(default_factory=TrackersConfig)
     show_packing: bool = skip_default_field(default=False)
     level_editor_tab: Optional[int] = skip_default_field(default=None)
     custom_level_editor_custom_save_formats: Optional[List[Dict]] = skip_default_field(

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -6,7 +6,7 @@ import json
 import logging
 import shutil
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TypeVar
 
 try:
     import winreg
@@ -126,17 +126,26 @@ def skip_default_field(default, metadata: Optional[Dict] = None, **kwargs):
     return dataclasses.field(default=default, metadata=metadata, **kwargs)
 
 
+T = TypeVar("T")
+
+# Common config for all trackers. Currently a placeholder
+@dataclass
+class CommonTrackerConfig:
+    def clone(self: T) -> T:
+        return dataclasses.replace(self)
+
+
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass
-class CategoryTrackerConfig:
+class CategoryTrackerConfig(CommonTrackerConfig):
     always_show_modifiers: bool = skip_default_field(default=False)
 
 
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass
-class PacifistTrackerConfig:
+class PacifistTrackerConfig(CommonTrackerConfig):
     show_kill_count: bool = skip_default_field(default=False)
 
 

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -1,5 +1,4 @@
 import logging
-from logging import CRITICAL, WARNING
 import tkinter as tk
 from tkinter import ttk
 

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -64,6 +64,8 @@ class CategoryButtons(ttk.Frame):
             self.always_show_modifiers.get()
         )
         self.modlunky_config.save()
+        if self.window:
+            self.window.update_config(self.modlunky_config.trackers.category)
 
     def launch(self):
         color_key = self.modlunky_config.tracker_color_key
@@ -74,7 +76,7 @@ class CategoryButtons(ttk.Frame):
             on_close=self.window_closed,
             file_name="category.txt",
             tracker=CategoryTracker(),
-            config=self.modlunky_config.trackers.category.clone(),
+            config=self.modlunky_config.trackers.category,
         )
 
     def window_closed(self):

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -1,9 +1,7 @@
-from enum import Enum
 import logging
 from logging import CRITICAL, WARNING
 import tkinter as tk
 from tkinter import ttk
-from queue import Empty
 
 from PIL import Image, ImageTk
 
@@ -14,7 +12,7 @@ from modlunky2.mem import Spel2Process
 from modlunky2.ui.trackers.common import (
     Tracker,
     TrackerWindow,
-    WindowKey,
+    WindowData,
 )
 from modlunky2.ui.trackers.runstate import RunState
 
@@ -89,7 +87,7 @@ class CategoryButtons(ttk.Frame):
         self.category_button["state"] = tk.DISABLED
 
 
-class CategoryTracker(Tracker[CategoryTrackerConfig]):
+class CategoryTracker(Tracker[CategoryTrackerConfig, WindowData]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.proc = None
@@ -100,7 +98,7 @@ class CategoryTracker(Tracker[CategoryTrackerConfig]):
         self.time_total = 0
         self.run_state = RunState()
 
-    def poll(self, proc: Spel2Process, config: CategoryTrackerConfig):
+    def poll(self, proc: Spel2Process, config: CategoryTrackerConfig) -> WindowData:
         game_state = proc.get_state()
         if game_state is None:
             return None
@@ -115,4 +113,4 @@ class CategoryTracker(Tracker[CategoryTrackerConfig]):
         label = self.run_state.get_display(
             game_state.screen, config.always_show_modifiers
         )
-        return {WindowKey.DISPLAY_STRING: label}
+        return WindowData(label)

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -24,9 +24,9 @@ class Command(Enum):
 
 
 class CategoryButtons(ttk.Frame):
-    def __init__(self, parent, ml_config: Config, *args, **kwargs):
+    def __init__(self, parent, modlunky_config: Config, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
-        self.ml_config = ml_config
+        self.modlunky_config = modlunky_config
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, minsize=60)
 
@@ -44,20 +44,29 @@ class CategoryButtons(ttk.Frame):
         self.category_button.grid(row=0, column=0, pady=5, padx=5, sticky="nswe")
 
         self.always_show_modifiers = tk.BooleanVar()
-        self.always_show_modifiers.set(False)
+        self.always_show_modifiers.set(
+            modlunky_config.trackers.category.always_show_modifiers
+        )
         self.always_show_modifiers_checkbox = ttk.Checkbutton(
             self,
             text="Always Show Modifiers",
             variable=self.always_show_modifiers,
             onvalue=True,
             offvalue=False,
+            command=self.toggle_always_show_modifiers,
         )
         self.always_show_modifiers_checkbox.grid(
             row=0, column=1, pady=5, padx=5, sticky="nw"
         )
 
+    def toggle_always_show_modifiers(self):
+        self.modlunky_config.trackers.category.always_show_modifiers = (
+            self.always_show_modifiers.get()
+        )
+        self.modlunky_config.save()
+
     def launch(self):
-        color_key = self.ml_config.tracker_color_key
+        color_key = self.modlunky_config.tracker_color_key
         self.disable_button()
         CategoryWindow(
             title="Category Tracker",

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -18,6 +18,7 @@ TRACKERS_DIR = DATA_DIR / "trackers"
 
 
 class CommonCommand(Enum):
+    CONFIG = "config"
     DIE = "die"
     WAIT = "wait"
 
@@ -26,10 +27,11 @@ class WatcherThread(threading.Thread):
     POLL_INTERVAL = 0.016
     ATTACH_INTERVAL = 1.0
 
-    def __init__(self, queue):
+    def __init__(self, recv_queue: Queue, send_queue: Queue):
         super().__init__()
         self.shut_down = False
-        self.queue: Queue = queue
+        self.recv_queue = recv_queue
+        self.send_queue = send_queue
 
         self.proc = None
 
@@ -61,7 +63,7 @@ class WatcherThread(threading.Thread):
         self.shut_down = True
 
     def send(self, command: CommonCommand, data):
-        self.queue.put({"command": command, "data": data})
+        self.send_queue.put({"command": command, "data": data})
 
     def die(self, message):
         self.send(CommonCommand.DIE, message)
@@ -123,7 +125,8 @@ class TrackerWindow(tk.Toplevel):
         super().__init__(*args, **kwargs)
         self.attributes("-topmost", "true")
         self.on_close = on_close
-        self.queue = Queue()
+        self.recv_queue = Queue()
+        self.send_queue = Queue()
         self.color_key = color_key
 
         self.icon_png = PhotoImage(file=BASE_DIR / "static/images/icon.png")

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -176,8 +176,8 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
         file_name: str,
         tracker: Tracker[ConfigType, WindowData],
         config: ConfigType,
+        color_key: str,
         *args,
-        color_key="#ff00ff",
         **kwargs,
     ):
         super().__init__(*args, **kwargs)

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -7,7 +7,7 @@ import time
 import tkinter as tk
 from queue import Empty, Queue
 from tkinter import PhotoImage
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from modlunky2.config import DATA_DIR, CommonTrackerConfig
 from modlunky2.constants import BASE_DIR
@@ -259,11 +259,6 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
         logger.log(level, "%s", message)
         self.destroy()
 
-    def destroy(self) -> None:
-        with self.text_file.open("w") as handle:
-            handle.write("Not running")
-        return super().destroy()
-
     def after_watcher_thread(self):
         schedule_again = True
         try:
@@ -302,4 +297,7 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
         if self.on_close:
             self.on_close()
 
-        super().destroy()
+        with self.text_file.open("w") as handle:
+            handle.write("Not running")
+
+        return super().destroy()

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -18,9 +18,9 @@ class Command(Enum):
 
 
 class PacifistButtons(ttk.Frame):
-    def __init__(self, parent, ml_config: Config, *args, **kwargs):
+    def __init__(self, parent, modlunky_config: Config, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
-        self.ml_config = ml_config
+        self.modlunky_config = modlunky_config
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, minsize=60)
 
@@ -32,18 +32,25 @@ class PacifistButtons(ttk.Frame):
         self.pacifist_button.grid(row=0, column=0, pady=5, padx=5, sticky="nswe")
 
         self.show_kill_count = tk.BooleanVar()
-        self.show_kill_count.set(False)
+        self.show_kill_count.set(self.modlunky_config.trackers.pacifist.show_kill_count)
         self.show_kill_count_checkbox = ttk.Checkbutton(
             self,
             text="Show Kill Count",
             variable=self.show_kill_count,
             onvalue=True,
             offvalue=False,
+            command=self.toggle_show_kill_count,
         )
         self.show_kill_count_checkbox.grid(row=0, column=1, pady=5, padx=5, sticky="nw")
 
+    def toggle_show_kill_count(self):
+        self.modlunky_config.trackers.pacifist.show_kill_count = (
+            self.show_kill_count.get()
+        )
+        self.modlunky_config.save()
+
     def launch(self):
-        color_key = self.ml_config.tracker_color_key
+        color_key = self.modlunky_config.tracker_color_key
         self.disable_button()
         PacifistWindow(
             title="Pacifist Tracker",

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -1,10 +1,8 @@
-import dataclasses
 from enum import Enum
 import logging
 from logging import CRITICAL, WARNING
 import tkinter as tk
 from tkinter import ttk
-from queue import Empty
 
 from modlunky2.config import Config, PacifistTrackerConfig
 from modlunky2.mem import Spel2Process
@@ -13,7 +11,7 @@ from modlunky2.mem.state import RunRecapFlags
 from modlunky2.ui.trackers.common import (
     Tracker,
     TrackerWindow,
-    WindowKey,
+    WindowData,
 )
 
 logger = logging.getLogger("modlunky2")
@@ -78,7 +76,7 @@ class PacifistButtons(ttk.Frame):
         self.pacifist_button["state"] = tk.DISABLED
 
 
-class PacifistTracker(Tracker[PacifistTrackerConfig]):
+class PacifistTracker(Tracker[PacifistTrackerConfig, WindowData]):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.kills_total = 0
@@ -86,7 +84,7 @@ class PacifistTracker(Tracker[PacifistTrackerConfig]):
     def initialize(self):
         self.kills_total = 0
 
-    def poll(self, proc: Spel2Process, config: PacifistTrackerConfig):
+    def poll(self, proc: Spel2Process, config: PacifistTrackerConfig) -> WindowData:
         game_state = proc.get_state()
         if game_state is None:
             return None
@@ -101,7 +99,7 @@ class PacifistTracker(Tracker[PacifistTrackerConfig]):
 
         is_pacifist = bool(run_recap_flags & RunRecapFlags.PACIFIST)
         label = self.get_text(is_pacifist, config)
-        return {WindowKey.DISPLAY_STRING: label}
+        return WindowData(label)
 
     def get_text(self, is_pacifist: bool, config: PacifistTrackerConfig):
         if is_pacifist:

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -1,3 +1,4 @@
+import dataclasses
 from enum import Enum
 import logging
 from logging import CRITICAL, WARNING
@@ -5,7 +6,7 @@ import tkinter as tk
 from tkinter import ttk
 from queue import Empty
 
-from modlunky2.config import Config
+from modlunky2.config import Config, PacifistTrackerConfig
 from modlunky2.mem import Spel2Process
 from modlunky2.mem.state import RunRecapFlags
 
@@ -63,7 +64,8 @@ class PacifistButtons(ttk.Frame):
             color_key=color_key,
             on_close=self.window_closed,
             file_name="pacifist.txt",
-            tracker=PacifistTracker(show_kill_count=self.show_kill_count.get()),
+            tracker=PacifistTracker(),
+            config=self.modlunky_config.trackers.pacifist.clone(),
         )
 
     def window_closed(self):
@@ -76,16 +78,15 @@ class PacifistButtons(ttk.Frame):
         self.pacifist_button["state"] = tk.DISABLED
 
 
-class PacifistTracker(Tracker):
-    def __init__(self, *args, show_kill_count, **kwargs):
+class PacifistTracker(Tracker[PacifistTrackerConfig]):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.show_kill_count = show_kill_count
         self.kills_total = 0
 
     def initialize(self):
         self.kills_total = 0
 
-    def poll(self, proc: Spel2Process):
+    def poll(self, proc: Spel2Process, config: PacifistTrackerConfig):
         game_state = proc.get_state()
         if game_state is None:
             return None
@@ -99,14 +100,14 @@ class PacifistTracker(Tracker):
             self.kills_total = player.inventory.kills_total
 
         is_pacifist = bool(run_recap_flags & RunRecapFlags.PACIFIST)
-        label = self.get_text(is_pacifist)
+        label = self.get_text(is_pacifist, config)
         return {WindowKey.DISPLAY_STRING: label}
 
-    def get_text(self, is_pacifist):
+    def get_text(self, is_pacifist: bool, config: PacifistTrackerConfig):
         if is_pacifist:
             return "Pacifist"
 
-        if self.show_kill_count:
+        if config.show_kill_count:
             return f"MURDERED {self.kills_total}!"
 
         return "MURDERER!"

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -17,10 +17,6 @@ from modlunky2.ui.trackers.common import (
 logger = logging.getLogger("modlunky2")
 
 
-class Command(Enum):
-    IS_PACIFIST = "is_pacifist"
-
-
 class PacifistButtons(ttk.Frame):
     def __init__(self, parent, modlunky_config: Config, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
@@ -53,6 +49,8 @@ class PacifistButtons(ttk.Frame):
             self.show_kill_count.get()
         )
         self.modlunky_config.save()
+        if self.window:
+            self.window.update_config(self.modlunky_config.trackers.pacifist)
 
     def launch(self):
         color_key = self.modlunky_config.tracker_color_key
@@ -63,7 +61,7 @@ class PacifistButtons(ttk.Frame):
             on_close=self.window_closed,
             file_name="pacifist.txt",
             tracker=PacifistTracker(),
-            config=self.modlunky_config.trackers.pacifist.clone(),
+            config=self.modlunky_config.trackers.pacifist,
         )
 
     def window_closed(self):

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -1,6 +1,4 @@
-from enum import Enum
 import logging
-from logging import CRITICAL, WARNING
 import tkinter as tk
 from tkinter import ttk
 

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -785,6 +785,5 @@ class RunState:
         return False
 
     def get_display(self, screen: Screen, always_show_modifiers: bool):
-        return self.run_label.text(
-            not self.should_show_modifiers(screen, always_show_modifiers)
-        )
+        hide_early = not self.should_show_modifiers(screen, always_show_modifiers)
+        return self.run_label.text(hide_early)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -57,8 +57,7 @@ class PlayerMotion:
 
 
 class RunState:
-    def __init__(self, always_show_modifiers=False):
-        self.always_show_modifiers = always_show_modifiers
+    def __init__(self):
         self.run_label = RunLabel()
 
         self.world = 0
@@ -767,8 +766,8 @@ class RunState:
         self.player_last_item_types = self.player_item_types
         self.player_item_types = item_types
 
-    def should_show_modifiers(self, screen: Screen):
-        if self.always_show_modifiers:
+    def should_show_modifiers(self, screen: Screen, always_show_modifiers: bool):
+        if always_show_modifiers:
             return True
 
         if screen == Screen.SCORES:
@@ -785,5 +784,7 @@ class RunState:
 
         return False
 
-    def get_display(self, screen: Screen):
-        return self.run_label.text(not self.should_show_modifiers(screen))
+    def get_display(self, screen: Screen, always_show_modifiers: bool):
+        return self.run_label.text(
+            not self.should_show_modifiers(screen, always_show_modifiers)
+        )


### PR DESCRIPTION
The user-visible parts of this change are

* Per-tracker configs (e.g. "Always Show Modifiers") are now persisted between runs of modlunky2
* Per-tracker config changes are applied on next poll, instead of requiring restarting the tracker

There are a couple warts:

* Color key changes aren't applied immediately
* If modlunky2 is downgraded, the per-tracker configs are lost

Notable internal changes:

* Unified `WatcherThread` and `TrackerWindow` implementations
* New `Tracker` interface for per-tracker bits
* Pacifist tracker now updates every 16ms (vs 100ms)
* Data shipped between `WatcherThread` and `TrackerWindow` is now in dataclasses (vs dicts)