### PR TITLE
Allow Excluding Starting Categories

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -6,7 +6,8 @@ import json
 import logging
 import shutil
 import time
-from typing import Dict, List, Optional, TypeVar
+from enum import Enum
+from typing import Dict, List, Optional, TypeVar, Set
 
 try:
     import winreg
@@ -135,12 +136,20 @@ class CommonTrackerConfig:
         return dataclasses.replace(self)
 
 
+class SaveableCategory(Enum):
+    NO = "No%"
+    NO_GOLD = "No Gold"
+    PACIFIST = "Pacifist"
+
+
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass
 class CategoryTrackerConfig(CommonTrackerConfig):
     always_show_modifiers: bool = skip_default_field(default=False)
-    excluded_categories: Optional[List[str]] = skip_default_field(default=None)
+    excluded_categories: Optional[Set[SaveableCategory]] = skip_default_field(
+        default=None
+    )
 
 
 @serialize(rename_all="spinalcase")

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -142,6 +142,7 @@ class CategoryTrackerConfig(CommonTrackerConfig):
     always_show_modifiers: bool = skip_default_field(default=False)
     excluded_categories: Optional[List[str]] = skip_default_field(default=None)
 
+
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -140,7 +140,7 @@ class CommonTrackerConfig:
 @dataclass
 class CategoryTrackerConfig(CommonTrackerConfig):
     always_show_modifiers: bool = skip_default_field(default=False)
-
+    excluded_categories: Optional[List[str]] = skip_default_field(default=None)
 
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -105,7 +105,7 @@ class CategoryButtons(ttk.Frame):
             if category.name in excluded_loaded:
                 variable.set(True)
             checkbox.grid(row=row, column=0, padx=5, pady=5, sticky="nw")
-            row += 1
+            current_row += 1
 
             self.excludable_dict[category] = (checkbox, variable)
 

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -34,6 +34,8 @@ class CategoryButtons(ttk.Frame):
             Image.open(ICON_PATH / "cat2.png").resize((24, 24), Image.ANTIALIAS)
         )
 
+        current_row = 0
+
         self.category_button = ttk.Button(
             self,
             image=self.cat_icon,
@@ -41,13 +43,15 @@ class CategoryButtons(ttk.Frame):
             compound="left",
             command=self.launch,
         )
-        self.category_button.grid(row=0, column=0, pady=5, padx=5, sticky="nswe")
+        self.category_button.grid(
+            row=current_row, column=0, pady=5, padx=5, sticky="nswe"
+        )
 
         self.always_show_modifiers = tk.BooleanVar()
         self.always_show_modifiers.set(
             modlunky_config.trackers.category.always_show_modifiers
         )
-        
+
         self.always_show_modifiers_checkbox = ttk.Checkbutton(
             self,
             text="Always Show Modifiers",
@@ -57,29 +61,37 @@ class CategoryButtons(ttk.Frame):
             command=self.toggle_always_show_modifiers,
         )
         self.always_show_modifiers_checkbox.grid(
-            row=0, column=1, pady=5, padx=5, sticky="nw"
+            row=current_row, column=1, pady=5, padx=5, sticky="nw"
         )
+
+        current_row += 1
 
         # Starting Category Exclusion
         ## This does not have any effect on the actual tracking logic, rather,
         ## like always_show_modifiers, it only has an effect on the actual
         ## text returned.
         self.category_exclude_label = ttk.Label(
-            self,
-            text="Exclude Starting Categories"
+            self, text="Exclude Starting Categories"
         )
-        self.category_exclude_label.grid(row=1, column=0, padx=5, pady=5, sticky="nw")
+        self.category_exclude_label.grid(
+            row=current_row, column=0, padx=5, pady=5, sticky="nw"
+        )
+
+        current_row += 1
 
         self.excludable_dict = {}
 
         # You can exclude any starting category that is non-terminal, i.e., any of them except Any%
-        valid_excludable_categories = [l for l in Label if l.value.start and not l.value.terminus]
+        valid_excludable_categories = [
+            l for l in Label if l.value.start and not l.value.terminus
+        ]
         excluded_loaded = modlunky_config.trackers.category.excluded_categories
 
         # Sort by '%' then by name descending
-        valid_excludable_categories.sort(key=lambda l: (l.value.percent_priority is not None, l.name), reverse=True)
+        valid_excludable_categories.sort(
+            key=lambda l: (l.value.percent_priority is not None, l.name), reverse=True
+        )
 
