### PR TITLE
Fix missing push block texture when in the surface theme.

### DIFF
--- a/src/modlunky2/sprites/floor_sheet.py
+++ b/src/modlunky2/sprites/floor_sheet.py
@@ -1,4 +1,5 @@
 from modlunky2.sprites.base_classes import AbstractFloorSheet
+from pathlib import Path
 
 __all__ = [
     "CaveFloorSheet",
@@ -97,3 +98,9 @@ class EggplantFloorSheet(AbstractFloorSheet):
 class SurfaceFloorSheet(AbstractFloorSheet):
     biome_name = "surface"
     _additional_chunks = {"surface_floor": (0, 0, 1, 1)}
+
+    def __init__(self, base_path: Path):
+        super().__init__(base_path=base_path)
+        new_map = self._chunk_map.copy()
+        new_map.pop("push_block")
+        self._chunk_map = new_map


### PR DESCRIPTION
The surface texture sheet does not have a push block texture, so we have to remove it from the chunk map to allow the default push block texture to be used.