### PR TITLE
Tracker low% updates

### DIFF
--- a/src/modlunky2/category/chain/common.py
+++ b/src/modlunky2/category/chain/common.py
@@ -146,13 +146,13 @@ class ChainMixin:
 
         while cur_hand_uid != 0:
             cur_hand = game_state.instance_id_to_pointer.get(cur_hand_uid)
-            if cur_hand is None or not cur_hand.present():
+            if cur_hand is None:
                 return
 
             yield cur_hand
 
             cur_hand = cur_hand.as_poly_type(Player)
-            if not cur_hand.present():
+            if cur_hand is None:
                 return
             cur_hand_uid = cur_hand.value.linked_companion_child
 
@@ -167,7 +167,7 @@ class ChainMixin:
 
             for item_uid in companion_items:
                 item = game_state.instance_id_to_pointer.get(item_uid)
-                if item is None or not item.present():
+                if item is None:
                     continue
                 if item.value.type.id is item_type:
                     return True

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -181,8 +181,8 @@ class EntityReduced:
 
 @dataclass(frozen=True)
 class Entity(EntityReduced):
-    overlay: PolyPointer[EntityReduced] = struct_field(
-        0x10, poly_pointer(dc_struct), default_factory=PolyPointer.make_empty
+    overlay: Optional[PolyPointer[EntityReduced]] = struct_field(
+        0x10, poly_pointer(dc_struct), default=None
     )
 
 

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -41,6 +41,7 @@ class Label(Enum):
     EGGPLANT = LabelMetadata("Eggplant", percent_priority=1)
     DEATH = LabelMetadata("Death", percent_priority=2, terminus=True)
     JUNGLE_TEMPLE = LabelMetadata("Jungle/Temple")
+    VOLCANA_TEMPLE = LabelMetadata("Volcana/Temple")
     DUAT = LabelMetadata("Duat")
     ABZU = LabelMetadata("Abzu")
     MILLIONAIRE = LabelMetadata("Millionaire")
@@ -64,7 +65,7 @@ class Label(Enum):
 class _CachedText:
     hide_early: bool
     text: str
-    excluded_categories: FrozenSet[Label]
+    excluded: FrozenSet[Label]
 
 
 class RunLabel:
@@ -93,6 +94,7 @@ class RunLabel:
     _HIDES = defaultdict(set)
     _HIDES[Label.EGGPLANT] |= {Label.SUNKEN_CITY}
     _HIDES[Label.LOW] |= {Label.NO_TELEPORTER, Label.NO_JETPACK, Label.ANY}
+    _HIDES[Label.CHAIN] |= {Label.JUNGLE_TEMPLE, Label.VOLCANA_TEMPLE}
     _HIDES[Label.NO_GOLD] |= {Label.ANY}
     _HIDES[Label.PACIFIST] |= {Label.ANY}
     _HIDES[Label.MILLIONAIRE] |= {Label.ANY}

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -187,11 +187,6 @@ class RunLabel:
             if needle in vis and vis.isdisjoint(need):
                 vis.discard(needle)
 
-        # Handle ICS% and No% hiding Low%. We do this here to avoid multiple passes over _HIDES/duplicating _HIDES[Label.LOW]
-        if not vis.isdisjoint({Label.NO, Label.ICE_CAVES_SHORTCUT}):
-            vis.discard(Label.LOW)
-            vis -= self._HIDES[Label.LOW]
-
         # Handle No% hiding No Gold. We do this here to avoid multiple passes over _HIDES.
         if Label.NO in vis:
             vis.discard(Label.NO_GOLD)
@@ -202,6 +197,11 @@ class RunLabel:
                 vis.discard(Label.SUNKEN_CITY)
             else:
                 vis.discard(Label.CHAIN)
+
+        # Handle ICS% and No% hiding Low%. We do this here to avoid multiple passes over _HIDES/duplicating _HIDES[Label.LOW]
+        if not vis.isdisjoint({Label.NO, Label.ICE_CAVES_SHORTCUT}):
+            vis.discard(Label.LOW)
+            vis -= self._HIDES[Label.LOW]
 
         return vis
 

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -224,17 +224,17 @@ class RunLabel:
         return found
 
     def text(self, hide_early: bool, excluded_categories: Set[SaveableCategory]) -> str:
-        excluded_categories = frozenset(
+        excluded = frozenset(
             [Label.from_saveable_category(sc) for sc in excluded_categories]
         )
         if (
             self._cached_text is not None
             and self._cached_text.hide_early == hide_early
-            and self._cached_text.excluded_categories == excluded_categories
+            and self._cached_text.excluded == excluded
         ):
             return self._cached_text.text
 
-        vis = self._visible(hide_early, excluded_categories)
+        vis = self._visible(hide_early, excluded)
         perc = self._percent(vis)
         parts = []
 
@@ -248,6 +248,6 @@ class RunLabel:
 
         text = " ".join(parts)
         self._cached_text = _CachedText(
-            hide_early=hide_early, text=text, excluded_categories=excluded_categories
+            hide_early=hide_early, text=text, excluded=excluded
         )
         return text

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -21,7 +21,7 @@ from modlunky2.mem.entities import (
     TELEPORT_ENTITIES,
 )
 from modlunky2.mem.memrauder.model import PolyPointer
-from modlunky2.mem.memrauder.msvc import UnorderedMap
+from modlunky2.mem.memrauder.spelunky2 import UidEntityMap
 from modlunky2.mem.state import (
     HudFlags,
     LoadingState,
@@ -185,7 +185,7 @@ class RunState:
         if not TELEPORT_ENTITIES.isdisjoint(prev_player_item_set):
             return True
 
-        if not player.overlay.present():
+        if player.overlay is None:
             return False
 
         overlay = player.overlay.value
@@ -202,7 +202,7 @@ class RunState:
 
         # We use a loop to handle player on a mount on an active floor
         overlay_poly = player.overlay
-        while overlay_poly.present():
+        while overlay_poly is not None:
             overlay = overlay_poly.as_type(Movable)
             if overlay is None:
                 break
@@ -286,12 +286,12 @@ class RunState:
     def update_has_mounted_tame(
         self,
         theme: Theme,
-        player_overlay: PolyPointer[Entity],
+        player_overlay: Optional[PolyPointer[Entity]],
     ):
         if not self.is_low_percent:
             return
 
-        if not player_overlay.present():
+        if player_overlay is None:
             return
 
         entity_type: EntityType = player_overlay.value.type.id
@@ -641,7 +641,7 @@ class RunState:
 
         for entity_uid in range(self.prev_next_uid, game_state.next_entity_uid):
             entity_poly = game_state.instance_id_to_pointer.get(entity_uid)
-            if entity_poly is None or not entity_poly.present():
+            if entity_poly is None:
                 continue
             if entity_poly.value.type is None:
                 continue
@@ -747,7 +747,7 @@ class RunState:
 
     def update_player_item_types(
         self,
-        instance_id_to_pointer: UnorderedMap[int, PolyPointer[Entity]],
+        instance_id_to_pointer: UidEntityMap,
         player: Player,
     ):
         item_types = set()
@@ -755,7 +755,7 @@ class RunState:
             return
         for item in player.items:
             entity_poly = instance_id_to_pointer.get(item)
-            if entity_poly is None or not entity_poly.present():
+            if entity_poly is None:
                 continue
 
             entity_type = entity_poly.value.type

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -512,6 +512,9 @@ class RunState:
         elif theme in [Theme.TIDE_POOL, Theme.ABZU]:
             self.world4_theme = Theme.TIDE_POOL
 
+        if self.world2_theme is Theme.VOLCANA and self.world4_theme is Theme.TEMPLE:
+            self.run_label.add(Label.VOLCANA_TEMPLE)
+
         if self.world2_theme is Theme.JUNGLE and self.world4_theme in {
             None,
             Theme.TEMPLE,

--- a/src/tests/mem/memrauder/test_dsl.py
+++ b/src/tests/mem/memrauder/test_dsl.py
@@ -33,7 +33,9 @@ class State:
     bool_tuple: Tuple[bool, ...] = struct_field(0x2, array(sc_bool, 3))
     player_set: FrozenSet[Player] = struct_field(0x5, array(dc_struct, 2))
     pointed_int: Optional[int] = struct_field(0xB, pointer(sc_uint16))
-    poly_player: PolyPointer[Player] = struct_field(0x13, poly_pointer(dc_struct))
+    poly_player: Optional[PolyPointer[Player]] = struct_field(
+        0x13, poly_pointer(dc_struct)
+    )
 
 
 def test_player():

--- a/src/tests/mem/memrauder/test_model.py
+++ b/src/tests/mem/memrauder/test_model.py
@@ -225,10 +225,11 @@ LOWEST_BYTES_READER = BytesReader(b"\x00\x01\x02\x03")
     [(Supreme, Supreme(1)), (Middle, Middle(1, 2)), (Lowest, Lowest(1, 2, 3))],
 )
 def test_poly_pointer_castless(cls, expected_val):
-    pp_type = PolyPointerType(FieldPath(), PolyPointer[cls], DataclassStruct)
+    pp_type = PolyPointerType(FieldPath(), Optional[PolyPointer[cls]], DataclassStruct)
     pp_supreme = pp_type.from_bytes(
         SUPREME_POINTER_BYTES, MemContext(LOWEST_BYTES_READER)
     )
+    assert pp_supreme is not None
     assert pp_supreme.addr == SUPREME_POINTER_ADDR
     assert pp_supreme.value == expected_val
 
@@ -238,15 +239,19 @@ def test_poly_pointer_castless(cls, expected_val):
     [(Supreme, Supreme(1)), (Middle, Middle(1, 2)), (Lowest, Lowest(1, 2, 3))],
 )
 def test_poly_pointer_cast_down(cls, expected_val):
-    pp_type = PolyPointerType(FieldPath(), PolyPointer[Supreme], DataclassStruct)
+    pp_type = PolyPointerType(
+        FieldPath(), Optional[PolyPointer[Supreme]], DataclassStruct
+    )
     pp_supreme = pp_type.from_bytes(
         SUPREME_POINTER_BYTES, MemContext(LOWEST_BYTES_READER)
     )
+    assert pp_supreme is not None
 
     cast_val = pp_supreme.as_type(cls)
     assert cast_val == expected_val
 
     pp_poly = pp_supreme.as_poly_type(cls)
+    assert pp_poly is not None
 
     assert pp_poly.addr == SUPREME_POINTER_ADDR
     assert pp_poly.value == expected_val
@@ -257,16 +262,20 @@ def test_poly_pointer_cast_down(cls, expected_val):
     [(Supreme), (Middle), (Lowest)],
 )
 def test_poly_pointer_cast_up(cls):
-    pp_type = PolyPointerType(FieldPath(), PolyPointer[Lowest], DataclassStruct)
+    pp_type = PolyPointerType(
+        FieldPath(), Optional[PolyPointer[Lowest]], DataclassStruct
+    )
     pp_lowest = pp_type.from_bytes(
         SUPREME_POINTER_BYTES, MemContext(LOWEST_BYTES_READER)
     )
-    expected_val = Lowest(1, 2, 3)
+    assert pp_lowest is not None
 
+    expected_val = Lowest(1, 2, 3)
     cast_val = pp_lowest.as_type(cls)
     assert cast_val == expected_val
 
     pp_poly = pp_lowest.as_poly_type(cls)
+    assert pp_poly is not None
 
     assert pp_poly.addr == SUPREME_POINTER_ADDR
     assert pp_poly.value == expected_val

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -941,25 +941,27 @@ def test_world_themes_state(world, theme, expected_world2_theme, expected_world4
 
 
 @pytest.mark.parametrize(
-    "world,theme,world2_theme,starting_labels,expected_jt,",
+    "world,theme,world2_theme,starting_labels,expected_label,",
     [
-        # Volcana has no labels associated with it
-        (2, Theme.VOLCANA, None, {Label.ANY}, False),
+        # Volcana "plain" and V/T
+        (2, Theme.VOLCANA, None, {Label.ANY}, None),
+        (2, Theme.TIDE_POOL, Theme.VOLCANA, {Label.ANY}, None),
+        (2, Theme.TEMPLE, Theme.VOLCANA, {Label.ANY}, Label.VOLCANA_TEMPLE),
         # We eagerly assume J/T
-        (2, Theme.JUNGLE, None, {Label.ANY}, True),
+        (2, Theme.JUNGLE, None, {Label.ANY}, Label.JUNGLE_TEMPLE),
         (
             2,
             Theme.JUNGLE,
             Theme.JUNGLE,
             {Label.ANY},
-            True,
+            Label.JUNGLE_TEMPLE,
         ),
         (
             2,
             Theme.JUNGLE,
             Theme.JUNGLE,
             {Label.SUNKEN_CITY},
-            True,
+            Label.JUNGLE_TEMPLE,
         ),
         # We actually went J/T
         (
@@ -967,21 +969,21 @@ def test_world_themes_state(world, theme, expected_world2_theme, expected_world4
             Theme.TEMPLE,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.ANY},
-            True,
+            Label.JUNGLE_TEMPLE,
         ),
         (
             4,
             Theme.TEMPLE,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.SUNKEN_CITY},
-            True,
+            Label.JUNGLE_TEMPLE,
         ),
         (
             4,
             Theme.TEMPLE,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.ANY},
-            True,
+            Label.JUNGLE_TEMPLE,
         ),
         # We went Jungle, but J/T is now impossible
         (
@@ -989,21 +991,21 @@ def test_world_themes_state(world, theme, expected_world2_theme, expected_world4
             Theme.TIDE_POOL,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.ANY},
-            False,
+            None,
         ),
         (
             4,
             Theme.TIDE_POOL,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.SUNKEN_CITY},
-            False,
+            None,
         ),
         (
             4,
             Theme.TIDE_POOL,
             Theme.JUNGLE,
             {Label.JUNGLE_TEMPLE, Label.ANY},
-            False,
+            None,
         ),
     ],
 )
