### PR TITLE
Add Web Service w/ WebSocket API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 Pillow==9.0.1
-platformdirs==2.5.1
+anyio==3.5.0
+colorhash==1.0.4
 fnvhash==0.1.0
+hypercorn==0.13.2
 packaging==21.3
+platformdirs==2.5.1
 pyperclip==1.8.2
 pyserde==0.7.1
 requests==2.27.1
 sfyi-fsb5==1.1
+starlette==0.18.0
 typing_extensions==4.1.1
 websockets==10.2
 zstandard==0.17.0
-colorhash==1.0.4

--- a/src/modlunky2/cli.py
+++ b/src/modlunky2/cli.py
@@ -60,7 +60,7 @@ def launch(args, log_level):
         exe_dir=exe_dir,
     )
 
-    shutdown_callback = web_service.launch_in_thread()
+    shutdown_callback = web_service.launch_in_thread(config)
     native_ui = ModlunkyUI(config, log_level)
     native_ui.mainloop()
     shutdown_callback()

--- a/src/modlunky2/cli.py
+++ b/src/modlunky2/cli.py
@@ -6,6 +6,7 @@ from typing import Optional
 from modlunky2.ui import ModlunkyUI
 from modlunky2.config import Config, make_user_dirs
 from modlunky2.utils import tb_info
+import modlunky2.web.service as web_service
 
 logger = logging.getLogger("modlunky2")
 
@@ -59,5 +60,7 @@ def launch(args, log_level):
         exe_dir=exe_dir,
     )
 
+    shutdown_callback = web_service.launch_in_thread()
     native_ui = ModlunkyUI(config, log_level)
     native_ui.mainloop()
+    shutdown_callback()

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -205,6 +205,7 @@ class Config:
         default=None, skip_if_default=True
     )
     command_prefix: Optional[List[str]] = field(default=None, skip_if_default=True)
+    api_port: int = field(default=9526)
 
     def __post_init__(self):
         if self.exe_dir is None:

