### PR TITLE
Improve config file stuff

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import dataclasses
+from copy import deepcopy
 from dataclasses import dataclass
 import json
 import logging
@@ -115,7 +115,7 @@ T = TypeVar("T")
 @dataclass
 class CommonTrackerConfig:
     def clone(self: T) -> T:
-        return dataclasses.replace(self)
+        return deepcopy(self)
 
 
 class SaveableCategory(Enum):

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -7,7 +7,7 @@ import logging
 import shutil
 import time
 from enum import Enum
-from typing import Any, Dict, List, Optional, TypeVar, Set
+from typing import List, Optional, TypeVar, Set
 
 try:
     import winreg
@@ -149,6 +149,23 @@ class TrackersConfig:
     pacifist: PacifistTrackerConfig = field(default_factory=PacifistTrackerConfig)
 
 
+@serialize  # Note: these fields aren't renamed for historical reasons
+@deserialize
+@dataclass
+class CustomLevelSaveFormat:
+    name: str
+    room_template_format: str
+    include_vanilla_setrooms: bool
+
+    @classmethod
+    def level_sequence(cls):
+        return cls("LevelSequence", "setroom{y}_{x}", True)
+
+    @classmethod
+    def vanilla(cls):
+        return cls("Vanilla setroom [warning]", "setroom{y}-{x}", False)
+
+
 @serialize(rename_all="spinalcase")
 @deserialize(rename_all="spinalcase")
 @dataclass
@@ -181,10 +198,10 @@ class Config:
     trackers: TrackersConfig = field(default_factory=TrackersConfig)
     show_packing: bool = field(default=False, skip_if_default=True)
     level_editor_tab: Optional[int] = field(default=None, skip_if_default=True)
-    custom_level_editor_custom_save_formats: Optional[List[Dict[str, Any]]] = field(
-        default=None, skip_if_default=True
+    custom_level_editor_custom_save_formats: List[CustomLevelSaveFormat] = field(
+        default_factory=list
     )
-    custom_level_editor_default_save_format: Optional[Dict[str, Any]] = field(
+    custom_level_editor_default_save_format: Optional[CustomLevelSaveFormat] = field(
         default=None, skip_if_default=True
     )
     command_prefix: Optional[List[str]] = field(default=None, skip_if_default=True)

--- a/src/modlunky2/ui/levels/tab.py
+++ b/src/modlunky2/ui/levels/tab.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-lines
 
+import dataclasses
 import datetime
 import glob
 import logging
@@ -16,9 +17,14 @@ from fnmatch import fnmatch
 from pathlib import Path
 from shutil import copyfile
 from tkinter import ttk
+from typing import Optional
+from typing_extensions import Self
 
 import pyperclip
 from PIL import Image, ImageDraw, ImageEnhance, ImageTk
+from serde.de import deserialize
+import serde.json
+from serde.se import serialize
 
 from modlunky2.config import Config
 from modlunky2.constants import BASE_DIR
@@ -45,11 +51,13 @@ class EditorType(Enum):
     CUSTOM_LEVELS = "custom_levels"
 
 
+@serialize
+@deserialize
+@dataclass
 class CustomLevelSaveFormat:
-    def __init__(self, name, room_template_format, include_vanilla_setrooms):
-        self.name = name or room_template_format
-        self.room_template_format = room_template_format
-        self.include_vanilla_setrooms = include_vanilla_setrooms
+    name: str
+    room_template_format: str
+    include_vanilla_setrooms: bool
 
     @classmethod
     def level_sequence(cls):
@@ -59,25 +67,12 @@ class CustomLevelSaveFormat:
     def vanilla(cls):
         return cls("Vanilla setroom [warning]", "setroom{y}-{x}", False)
 
-    def to_json(self):
-        return {
-            "name": self.name,
-            "room_template_format": self.room_template_format,
-            "include_vanilla_setrooms": self.include_vanilla_setrooms,
-        }
+    def to_json(self) -> str:
+        return serde.json.to_json(self)
 
     @classmethod
-    def from_json(cls, json):
-        return cls(
-            json["name"], json["room_template_format"], json["include_vanilla_setrooms"]
-        )
-
-    def __eq__(self, other):
-        return (
-            self.name == other.name
-            and self.room_template_format == other.room_template_format
-            and self.include_vanilla_setrooms == other.include_vanilla_setrooms
-        )
+    def from_json(cls, json: str) -> Self:
+        return serde.json.from_json(cls, json)
 
 
 class LevelsTab(Tab):


### PR DESCRIPTION
pyserde 0.6.0 added a `field()` function that wraps `dataclasses.field()`. We can use it to tidy config.py substantially.

That release also added `@serde`, which applies `@deserialize`, `@serialize`, and `@dataclass`. However, I'm not including it here. I'm seeing behavior changes and haven't debugged why. It's also slightly less helpful because it 'hides' `@dataclass` from type checkers; I hope to apply `@dataclass_transform` ([PEP 681](https://www.python.org/dev/peps/pep-0681/), available in `typing_extensions`) in another change (preferably upstream) to make it prettier.

I've also refactored the "custom level editor" config to use pyserde. I think it simplifies the code a lot. I'm a bit worried about errors in the refactoring... I split it into two commits:

* Use pyserde instead of hand-rolled json. This is pretty self-contained
* Use config directly instead of maintaining copies. This is more invasive

The change to use deepcopy should have no effect on the current state. However, it's more foolproof if/when we add structures inside.

I've also made config.py pass pyright `basic` checks plus `reportMissingTypeArgument`. This is sort of a pilot for updating the codebase. I'm not happy with the sprinkled checks to narrow `Optional` types and am trying to formulate a more tenable plan (likely including [type guards](https://www.python.org/dev/peps/pep-0647/)).