@@ -1012,15 +1014,20 @@ def test_world_themes_label(
     theme,
     world2_theme,
     starting_labels,
-    expected_jt,
+    expected_label,
 ):
     run_state = RunState()
     run_state.run_label = RunLabel(starting=starting_labels)
     run_state.world2_theme = world2_theme
     run_state.update_world_themes(world, theme)
 
-    is_jt = Label.JUNGLE_TEMPLE in run_state.run_label._set
-    assert is_jt == expected_jt
+    if expected_label is Label.JUNGLE_TEMPLE:
+        assert Label.JUNGLE_TEMPLE in run_state.run_label._set
+    if expected_label is Label.VOLCANA_TEMPLE:
+        assert Label.VOLCANA_TEMPLE in run_state.run_label._set
+    if expected_label is None:
+        assert Label.JUNGLE_TEMPLE not in run_state.run_label._set
+        assert Label.VOLCANA_TEMPLE not in run_state.run_label._set
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Visible changes
* Update clover rule for low%
* Add support for Volcana/Temple
* Chain Low% hides Jungle/Temple and Volcana/Temple
* Fix naming of Chain No% Abzu/Duat

I also did some typing cleanup while I was in the area. The big change is `PolyPointer` no longer has a weird 'empty' version. That simplifies checks and makes the `value` a plain value (vs `Optional`).

Other typing tweaks:

* Pyright doesn't like it when a variable has an explicit type and an incompatible one is assigned to it
* `Optional[Foo]` is not assignable to `Type[Any]` because `UnionType` is not assignable to `Type` (because `Union` can't be instantiated / isn't callable)