-        row=2
         for category in valid_excludable_categories:
             variable = tk.BooleanVar()
             checkbox = ttk.Checkbutton(
@@ -112,7 +124,6 @@ class CategoryButtons(ttk.Frame):
         self.modlunky_config.save()
         if self.window:
             self.window.update_config(self.modlunky_config.trackers.category)
-
 
     def launch(self):
         color_key = self.modlunky_config.tracker_color_key

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Set, FrozenSet
 
+from modlunky2.config import SaveableCategory  # For saving
+
 
 @dataclass
 class LabelMetadata:
@@ -46,6 +48,16 @@ class Label(Enum):
     COSMIC_OCEAN = LabelMetadata("Cosmic Ocean", percent_priority=2, terminus=True)
     SCORE = LabelMetadata("Score")
     NO_CO = LabelMetadata("No CO", start=True, hide_early=False, add_ok=True)
+
+    @classmethod
+    def from_saveable_category(cls, sc):
+        mapping = {
+            SaveableCategory.NO: Label.NO,
+            SaveableCategory.NO_GOLD: Label.NO_GOLD,
+            SaveableCategory.PACIFIST: Label.PACIFIST,
+        }
+
+        return mapping[sc]
 
 
 @dataclass(frozen=True)
@@ -214,7 +226,7 @@ class RunLabel:
 
     def text(self, hide_early, excluded_categories=None) -> str:
         excluded_categories = (
-            frozenset([Label[n] for n in excluded_categories])
+            frozenset([Label.from_saveable_category(sc) for sc in excluded_categories])
             if excluded_categories is not None
             else frozenset()
         )

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Set, FrozenSet, Iterable
+from typing import Optional, Set, FrozenSet
 
 
 @dataclass
@@ -153,7 +153,9 @@ class RunLabel:
             if len(inter) > 1:
                 raise Exception(f"Found mutually-exclusive labels {inter}")
 
-    def _visible(self, hide_early: bool, excluded_categories: FrozenSet[Label]) -> Set[Label]:
+    def _visible(
+        self, hide_early: bool, excluded_categories: FrozenSet[Label]
+    ) -> Set[Label]:
         vis = set(self._set)
         vis -= excluded_categories
 
@@ -211,9 +213,17 @@ class RunLabel:
         return found
 
     def text(self, hide_early, excluded_categories=None) -> str:
-        excluded_categories = frozenset([Label[n] for n in excluded_categories]) if excluded_categories is not None else frozenset()
+        excluded_categories = (
+            frozenset([Label[n] for n in excluded_categories])
+            if excluded_categories is not None
+            else frozenset()
+        )
 
-        if self._cached_text is not None and self._cached_text.hide_early == hide_early and self._cached_text.excluded_categories == excluded_categories:
+        if (
+            self._cached_text is not None
+            and self._cached_text.hide_early == hide_early
+            and self._cached_text.excluded_categories == excluded_categories
+        ):
             return self._cached_text.text
 
         vis = self._visible(hide_early, excluded_categories)
@@ -229,5 +239,7 @@ class RunLabel:
                 parts.append(candidate.value.text)
 
         text = " ".join(parts)
-        self._cached_text = _CachedText(hide_early=hide_early, text=text, excluded_categories=excluded_categories)
+        self._cached_text = _CachedText(
+            hide_early=hide_early, text=text, excluded_categories=excluded_categories
+        )
         return text

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -784,6 +784,7 @@ class RunState:
 
         return False
 
-    def get_display(self, screen: Screen, always_show_modifiers: bool):
+    def get_display(self, screen: Screen, always_show_modifiers: bool, excluded_categories=None):
+        excluded_categories = excluded_categories if excluded_categories is not None else []
         hide_early = not self.should_show_modifiers(screen, always_show_modifiers)
-        return self.run_label.text(hide_early)
+        return self.run_label.text(hide_early, excluded_categories)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -784,7 +784,11 @@ class RunState:
 
         return False
 
-    def get_display(self, screen: Screen, always_show_modifiers: bool, excluded_categories=None):
-        excluded_categories = excluded_categories if excluded_categories is not None else []
+    def get_display(
+        self, screen: Screen, always_show_modifiers: bool, excluded_categories=None
+    ):
+        excluded_categories = (
+            excluded_categories if excluded_categories is not None else []
+        )
         hide_early = not self.should_show_modifiers(screen, always_show_modifiers)
         return self.run_label.text(hide_early, excluded_categories)

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -37,6 +37,7 @@ from modlunky2.category.chain.sunken import AbzuChain, DuatChain
 from modlunky2.category.chain.cosmic import CosmicOceanChain
 from modlunky2.category.chain.eggplant import EggplantChain
 from modlunky2.ui.trackers.label import Label, RunLabel
+from modlunky2.config import CategoryTrackerConfig
 
 
 logger = logging.getLogger("modlunky2")
@@ -784,11 +785,13 @@ class RunState:
 
         return False
 
-    def get_display(
-        self, screen: Screen, always_show_modifiers: bool, excluded_categories=None
-    ):
+    def get_display(self, screen: Screen, config: CategoryTrackerConfig) -> str:
         excluded_categories = (
-            excluded_categories if excluded_categories is not None else []
+            config.excluded_categories
+            if config.excluded_categories is not None
+            else frozenset()
         )
-        hide_early = not self.should_show_modifiers(screen, always_show_modifiers)
+        hide_early = not self.should_show_modifiers(
+            screen, config.always_show_modifiers
+        )
         return self.run_label.text(hide_early, excluded_categories)

--- a/src/tests/ui/trackers/label_test.py
+++ b/src/tests/ui/trackers/label_test.py
@@ -328,7 +328,7 @@ def test_visibility_bipartite():
 @mark.parametrize("labels,expected", MOSSRANKING_CATEGORIES)
 def test_mossranking_alignment(labels, expected):
     run_label = RunLabel(labels)
-    actual = run_label.text(hide_early=False)
+    actual = run_label.text(hide_early=False, excluded_categories=set())
     assert actual == expected
 
 
@@ -376,5 +376,5 @@ ASSORTED_LABELS = [
 @mark.parametrize("labels,expected", ASSORTED_LABELS)
 def test_assorted_labels(labels, expected):
     run_label = RunLabel(labels)
-    actual = run_label.text(hide_early=False)
+    actual = run_label.text(hide_early=False, excluded_categories=set())
     assert actual == expected


### PR DESCRIPTION
Adds checkboxes to the category tracker that disables the visualization of all non-terminal starting categories, i.e., all of them except Any%.

Mainly because Hectique asked for it and I was bored.

Ran the unit tests and tested it for a while. Seems fine.

![Screenshot from 2022-01-09 08-00-48](https://user-images.githubusercontent.com/97376983/148671379-5ea22938-44fe-47bc-875e-d2894817a81b.png)

