### PR TITLE
Expand and update documentation

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         # Install pyinstaller in addition to usual deps
         python -m pip install --upgrade pip
-        pip install -r requirements.txt -r requirements-dev.txt -r requirements-win.txt pyinstaller
+        pip install -r requirements.txt -r requirements-dev.txt -r requirements-win.txt
     - name: Install package
       run: |
         python setup.py develop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to modlunky2
+
+## Discussion
+
+Most discussion occurs in the [Spelunky Community Discord server](https://discord.gg/spelunky-community)
+
+* `#s2-modding-help` — Get help with using or making mods
+* `#s2-modding-tooldevs` — Discuss development, e.g. bug fixes or implementing new features
+
+## Bugs
+
+Before reporting a bug, please check the [existing ones](https://github.com/spelunky-fyi/modlunky2/issues)
+to see whether yours has already been reported.
+
+## Development
+
+### Setup
+
+Before making substantial changes to Modlunky2, please discuss them in `#s2-modding-tooldevs`
+
+#### Python virtualenv
+
+A virtualenv is a nice way to keep this project's dependencies isolated from the rest of your  system.
+This step is optional but recommended
+
+In the root directory you can make a virtualenv. It will be excluded from commits by default
+
+```console
+python -m venv venv
+```
+
+Whenever developing the project you'll want to activate the [virtualenv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment)
+in your terminal. This is platform dependent
+
+> :warning: If you're using PowerShell on Windows you might need to run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`.
+
+| Platform | Shell           | Command to activate virtual environment |
+|----------|-----------------|-----------------------------------------|
+| Windows  | cmd.exe         | `<venv>\Scripts\activate.bat`           |
+|          | PowerShell      | `<venv>\Scripts\Activate.ps1`           |
+| POSIX    | bash/zsh        | `source <venv>/bin/activate`            |
+|          | fish            | `source <venv>/bin/activate.fish`       |
+|          | csh/tcsh        | `source <venv>/bin/activate.csh`        |
+|          | PowerShell Core | `<venv>/bin/Activate.ps1`               |
+
+#### Python packages
+
+Once you have your virtual environment setup and activated, you'll want to finish setting up the
+development environment.
+
+```console
+pip install --upgrade -r requirements.txt -r requirements-dev.txt -r requirements-win.txt
+python setup.py develop
+```
+
+This will install any dependencies as well as setting up links on your path to your local source files.
+
+### Running
+
+You can simply run Modlunky2 in a console via
+
+```console
+modlunky2
+```
+
+If the command is not found, you may have forgotten to activate the virtualenv.
+
+### IDE
+
+[VS Code](https://code.visualstudio.com/) is the most common IDE used for Modlunky2 development.
+You'll need the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python).
+Since we require strict formatting, it's helpful to enable `editor.formatOnSave` and
+set `python.formatting.provider` to `black`.
+
+### Building `modlunky2.exe`
+
+> :warning: This usually isn't needed for development, just releases.
+
+#### GitHub
+
+If your code is in `main` branch (or a PR for it), you can download the exe from
+[GitHub actions](https://github.com/spelunky-fyi/modlunky2/actions/workflows/build-exe.yml).
+
+#### Local build
+
+You need to [install Rust](https://www.rust-lang.org/tools/install). We use it to bootstrap the Python application.
+
+To build the exe, run
+
+```console
+python build-exe.py
+```
+
+Once its done, it will open the folder `src/launcher/target/release/` which contains `modlunky2.exe`
+
+#### Troubleshooting
+
+##### Pyinstaller
+
+The default pyinstaller from pip is usually fine.
+
+If `modlunky2.exe` is being removed by antivirus, [building your own](https://pyinstaller.readthedocs.io/en/stable/bootloader-building.html) might help.
+
+##### Audio DLLs
+
+The `dll`'s to extract audio are included in the `dist` directory. These are used to extract files from the FSB soundbank.
+
+If updated versions are needed, they can be obtained from [python-fsb5](https://github.com/HearthSim/python-fsb5/releases).
+Put the `libogg.dll` and `libvorbis.dll` files from `python-fsb5_win64.zip` into the `dist` directory.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ Special thanks to the following contributors for helping make modlunky possible:
 * `JackHasWifi`
 * `mriswithe`
 * `Malacath`
+* `MauveAlert`

--- a/README.md
+++ b/README.md
@@ -1,100 +1,32 @@
+# modlunky2
+
 [![Python Testing](https://github.com/spelunky-fyi/modlunky2/actions/workflows/test.yml/badge.svg)](https://github.com/spelunky-fyi/modlunky2/actions/workflows/test.yml)
 [![Latest Release](https://img.shields.io/github/release/spelunky-fyi/modlunky2.svg?style=flat)](https://github.com/spelunky-fyi/modlunky2/releases/latest)
 ![Downloads](https://img.shields.io/github/downloads/spelunky-fyi/modlunky2/total.svg?style=flat)
-[![PyPi Version](https://img.shields.io/pypi/v/modlunky2.svg)](https://pypi.python.org/pypi/modlunky2/)
 
+Modlunky 2 is a tool for creating and using mods related to Spelunky 2. It offers
 
-# modlunky2
-
-Modlunky 2 is a tool for creating and using mods related to Spelunky 2.
-
-## Installation
-
-[Download the latest version](https://github.com/spelunky-fyi/modlunky2/releases) of modlunky2.exe to your Spelunky 2 installation directory.
+* Mod management, including
+  * Downloading and updating mods from spelunky.fyi
+  * Launching Spelunky 2 with mods (via Playlunky)
+* Creating and editing levels
+* Extracting assets (e.g. images and audio)
+* Updating and launching Overlunky
+* Speedrun trackers
 
 ## Usage
 
 Follow the instructions in the [Modlunky 2 Wiki](https://github.com/spelunky-fyi/modlunky2/wiki).
 
-## Disclaimer
-You are strongly discouraged from using any modding tools in your actual online Steam installation as to prevent unlocking achievements, corrupting your savefile and cheating in the leaderboards.
+> :warning: Spelunky 2 doesn't officially support modding. Do not report modding related bugs to Blitworks.
 
-You can make a copy of your game somewhere else and install [Mr. Goldbergs Steam Emulator](https://gitlab.com/Mr_Goldberg/goldberg_emulator/-/releases) in the game directory. (TL;DR: Copy the steam_api64.dll from the zip to the offline game directory and create steam_appid.txt with the text `418530` in it.) Also block the modded installation in your firewall.
+## Contributing
 
-If you break anything using this tool you get to keep both pieces. Do not report modding related bugs to Blitworks.
+The [documentation for contributing](CONTRIBUTING.md) explains
 
-## Development
-
-If you'd like to contribute to `modlunky2` here are some steps to setup your environment.
-
-### VirtualEnv
-
-*While not required, a virtualenv is a nice way to keep this projects dependencies isolated from the rest of your system. This step is optional but recommended*
-
-In the root directory you can make a virtualenv. It will be excluded from commits by default
-
-```console
-python -m venv venv
-```
-Whenever developing the project you'll want to activate the virtualenv in your terminal. This is platform dependent and there are more comprehensive docs available here: https://docs.python.org/3/library/venv.html
-
-> :warning: If you're using PowerShell on Windows you might need to run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`. More information on execution policy is available in the link above.
-
-| Platform | Shell           | Command to activate virtual environment |
-|----------|-----------------|-----------------------------------------|
-| POSIX    | bash/zsh        | $ source <venv>/bin/activate            |
-|          | fish            | $ source <venv>/bin/activate.fish       |
-|          | csh/tcsh        | $ source <venv>/bin/activate.csh        |
-|          | PowerShell Core | $ <venv>/bin/Activate.ps1               |
-| Windows  | cmd.exe         | C:\> <venv>\Scripts\activate.bat        |
-|          | PowerShell      | PS C:\> <venv>\Scripts\Activate.ps1     |
-
-
-### Setup
-
-Once you have your virtual environment setup and activated you'll want to finish setting up the development environment.
-
-```console
-> pip install --upgrade -r requirements.txt -r requirements-dev.txt -r requirements-win.txt
-> python setup.py develop
-```
-
-This will install any dependencies as well as setting up links on your path to your local source files. Once this is done
-you'll be able to execute the binaries right from your path after any changes to the source without the need to build or
-install anything. If you add new source files you may have to run `python setup.py develop` again to make sure they're linked.
-
-### Running Locally
-
-```
-modlunky2
-```
-
-### Building Distributions
-
-#### PyPI
-```
-python setup.py sdist
-python -m twine upload .\dist\modlunky2-$VERSION.tar.gz
-```
-
-#### EXE
-
-##### PyInstaller
-The default pyinstaller from pip seems prone to false detection from antivirus. Instructions on building your own available at https://pyinstaller.readthedocs.io/en/stable/bootloader-building.html
-
-Alternatively you can `pip install pyinstaller`
-
-See: https://stackoverflow.com/a/52054580
-
-##### Audio DLLs
-We need some ogg/vorbis `dll`'s in order to support extracting files from the FSB soundbank. These can be obtained from https://github.com/HearthSim/python-fsb5/releases
-
-Drop the `libogg.dll` and `libvorbis.dll` files from python-fsb5_win64.zip into the `dist` directory
-
-##### Build
-```
-python build-exe.py
-```
+* How to report bugs
+* Where to discuss changes
+* Setup for development
 
 ## Contributors
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ flake8==4.0.1
 pylint==2.12.2
 pytest==6.2.5
 pip-api==0.0.26
-twine
+pyinstaller==4.7


### PR DESCRIPTION
Since a lot's moved around, here's my attempt at a list of changes...

* General tidying based on markdownlint
* Readme
  * Remove pypi badge 
  * Outline various things Modlunky2 does
  * Remove partial installation and usage instructions, in favor of wiki link
  * Abbreviate disclaimer
  * Move development info to a separate Contributing page
* Contributing
  * Add pointers to Discord
  * Suggest looking at bugs before filing new ones
  * Suggest discussing changes
  * Setup tweaks
    * List Windows venv commands first
    * Remove shell prompts from console bits
    * Recommend VS Code
  * Remove wheel instructions
  * Building exe 
    * Point to GitHub actions
    * Mention Rust
    * Shove "custom pyinstaller" and dll under "Troubleshooting"
  * requirements-dev.txt
    * include pyinstaller
    * remove twine