--- a/src/modlunky2/web/api/framework/multiplexing.py
+++ b/src/modlunky2/web/api/framework/multiplexing.py
@@ -28,8 +28,6 @@ from modlunky2.web.api.framework.session import (
 logger = logging.getLogger("modlunky2")
 
 ParamType = TypeVar("ParamType")
-SendType = TypeVar("SendType")
-Sender = Callable[[SendType], Awaitable[None]]
 
 
 class SendConnection:
@@ -89,7 +87,7 @@ class WSMultiplexer:
             logger.warning("Deserializing request failed %s", ex)
             return
 
-        info = self._param_to_endpoint[type(obj)]
+        endpoint = self._param_to_endpoint[type(obj)]
         sender = SendConnection(websocket, session_id)
 
-        await info.endpoint(sender, obj)
+        await endpoint(sender, obj)

--- a/src/modlunky2/web/api/framework/multiplexing.py
+++ b/src/modlunky2/web/api/framework/multiplexing.py
@@ -3,7 +3,7 @@ from anyio.abc import TaskGroup
 from dataclasses import dataclass
 import logging
 from starlette.routing import WebSocketRoute
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketDisconnect
 from typing import (
     Any,
     Awaitable,
@@ -85,6 +85,10 @@ class WSMultiplexer:
                         await self._dispatch_one(websocket, session_id, tg)
         except SessionException as ex:
             await websocket.close(reason=str(ex))
+        except WebSocketDisconnect:
+            # We swallow disconnect since it's OK for clients to close the connection.
+            # We don't swallow close since we don't (currently) expect handlers to close the connection.
+            pass
 
     async def _dispatch_one(
         self, websocket: WebSocket, session_id: SessionId, task_group: TaskGroup

--- a/src/modlunky2/web/api/framework/multiplexing.py
+++ b/src/modlunky2/web/api/framework/multiplexing.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+import logging
+from starlette.routing import WebSocketRoute
+from starlette.websockets import WebSocket, WebSocketDisconnect
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Type,
+    TypeVar,
+)
+
+from modlunky2.web.api.framework.serde_tag import (
+    TagException,
+    TagDeserializer,
+    to_tagged_dict,
+)
+from modlunky2.web.api.framework.session import SessionException, SessionManager
+
+logger = logging.getLogger("modlunky2")
+
+ParamType = TypeVar("ParamType")
+SendType = TypeVar("SendType")
+Sender = Callable[[SendType], Awaitable[None]]
+
+
+class SendConnection:
+    def __init__(self, websocket: WebSocket, session_id: str) -> None:
+        self._websocket = websocket
+        self._session_id = session_id
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    async def send(self, obj: Any) -> None:
+        data = to_tagged_dict(obj)
+        await self._websocket.send_json(data)
+
+
+MultiplexerEndpoint = Callable[[SendConnection, ParamType], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class WSMultiplexerRoute(Generic[ParamType]):
+    param_type: Type[ParamType]
+    endpoint: MultiplexerEndpoint[ParamType]
+
+
+class WSMultiplexer:
+    def __init__(self, routes: Iterable[WSMultiplexerRoute[Any]]) -> None:
+        self._param_to_endpoint: Dict[Type[Any], MultiplexerEndpoint[Any]] = {}
+        for r in routes:
+            self._param_to_endpoint[r.param_type] = r.endpoint
+
+        self._param_deserializer = TagDeserializer(self._param_to_endpoint.keys())
+        self._sid_manager = SessionManager("ws_session_id")
+        self._route = WebSocketRoute("/{ws_session_id}", self._endpoint)
+
+    @property
+    def starlette_route(self) -> WebSocketRoute:
+        return self._route
+
+    async def _endpoint(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        try:
+            with self._sid_manager.session_for(websocket) as session_id:
+                try:
+                    while True:
+                        await self._dispatch_one(websocket, session_id)
+                except WebSocketDisconnect:
+                    pass
+        except SessionException as ex:
+            await websocket.close(reason=str(ex))
+
+    async def _dispatch_one(self, websocket: WebSocket, session_id: str) -> None:
+        data: Dict[str, Any] = await websocket.receive_json()
+        try:
+            obj = self._param_deserializer.from_tagged_dict(data)
+        except (TagException, TypeError) as ex:
+            logger.warning("Deserializing request failed %s", ex)
+            return
+
+        info = self._param_to_endpoint[type(obj)]
+        sender = SendConnection(websocket, session_id)
+
+        await info.endpoint(sender, obj)

--- a/src/modlunky2/web/api/framework/pubsub.py
+++ b/src/modlunky2/web/api/framework/pubsub.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+import dataclasses
+from enum import Enum, auto
+import logging
+import math
+from anyio import create_memory_object_stream, create_task_group
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from dataclasses import InitVar, dataclass
+from serde import serde
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Set,
+    Tuple,
+    Type,
+)
+
+
+from modlunky2.web.api.framework.multiplexing import SendConnection, WSMultiplexerRoute
+from modlunky2.web.api.framework.serde_tag import to_tagged_dict
+from modlunky2.web.api.framework.session import SessionId
+
+logger = logging.getLogger("modlunky2")
+
+
+@serde
+@dataclass(frozen=True)
+class Subscribe:
+    topics: Set[str]
+
+
+@serde
+@dataclass(frozen=True)
+class Unsubscribe:
+    topics: Set[str]
+
+
+@serde
+@dataclass(frozen=True)
+class Published:
+    # Should be TaggedMessage, but I'm unsure how to use pyserde with it
+    message: Dict[str, Any]
+
+
+class ServiceLevel(Enum):
+    MUST_DELIVER = auto()
+    MAY_DROP = auto()
+
+
+@dataclass(frozen=True)
+class PubSubTopic:
+    typ: Type[Any]
+    service_level: ServiceLevel
+
+
+@dataclass
+class _TopicInfo:
+    service_level: ServiceLevel
+    subscribers: Set[SessionId] = dataclasses.field(default_factory=set)
+
+
+@dataclass
+class _StreamPair:
+    max_buffer_size: InitVar[float]
+
+    send: MemoryObjectSendStream[Published] = dataclasses.field(init=False)
+    recv: MemoryObjectReceiveStream[Published] = dataclasses.field(init=False)
+
+    def __post_init__(self, max_buffer_size: float):
+        self.send, self.recv = create_memory_object_stream(max_buffer_size, Published)
+
+
+@dataclass
+class _SessionCopier:
+    connection: SendConnection
+
+    _may_drop: _StreamPair = dataclasses.field(init=False)
+    _must_deliver: _StreamPair = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self._may_drop = _StreamPair(0)
+        self._must_deliver = _StreamPair(math.inf)
+
+    def send(self, level: ServiceLevel, pub: Published):
+        if level is ServiceLevel.MAY_DROP:
+            stream = self._may_drop.send
+        elif level is ServiceLevel.MUST_DELIVER:
+            stream = self._must_deliver.send
+        else:
+            raise ValueError(f"Unknown service level {level}")
+
+        stream.send_nowait(pub)
+
+    async def run(self) -> None:
+        """Send messages until the client disconnects"""
+        try:
+            async with create_task_group() as tg:  # , self._may_drop.recv as _, self._must_deliver.recv as _:
+                tg.start_soon(self._run_one, self._may_drop.recv)
+                tg.start_soon(self._run_one, self._must_deliver.recv)
+        finally:
+            self._may_drop.recv.close()
+            self._must_deliver.recv.close()
+
+    async def _run_one(self, recv: MemoryObjectReceiveStream[Published]) -> None:
+        async for pub in recv:
+            await self.connection.send(pub)
+
+
+@dataclass
+class PubSubManager:
+    topics: InitVar[Iterable[PubSubTopic]]
+
+    _topic_info: Dict[str, _TopicInfo] = dataclasses.field(
+        init=False, default_factory=dict
+    )
+    _sessions: Dict[SessionId, _SessionCopier] = dataclasses.field(
+        init=False, default_factory=dict
+    )
+
+    def __post_init__(self, topics: Iterable[PubSubTopic]):
+        for t in topics:
+            name = t.typ.__name__
+            if name in self._topic_info:
+                raise ValueError(f"Topic {name} appears more than once")
+            self._topic_info[name] = _TopicInfo(t.service_level)
+
+    @property
+    def multiplexer_routes(self) -> Tuple[WSMultiplexerRoute[Any], ...]:
+        return (
+            WSMultiplexerRoute(Subscribe, self._subscribe),
+            WSMultiplexerRoute(Unsubscribe, self._unsubscribe),
+        )
+
+    def publish(self, msg: Any):
+        topic_name = type(msg).__name__
+        if topic_name not in self._topic_info:
+            raise ValueError(f"Topic {topic_name} is unknown")
+        info = self._topic_info[topic_name]
+        pub = Published(to_tagged_dict(msg))
+        for sid in info.subscribers:
+            self._sessions[sid].send(info.service_level, pub)
+
+    async def _subscribe(self, connection: SendConnection, req: Subscribe) -> None:
+        self._check_topics(req.topics)
+        self._maybe_add_session(connection)
+        for topic in req.topics:
+            self._topic_info[topic].subscribers.add(connection.session_id)
+
+    async def _unsubscribe(self, connection: SendConnection, req: Unsubscribe) -> None:
+        self._check_topics(req.topics)
+        for topic in req.topics:
+            self._topic_info[topic].subscribers.discard(connection.session_id)
+
+    def _check_topics(self, raw_topics: Set[str]) -> None:
+        unknown_topics: Set[str] = set()
+        for t in raw_topics:
+            if t not in self._topic_info:
+                unknown_topics.add(t)
+
+        if unknown_topics:
+            raise ValueError(f"Request contains unknown topics {unknown_topics!r}")
+
+    def _maybe_add_session(self, connection: SendConnection):
+        if connection.session_id in self._sessions:
+            return
+        self._sessions[connection.session_id] = _SessionCopier(connection)
+        connection.task_group.start_soon(
+            self._run_session,
+            connection.session_id,
+            name=f"pubsub copier for sid {connection.session_id}",
+        )
+
+    async def _run_session(self, session_id: SessionId):
+        try:
+            await self._sessions[session_id].run()
+        finally:
+            # Cleanup the session
+            for ti in self._topic_info.values():
+                ti.subscribers.discard(session_id)
+            del self._sessions[session_id]

--- a/src/modlunky2/web/api/framework/serde_tag.py
+++ b/src/modlunky2/web/api/framework/serde_tag.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from types import MappingProxyType
+from typing import Any, Dict, Iterable, Type
+
+from serde.de import from_dict, is_deserializable
+from serde.se import to_dict
+
+
+class TagException(Exception):
+    pass
+
+
+def to_tagged_dict(obj: Any) -> Dict[str, Dict[str, Any]]:
+    data = to_dict(obj)
+    tag = type(obj).__name__
+    return {tag: data}
+
+
+@dataclass(frozen=True)
+class TagDeserializer:
+    types: InitVar[Iterable[Type[Any]]]
+
+    _type_map: Dict[str, Type[Any]] = field(default_factory=dict, init=False)
+
+    def __post_init__(self, types: Iterable[Type[Any]]):
+        type_map: Dict[str, Type[Any]] = {}
+        for typ in types:
+            if not is_deserializable(typ):
+                raise TagException(f"{typ} isn't deserializable with pyserde")
+
+            type_map[typ.__name__] = typ
+        object.__setattr__(self, "_type_map", MappingProxyType(type_map))
+
+    def from_tagged_dict(self, data: Dict[str, Any]) -> Any:
+        if len(data) != 1:
+            raise TagException(f"Data has {len(data)} keys, expected 1")
+        tag = next(iter(data.keys()))
+
+        if tag not in self._type_map:
+            raise TagException(f"Data has tag {tag}, which isn't a known type")
+        typ = self._type_map[tag]
+
+        return from_dict(typ, data[tag])

--- a/src/modlunky2/web/api/framework/serde_tag.py
+++ b/src/modlunky2/web/api/framework/serde_tag.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
 from types import MappingProxyType
-from typing import Any, Dict, Iterable, Type
+from typing import Any, Dict, Iterable, NewType, Type
 
 from serde.de import from_dict, is_deserializable
 from serde.se import to_dict
+
+TaggedMessage = NewType("TaggedMessage", Dict[str, Any])
 
 
 class TagException(Exception):
     pass
 
 
-def to_tagged_dict(obj: Any) -> Dict[str, Dict[str, Any]]:
+def to_tagged_dict(obj: Any) -> TaggedMessage:
     data = to_dict(obj)
     tag = type(obj).__name__
-    return {tag: data}
+    return TaggedMessage({tag: data})
 
 
 @dataclass(frozen=True)
@@ -33,7 +35,7 @@ class TagDeserializer:
             type_map[typ.__name__] = typ
         object.__setattr__(self, "_type_map", MappingProxyType(type_map))
 
-    def from_tagged_dict(self, data: Dict[str, Any]) -> Any:
+    def from_tagged_dict(self, data: TaggedMessage) -> Any:
         if len(data) != 1:
             raise TagException(f"Data has {len(data)} keys, expected 1")
         tag = next(iter(data.keys()))

--- a/src/modlunky2/web/api/framework/serde_tag.py
+++ b/src/modlunky2/web/api/framework/serde_tag.py
@@ -15,7 +15,7 @@ class TagException(Exception):
 
 
 def to_tagged_dict(obj: Any) -> TaggedMessage:
-    data = to_dict(obj)
+    data = to_dict(obj, convert_sets=True)
     tag = type(obj).__name__
     return TaggedMessage({tag: data})
 

--- a/src/modlunky2/web/api/framework/session.py
+++ b/src/modlunky2/web/api/framework/session.py
@@ -36,6 +36,7 @@ class SessionManager:
             )
         self.sid_to_addr[sid] = addr
 
-        yield sid
-
-        del self.sid_to_addr[sid]
+        try:
+            yield sid
+        finally:
+            del self.sid_to_addr[sid]

--- a/src/modlunky2/web/api/framework/session.py
+++ b/src/modlunky2/web/api/framework/session.py
@@ -1,0 +1,40 @@
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import logging
+from starlette.datastructures import Address
+from starlette.websockets import WebSocket
+from typing import Dict, Generator, NewType
+
+logger = logging.getLogger("modlunky2")
+
+SessionId = NewType("SessionId", str)
+
+
+class SessionException(Exception):
+    pass
+
+
+@dataclass
+class SessionManager:
+    route_sid_param_name: str
+    sid_to_addr: Dict[SessionId, Address] = field(default_factory=dict)
+
+    @contextmanager
+    def session_for(self, websocket: WebSocket) -> Generator[SessionId, None, None]:
+        sid = SessionId(websocket.path_params[self.route_sid_param_name])
+        addr = websocket.client
+        if sid in self.sid_to_addr and self.sid_to_addr[sid] != addr:
+            logger.warning(
+                "Session %s already in use by %r, attempted reuse by %r",
+                sid,
+                self.sid_to_addr[sid],
+                addr,
+            )
+            raise SessionException(
+                f"Session ID {sid} is already used by another client"
+            )
+        self.sid_to_addr[sid] = addr
+
+        yield sid
+
+        del self.sid_to_addr[sid]

--- a/src/modlunky2/web/api/framework/session.py
+++ b/src/modlunky2/web/api/framework/session.py
@@ -23,7 +23,8 @@ class SessionManager:
     def session_for(self, websocket: WebSocket) -> Generator[SessionId, None, None]:
         sid = SessionId(websocket.path_params[self.route_sid_param_name])
         addr = websocket.client
-        if sid in self.sid_to_addr and self.sid_to_addr[sid] != addr:
+
+        if sid in self.sid_to_addr:
             logger.warning(
                 "Session %s already in use by %r, attempted reuse by %r",
                 sid,
@@ -31,7 +32,7 @@ class SessionManager:
                 addr,
             )
             raise SessionException(
-                f"Session ID {sid} is already used by another client"
+                f"Session ID {sid} is currently being used by another connection"
             )
         self.sid_to_addr[sid] = addr
 

--- a/src/modlunky2/web/demo.py
+++ b/src/modlunky2/web/demo.py
@@ -58,7 +58,7 @@ async def app_lifespan(pub_manager: PubSubManager, _app: Starlette):
         tg.cancel_scope.cancel()
 
 
-def make_app() -> Starlette:
+def make_asgi_app() -> Starlette:
     topics = [PubSubTopic(TimeTick, ServiceLevel.MAY_DROP)]
     pub_manager = PubSubManager(topics)
     multiplexer = WSMultiplexer(

--- a/src/modlunky2/web/demo.py
+++ b/src/modlunky2/web/demo.py
@@ -1,6 +1,25 @@
+from serde import serde
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
+
+from modlunky2.web.api.framework.multiplexing import (
+    SendConnection,
+    WSMultiplexer,
+    WSMultiplexerRoute,
+)
 
 
 async def hello_world(_request: Request):
     return PlainTextResponse("Hello world!")
+
+
+@serde
+class EchoMessage:
+    message: str
+
+
+async def echo(connection: SendConnection, msg: EchoMessage):
+    await connection.send(msg)
+
+
+multiplexer = WSMultiplexer([WSMultiplexerRoute(EchoMessage, echo)])

--- a/src/modlunky2/web/demo.py
+++ b/src/modlunky2/web/demo.py
@@ -1,12 +1,23 @@
+from contextlib import asynccontextmanager
+from functools import partial
+import logging
+import time
+from typing import NoReturn
+from anyio import create_task_group, current_time, sleep
+from dataclasses import dataclass
 from serde import serde
-from starlette.requests import Request
-from starlette.responses import PlainTextResponse
-
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
 from modlunky2.web.api.framework.multiplexing import (
     SendConnection,
     WSMultiplexer,
     WSMultiplexerRoute,
 )
+from modlunky2.web.api.framework.pubsub import PubSubManager, PubSubTopic, ServiceLevel
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+logger = logging.getLogger("modlunky2")
 
 
 async def hello_world(_request: Request):
@@ -14,6 +25,7 @@ async def hello_world(_request: Request):
 
 
 @serde
+@dataclass
 class EchoMessage:
     message: str
 
@@ -22,4 +34,40 @@ async def echo(connection: SendConnection, msg: EchoMessage):
     await connection.send(msg)
 
 
-multiplexer = WSMultiplexer([WSMultiplexerRoute(EchoMessage, echo)])
+@serde
+@dataclass
+class TimeTick:
+    now: float
+
+
+async def ticker(pub_manager: PubSubManager) -> NoReturn:
+    period = 5  # in seconds
+    while True:
+        delay = period - current_time() % period
+        civil_time = time.time()
+
+        pub_manager.publish(TimeTick(civil_time))
+        await sleep(delay)
+
+
+@asynccontextmanager
+async def app_lifespan(pub_manager: PubSubManager, _app: Starlette):
+    async with create_task_group() as tg:
+        tg.start_soon(ticker, pub_manager)
+        yield
+        tg.cancel_scope.cancel()
+
+
+def make_app() -> Starlette:
+    topics = [PubSubTopic(TimeTick, ServiceLevel.MAY_DROP)]
+    pub_manager = PubSubManager(topics)
+    multiplexer = WSMultiplexer(
+        (WSMultiplexerRoute(EchoMessage, echo),) + pub_manager.multiplexer_routes
+    )
+    routes = [
+        Route("/", hello_world),
+        Mount("/echo", routes=[multiplexer.starlette_route]),
+    ]
+    return Starlette(
+        debug=True, routes=routes, lifespan=partial(app_lifespan, pub_manager)
+    )

--- a/src/modlunky2/web/demo.py
+++ b/src/modlunky2/web/demo.py
@@ -1,0 +1,6 @@
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+
+async def hello_world(_request: Request):
+    return PlainTextResponse("Hello world!")

--- a/src/modlunky2/web/service.py
+++ b/src/modlunky2/web/service.py
@@ -8,12 +8,13 @@ from hypercorn.asyncio import serve
 from hypercorn.config import Config as HypercornConfig
 from hypercorn.typing import ASGI3Framework
 
-import modlunky2.web.demo as demo
+from modlunky2.config import Config
+from modlunky2.web.demo import make_asgi_app
 
 
-def launch_in_thread() -> Callable[[], None]:
+def launch_in_thread(config: Config) -> Callable[[], None]:
     shutting_down = threading.Event()
-    thread = threading.Thread(target=_async_worker, args=(shutting_down,))
+    thread = threading.Thread(target=_async_worker, args=(config, shutting_down))
     thread.start()
 
     def callback():
@@ -23,10 +24,10 @@ def launch_in_thread() -> Callable[[], None]:
     return callback
 
 
-def _async_worker(shutting_down: threading.Event):
-    app = demo.make_app()
+def _async_worker(config: Config, shutting_down: threading.Event):
+    app = make_asgi_app()
     hypercorn_conf = HypercornConfig()
-    hypercorn_conf.bind = "127.0.0.1:9526"
+    hypercorn_conf.bind = f"127.0.0.1:{config.api_port}"
     hypercorn_conf.websocket_ping_interval = 30.0
 
     async def shutdown_trigger():

--- a/src/modlunky2/web/service.py
+++ b/src/modlunky2/web/service.py
@@ -2,12 +2,11 @@ import threading
 import typing
 from typing import Callable
 
-import anyio
+from anyio import run
+from anyio.to_thread import run_sync
 from hypercorn.asyncio import serve
 from hypercorn.config import Config as HypercornConfig
 from hypercorn.typing import ASGI3Framework
-from starlette.applications import Starlette
-from starlette.routing import Mount, Route
 
 import modlunky2.web.demo as demo
 
@@ -25,18 +24,13 @@ def launch_in_thread() -> Callable[[], None]:
 
 
 def _async_worker(shutting_down: threading.Event):
-    routes = [
-        Route("/", demo.hello_world),
-        Mount("/echo", routes=[demo.multiplexer.starlette_route]),
-    ]
-    app = Starlette(debug=True, routes=routes)
-
+    app = demo.make_app()
     hypercorn_conf = HypercornConfig()
     hypercorn_conf.bind = "127.0.0.1:9526"
     hypercorn_conf.websocket_ping_interval = 30.0
 
     async def shutdown_trigger():
-        await anyio.to_thread.run_sync(shutting_down.wait)
+        await run_sync(shutting_down.wait)
 
     async def _serve():
         await serve(
@@ -46,4 +40,4 @@ def _async_worker(shutting_down: threading.Event):
             shutdown_trigger=shutdown_trigger,
         )
 
-    anyio.run(_serve)
+    run(_serve)

--- a/src/modlunky2/web/service.py
+++ b/src/modlunky2/web/service.py
@@ -1,0 +1,46 @@
+import threading
+import typing
+from typing import Callable
+
+import anyio
+from hypercorn.asyncio import serve
+from hypercorn.config import Config as HypercornConfig
+from hypercorn.typing import ASGI3Framework
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+import modlunky2.web.demo as demo
+
+
+def launch_in_thread() -> Callable[[], None]:
+    shutting_down = threading.Event()
+    thread = threading.Thread(target=_async_worker, args=(shutting_down,))
+    thread.start()
+
+    def callback():
+        shutting_down.set()
+        thread.join()
+
+    return callback
+
+
+def _async_worker(shutting_down: threading.Event):
+    routes = [Route("/", demo.hello_world)]
+    app = Starlette(debug=True, routes=routes)
+
+    hypercorn_conf = HypercornConfig()
+    hypercorn_conf.bind = "127.0.0.1:9526"
+    hypercorn_conf.debug = True
+
+    async def shutdown_trigger():
+        await anyio.to_thread.run_sync(shutting_down.wait)
+
+    async def _serve():
+        await serve(
+            # Hypercorn's ASGI3Framework uses a more precise type than Starlette
+            typing.cast(ASGI3Framework, app),
+            hypercorn_conf,
+            shutdown_trigger=shutdown_trigger,
+        )
+
+    anyio.run(_serve)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/src/tests/web/api/framework/multiplexing_test.py
+++ b/src/tests/web/api/framework/multiplexing_test.py
@@ -58,6 +58,21 @@ def test_duplicate_session(client: TestClient):
             connection2.receive_json()
 
 
+def test_two_connections(client: TestClient):
+    connection1: WebSocketTestSession = client.websocket_connect("/123")
+    connection2: WebSocketTestSession = client.websocket_connect("/456")
+    with connection1, connection2:
+        connection1.send_json({"Person": {"name": "Roffy"}})
+        assert connection1.receive_json() == {
+            "Greeting": {"phrase": "hi Roffy from 123"}
+        }
+
+        connection2.send_json({"Person": {"name": "Colin"}})
+        assert connection2.receive_json() == {
+            "Greeting": {"phrase": "hi Colin from 456"}
+        }
+
+
 def test_skip_unrecognized(client: TestClient):
     connection: WebSocketTestSession = client.websocket_connect("/789")
     with connection:

--- a/src/tests/web/api/framework/multiplexing_test.py
+++ b/src/tests/web/api/framework/multiplexing_test.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from typing import Generator
+import pytest
+from serde import serde
+from starlette.applications import Starlette
+from starlette.testclient import TestClient, WebSocketTestSession
+from starlette.websockets import WebSocketDisconnect
+
+from modlunky2.web.api.framework.multiplexing import (
+    SendConnection,
+    WSMultiplexer,
+    WSMultiplexerRoute,
+)
+
+
+@serde
+@dataclass
+class Person:
+    name: str
+
+
+@serde
+@dataclass
+class Greeting:
+    phrase: str
+
+
+async def hello(connection: SendConnection, person: Person):
+    await connection.send(Greeting(f"hi {person.name} from {connection.session_id}"))
+
+
+@pytest.fixture(name="client")
+def make_client() -> Generator[TestClient, None, None]:
+    multiplexer = WSMultiplexer([WSMultiplexerRoute[Person](Person, hello)])
+    app = Starlette(routes=[multiplexer.starlette_route])
+    test_client = TestClient(app=app)
+    with test_client:
+        yield test_client
+
+
+def test_requests(client: TestClient):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json({"Person": {"name": "Ana"}})
+        assert connection.receive_json() == {"Greeting": {"phrase": "hi Ana from 123"}}
+
+        connection.send_json({"Person": {"name": "Terra"}})
+        assert connection.receive_json() == {
+            "Greeting": {"phrase": "hi Terra from 123"}
+        }
+
+
+def test_duplicate_session(client: TestClient):
+    connection1: WebSocketTestSession = client.websocket_connect("/456")
+    with connection1:
+        connection2: WebSocketTestSession = client.websocket_connect("/456")
+        with connection2:
+            with pytest.raises(WebSocketDisconnect, match=r"ID 456"):
+                connection2.receive_json()
+
+
+def test_skip_unrecognized(client: TestClient):
+    connection: WebSocketTestSession = client.websocket_connect("/789")
+    with connection:
+        connection.send_json({"Mysterious": {}})
+        connection.send_json({"Person": {"name": "Tina"}})
+        assert connection.receive_json() == {"Greeting": {"phrase": "hi Tina from 789"}}

--- a/src/tests/web/api/framework/multiplexing_test.py
+++ b/src/tests/web/api/framework/multiplexing_test.py
@@ -52,11 +52,10 @@ def test_requests(client: TestClient):
 
 def test_duplicate_session(client: TestClient):
     connection1: WebSocketTestSession = client.websocket_connect("/456")
-    with connection1:
-        connection2: WebSocketTestSession = client.websocket_connect("/456")
-        with connection2:
-            with pytest.raises(WebSocketDisconnect, match=r"ID 456"):
-                connection2.receive_json()
+    connection2: WebSocketTestSession = client.websocket_connect("/456")
+    with connection1, connection2:
+        with pytest.raises(WebSocketDisconnect, match=r"ID 456"):
+            connection2.receive_json()
 
 
 def test_skip_unrecognized(client: TestClient):

--- a/src/tests/web/api/framework/pubsub_test.py
+++ b/src/tests/web/api/framework/pubsub_test.py
@@ -1,7 +1,10 @@
+from contextlib import asynccontextmanager
+from anyio import create_memory_object_stream, create_task_group
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from dataclasses import dataclass
 from starlette.applications import Starlette
 from starlette.testclient import TestClient, WebSocketTestSession
-from typing import Any, Generator, Type, TypeVar
+from typing import Any, Generator, Type, TypeVar, cast
 import pytest
 from serde import serde
 
@@ -11,11 +14,13 @@ from modlunky2.web.api.framework.multiplexing import (
     WSMultiplexerRoute,
 )
 from modlunky2.web.api.framework.pubsub import (
+    _SessionCopier,
     PubSubManager,
     PubSubTopic,
     Published,
     ServiceLevel,
     Subscribe,
+    Unsubscribe,
 )
 from modlunky2.web.api.framework.serde_tag import (
     TagDeserializer,
@@ -54,6 +59,18 @@ async def echo_handler(connection: SendConnection, req: Echo) -> None:
     await connection.send(req)
 
 
+T = TypeVar("T")
+
+
+def from_published(tag_de: TagDeserializer, data: Any, typ: Type[T]) -> T:
+    pub = tag_de.from_tagged_dict(data)
+    assert isinstance(pub, Published)
+
+    msg = tag_de.from_tagged_dict(TaggedMessage(pub.message))
+    assert isinstance(msg, typ)
+    return msg
+
+
 @pytest.fixture(name="tag_de")
 def make_tag_de() -> TagDeserializer:
     return TagDeserializer([Echo, Notice, Published])
@@ -85,22 +102,7 @@ def test_not_subscribed(client: TestClient):
         # When the connection context exits, it asserts there are no messages in its queue
 
 
-T = TypeVar("T")
-
-
-def from_published(tag_de: TagDeserializer, data: Any, typ: Type[T]) -> T:
-    pub = tag_de.from_tagged_dict(data)
-    assert isinstance(pub, Published)
-
-    msg = tag_de.from_tagged_dict(TaggedMessage(pub.message))
-    assert isinstance(msg, typ)
-    return msg
-
-
-def test_one_subscribed(
-    client: TestClient,
-    tag_de: TagDeserializer,
-):
+def test_one_subscribed(client: TestClient, tag_de: TagDeserializer):
     connection: WebSocketTestSession = client.websocket_connect("/123")
     with connection:
         connection.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
@@ -113,10 +115,37 @@ def test_one_subscribed(
         assert got_msg == Notice(to_send)
 
 
-def test_two_subscribed(
-    client: TestClient,
-    tag_de: TagDeserializer,
-):
+def test_one_subscribed_duplicate(client: TestClient, tag_de: TagDeserializer):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+        # This duplication should be OK
+        connection.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+
+        to_send = "still ok"
+        connection.send_json(to_tagged_dict(Broadcast(to_send)))
+
+        data = connection.receive_json()
+        got_msg = from_published(tag_de, data, Notice)
+        assert got_msg == Notice(to_send)
+
+
+def test_unsubscribe_wo_sub(client: TestClient):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json(to_tagged_dict(Unsubscribe({Notice.__name__})))
+        connection.send_json(to_tagged_dict(Broadcast("can't hear this")))
+
+
+def test_unsubscribe_after_sub(client: TestClient):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+        connection.send_json(to_tagged_dict(Unsubscribe({Notice.__name__})))
+        connection.send_json(to_tagged_dict(Broadcast("not heard")))
+
+
+def test_two_subscribed(client: TestClient, tag_de: TagDeserializer):
     c1: WebSocketTestSession = client.websocket_connect("/123")
     c2: WebSocketTestSession = client.websocket_connect("/456")
     with c1:
@@ -153,3 +182,97 @@ def test_two_subscribed(
         data3 = c1.receive_json()
         got3 = from_published(tag_de, data3, Notice)
         assert got3 == Notice(to_send)
+
+
+@pytest.mark.parametrize("to_send", [Subscribe({"bogus"}), Unsubscribe({"bad"})])
+def test_subscribe_unknown(client: TestClient, to_send: Any):
+    with client:
+        connection: WebSocketTestSession = client.websocket_connect("/123")
+        with pytest.raises(ValueError, match=r"unknown topics"), connection:
+            connection.send_json(to_tagged_dict(to_send))
+            # This ensures we wait for the exception
+            connection.receive_json()
+
+
+def test_duplicate_topic_name():
+    topics = [
+        PubSubTopic(Notice, ServiceLevel.MAY_DROP),
+        PubSubTopic(Notice, ServiceLevel.MUST_DELIVER),
+    ]
+    with pytest.raises(ValueError, match=r"more than once"):
+        PubSubManager(topics)
+
+
+def test_publish_unknown():
+    pub_manager = PubSubManager([PubSubTopic(Notice, ServiceLevel.MUST_DELIVER)])
+    with pytest.raises(ValueError, match=r"unknown"):
+        pub_manager.publish(Broadcast("shouldn't work"))
+
+
+@dataclass
+class FakeSendConnection:
+    _send: MemoryObjectSendStream[Published]
+
+    async def send(self, pub: Published):
+        await self._send.send(pub)
+
+
+@dataclass
+class CopierFixture:
+    copier: _SessionCopier
+    receive: MemoryObjectReceiveStream[Published]
+
+
+@asynccontextmanager
+async def make_copier_fixture():
+    # Note: We use a context manager to safely manage the task group
+
+    send, receive = create_memory_object_stream(1, Published)
+    connection = cast(SendConnection, FakeSendConnection(send))
+    copier = _SessionCopier(connection)
+
+    async with send, receive, create_task_group() as tg:
+        await tg.start(copier.run)
+
+        yield CopierFixture(copier, receive)
+
+        # Stop the copier
+        tg.cancel_scope.cancel()
+
+    # Make sure there's nothing left in the stream
+    assert receive.statistics().current_buffer_used == 0
+
+
+@pytest.mark.anyio
+async def test_copier_must_deliver():
+    async with make_copier_fixture() as fix:
+        fix.copier.send(ServiceLevel.MUST_DELIVER, Published({"started": True}))
+        assert await fix.receive.receive() == Published({"started": True})
+
+
+@pytest.mark.anyio
+async def test_copier_may_drop():
+    async with make_copier_fixture() as fix:
+        fix.copier.send(ServiceLevel.MAY_DROP, Published({"kept": True}))
+        assert await fix.receive.receive() == Published({"kept": True})
+
+
+@pytest.mark.anyio
+async def test_copier_priority_case1():
+    async with make_copier_fixture() as fix:
+        fix.copier.send(ServiceLevel.MUST_DELIVER, Published({"clogging": True}))
+        fix.copier.send(ServiceLevel.MAY_DROP, Published({"buffered": True}))
+        fix.copier.send(ServiceLevel.MUST_DELIVER, Published({"must_keep": True}))
+        for k in ["clogging", "buffered", "must_keep"]:
+            assert await fix.receive.receive() == Published({k: True})
+
+
+@pytest.mark.anyio
+async def test_copier_priority_case2():
+    async with make_copier_fixture() as fix:
+        fix.copier.send(ServiceLevel.MAY_DROP, Published({"clogging": True}))
+        fix.copier.send(ServiceLevel.MAY_DROP, Published({"dropped": True}))
+        fix.copier.send(ServiceLevel.MUST_DELIVER, Published({"must_keep_1": True}))
+        fix.copier.send(ServiceLevel.MUST_DELIVER, Published({"must_keep_2": True}))
+        for k in ["clogging", "must_keep_1", "must_keep_2"]:
+            assert await fix.receive.receive() == Published({k: True})

--- a/src/tests/web/api/framework/pubsub_test.py
+++ b/src/tests/web/api/framework/pubsub_test.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from starlette.applications import Starlette
 from starlette.testclient import TestClient, WebSocketTestSession
-from typing import Generator
+from typing import Any, Generator, Type, TypeVar
 import pytest
 from serde import serde
 
@@ -26,6 +26,12 @@ from modlunky2.web.api.framework.serde_tag import (
 
 @serde
 @dataclass
+class Echo:
+    msg: str
+
+
+@serde
+@dataclass
 class Broadcast:
     announcement: str
 
@@ -44,9 +50,13 @@ class Broadcaster:
         self.manager.publish(Notice(req.announcement))
 
 
+async def echo_handler(connection: SendConnection, req: Echo) -> None:
+    await connection.send(req)
+
+
 @pytest.fixture(name="tag_de")
 def make_tag_de() -> TagDeserializer:
-    return TagDeserializer([Notice, Published])
+    return TagDeserializer([Echo, Notice, Published])
 
 
 @pytest.fixture(name="client")
@@ -55,7 +65,10 @@ def make_client() -> Generator[TestClient, None, None]:
 
     broadcaster = Broadcaster(manager)
     multiplexer = WSMultiplexer(
-        (WSMultiplexerRoute[Broadcast](Broadcast, broadcaster.handler),)
+        (
+            WSMultiplexerRoute[Broadcast](Broadcast, broadcaster.handler),
+            WSMultiplexerRoute[Echo](Echo, echo_handler),
+        )
         + manager.multiplexer_routes
     )
 
@@ -72,6 +85,18 @@ def test_not_subscribed(client: TestClient):
         # When the connection context exits, it asserts there are no messages in its queue
 
 
+T = TypeVar("T")
+
+
+def from_published(tag_de: TagDeserializer, data: Any, typ: Type[T]) -> T:
+    pub = tag_de.from_tagged_dict(data)
+    assert isinstance(pub, Published)
+
+    msg = tag_de.from_tagged_dict(TaggedMessage(pub.message))
+    assert isinstance(msg, typ)
+    return msg
+
+
 def test_one_subscribed(
     client: TestClient,
     tag_de: TagDeserializer,
@@ -84,8 +109,47 @@ def test_one_subscribed(
         connection.send_json(to_tagged_dict(Broadcast(to_send)))
 
         data = connection.receive_json()
-        got_pub = tag_de.from_tagged_dict(data)
-        assert isinstance(got_pub, Published)
-
-        got_msg = tag_de.from_tagged_dict(TaggedMessage(got_pub.message))
+        got_msg = from_published(tag_de, data, Notice)
         assert got_msg == Notice(to_send)
+
+
+def test_two_subscribed(
+    client: TestClient,
+    tag_de: TagDeserializer,
+):
+    c1: WebSocketTestSession = client.websocket_connect("/123")
+    c2: WebSocketTestSession = client.websocket_connect("/456")
+    with c1:
+        with c2:
+            c1.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+            c2.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+
+            # WebSocketTestSession.send_json() doesn't wait for the message to be processed before returning.
+            # So, we use echos to ensure both Subscribe requests have been processed.
+            echo1 = to_tagged_dict(Echo("yo"))
+            c1.send_json(echo1)
+            assert c1.receive_json() == echo1
+
+            echo2 = to_tagged_dict(Echo("hi"))
+            c2.send_json(echo2)
+            assert c2.receive_json() == echo2
+
+            # Make the publish event happen
+            to_send = "you two"
+            c2.send_json(to_tagged_dict(Broadcast(to_send)))
+
+            data1 = c1.receive_json()
+            got1 = from_published(tag_de, data1, Notice)
+            assert got1 == Notice(to_send)
+
+            data2 = c2.receive_json()
+            got2 = from_published(tag_de, data2, Notice)
+            assert got2 == Notice(to_send)
+
+        # Try publishing after a client disconnected
+        to_send = "just us"
+        c1.send_json(to_tagged_dict(Broadcast(to_send)))
+
+        data3 = c1.receive_json()
+        got3 = from_published(tag_de, data3, Notice)
+        assert got3 == Notice(to_send)

--- a/src/tests/web/api/framework/pubsub_test.py
+++ b/src/tests/web/api/framework/pubsub_test.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+from starlette.applications import Starlette
+from starlette.testclient import TestClient, WebSocketTestSession
+from typing import Generator
+import pytest
+from serde import serde
+
+from modlunky2.web.api.framework.multiplexing import (
+    SendConnection,
+    WSMultiplexer,
+    WSMultiplexerRoute,
+)
+from modlunky2.web.api.framework.pubsub import (
+    PubSubManager,
+    PubSubTopic,
+    Published,
+    ServiceLevel,
+    Subscribe,
+)
+from modlunky2.web.api.framework.serde_tag import (
+    TagDeserializer,
+    TaggedMessage,
+    to_tagged_dict,
+)
+
+
+@serde
+@dataclass
+class Broadcast:
+    announcement: str
+
+
+@serde
+@dataclass
+class Notice:
+    message: str
+
+
+@dataclass
+class Broadcaster:
+    manager: PubSubManager
+
+    async def handler(self, _connection: SendConnection, req: Broadcast) -> None:
+        self.manager.publish(Notice(req.announcement))
+
+
+@pytest.fixture(name="tag_de")
+def make_tag_de() -> TagDeserializer:
+    return TagDeserializer([Notice, Published])
+
+
+@pytest.fixture(name="client")
+def make_client() -> Generator[TestClient, None, None]:
+    manager = PubSubManager([PubSubTopic(Notice, ServiceLevel.MUST_DELIVER)])
+
+    broadcaster = Broadcaster(manager)
+    multiplexer = WSMultiplexer(
+        (WSMultiplexerRoute[Broadcast](Broadcast, broadcaster.handler),)
+        + manager.multiplexer_routes
+    )
+
+    app = Starlette(routes=[multiplexer.starlette_route])
+    test_client = TestClient(app=app)
+    with test_client:
+        yield test_client
+
+
+def test_not_subscribed(client: TestClient):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json(to_tagged_dict(Broadcast("not listening")))
+        # When the connection context exits, it asserts there are no messages in its queue
+
+
+def test_one_subscribed(
+    client: TestClient,
+    tag_de: TagDeserializer,
+):
+    connection: WebSocketTestSession = client.websocket_connect("/123")
+    with connection:
+        connection.send_json(to_tagged_dict(Subscribe({Notice.__name__})))
+
+        to_send = "listen up"
+        connection.send_json(to_tagged_dict(Broadcast(to_send)))
+
+        data = connection.receive_json()
+        got_pub = tag_de.from_tagged_dict(data)
+        assert isinstance(got_pub, Published)
+
+        got_msg = tag_de.from_tagged_dict(TaggedMessage(got_pub.message))
+        assert got_msg == Notice(to_send)

--- a/src/tests/web/api/framework/serde_tag_test.py
+++ b/src/tests/web/api/framework/serde_tag_test.py
@@ -1,0 +1,84 @@
+from __future__ import annotations  # PEP 563
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import Any, Dict
+import pytest
+
+from serde import serde
+
+from modlunky2.web.api.framework.serde_tag import (
+    TagException,
+    TagDeserializer,
+    to_tagged_dict,
+)
+
+
+@serde
+@dataclass
+class A:
+    kind: str
+    a_num: int
+
+
+@serde
+@dataclass
+class B:
+    kind: str
+    a_str: str
+
+
+@serde
+@dataclass
+class Rogue:
+    kind: str
+    a_float: float
+
+
+class NotSerde:
+    pass
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [A("A", 3), B("B", "woah")],
+)
+def test_round_trip(obj: Any):
+    de = TagDeserializer([A, B])
+    assert de.from_tagged_dict(to_tagged_dict(obj)) == obj
+
+
+@pytest.mark.parametrize(
+    "data,obj",
+    [
+        ({"A": {"kind": "hi", "a_num": 23}}, A("hi", 23)),
+        ({"B": {"kind": "bye", "a_str": "what"}}, B("bye", "what")),
+    ],
+)
+def test_ok_dict(data: Dict[str, Any], obj: Any):
+    de = TagDeserializer([A, B])
+    assert de.from_tagged_dict(data) == obj
+    assert to_tagged_dict(obj) == data
+
+
+@pytest.mark.parametrize(
+    "data,expectation",
+    [
+        (
+            {"C": {"some": "thing"}},
+            pytest.raises(TagException, match=r"isn't a known type"),
+        ),
+        (
+            {"A": {"kind": "thing", "a_num": 99}, "more": 3},
+            pytest.raises(TagException, match=r"expected 1"),
+        ),
+    ],
+)
+def test_bad_dict(data: Dict[str, Any], expectation: AbstractContextManager[None]):
+    de = TagDeserializer([A, B])
+    with expectation:
+        de.from_tagged_dict(data)
+
+
+def test_bad_type():
+    with pytest.raises(TagException, match=r"isn't deserializable"):
+        TagDeserializer([NotSerde])

--- a/src/tests/web/api/framework/session_test.py
+++ b/src/tests/web/api/framework/session_test.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import pytest
 from starlette.datastructures import Address
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketDisconnect
 from typing import Dict, cast
 
 from modlunky2.web.api.framework.session import (
@@ -44,6 +44,26 @@ def test_two_sessions_ok():
         assert got_sid1 == sid1
         with manager.session_for(websocket2) as got_sid2:
             assert got_sid2 == sid2
+
+
+def test_reuse_after_disconnect():
+    sid = SessionId("654")
+    websocket = cast(WebSocket, FakeWebSocket({PARAM_NAME: sid}, Address("local", 987)))
+
+    manager = SessionManager(PARAM_NAME)
+    # We use try/except because pyright doesn't know pytest.raises() swallows exceptions
+    try:
+        with manager.session_for(websocket) as got_sid:
+            assert got_sid == sid
+            raise WebSocketDisconnect()
+    except WebSocketDisconnect:
+        pass
+    else:
+        # This shouldn't be reached
+        assert False
+
+    with manager.session_for(websocket) as got_sid:
+        assert got_sid == sid
 
 
 @pytest.mark.parametrize(

--- a/src/tests/web/api/framework/session_test.py
+++ b/src/tests/web/api/framework/session_test.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+import pytest
+from starlette.datastructures import Address
+from starlette.websockets import WebSocket
+from typing import Dict, cast
+
+from modlunky2.web.api.framework.session import (
+    SessionException,
+    SessionId,
+    SessionManager,
+)
+
+
+@dataclass
+class FakeWebSocket:
+    path_params: Dict[str, str]
+    client: Address
+
+
+PARAM_NAME = "sid"
+
+
+@pytest.mark.parametrize("sid", [SessionId("123"), SessionId("abc")])
+def test_one_session(sid: SessionId):
+    websocket = cast(WebSocket, FakeWebSocket({PARAM_NAME: sid}, Address("local", 456)))
+
+    manager = SessionManager(PARAM_NAME)
+    with manager.session_for(websocket) as got_sid:
+        assert got_sid == sid
+
+
+def test_two_sessions_ok():
+    sid1 = SessionId("123")
+    sid2 = SessionId("456")
+    websocket1 = cast(
+        WebSocket, FakeWebSocket({PARAM_NAME: sid1}, Address("local", 1011))
+    )
+    websocket2 = cast(
+        WebSocket, FakeWebSocket({PARAM_NAME: sid2}, Address("local", 2022))
+    )
+
+    manager = SessionManager(PARAM_NAME)
+    with manager.session_for(websocket1) as got_sid1:
+        assert got_sid1 == sid1
+        with manager.session_for(websocket2) as got_sid2:
+            assert got_sid2 == sid2
+
+
+@pytest.mark.parametrize(
+    "sid,client1,client2",
+    [
+        # Duplicate from different clients
+        (
+            SessionId("123"),
+            Address("local", 1011),
+            Address("local", 2022),
+        ),
+        # Duplicate from the same client
+        (
+            SessionId("abc"),
+            Address("local", 1011),
+            Address("local", 1011),
+        ),
+    ],
+)
+def test_two_sessions_conflict(sid: SessionId, client1: Address, client2: Address):
+    websocket1 = cast(WebSocket, FakeWebSocket({PARAM_NAME: sid}, client1))
+    websocket2 = cast(WebSocket, FakeWebSocket({PARAM_NAME: sid}, client2))
+
+    manager = SessionManager(PARAM_NAME)
+    with pytest.raises(SessionException):
+        with manager.session_for(websocket1) as got_sid1:
+            assert got_sid1 == sid
+            with manager.session_for(websocket2):
+                pass


### PR DESCRIPTION
I think this is at a reasonable milestone to start merging in (or close to it)

* Starts a server on port 9526 (edit: now configurable in `config.json` via `api-port`)
* "Tagged" messages, currently `{"SomeTypeName": {"some_field": True}}`
* Multiplexed dispatch of incoming messages, based on their type
* Clients choose their own session ID, baked into the path
  * Just used to simplify internals a bit
  * Server will reject connections if the session ID is currently in-use
* Simple PubSub system
  * No persistence or reconnect support
  * Client sends
    * `{"Subscribe": {"topics": ["Foo", "Bar"]}}`
    * `{"Unsubscribe": {"topics": ["Foo", "Bar"]}}`
  * Server sends `{"Published": {"Foo": {"widgets": 3}}}`
  * Python API differentiates between priorities, delivers messages in-order
    * May drop -- Not guaranteed to reach client
    * Must deliver -- Unbounded buffer. All of these messages will be sent before any "may drop" messages
* Uses
  * [Hypercorn](https://pgjones.gitlab.io/hypercorn/) -- ASGI server
  * [Starlette](https://www.starlette.io/) -- ASGI framework
  * [AnyIO](https://anyio.readthedocs.io/en/stable/) -- structured concurrency
  * [typing_extensions](https://github.com/python/typing/tree/master/typing_extensions) - compatibility for `typing`
* Nice things
  * 100% compliant with pyright "basic" type-checking
  * 100% branch coverage for framework module (pytest-cov)

I expect this will blow up on older Python versions and I'll need to sprinkle in some `typing_extensions` on it