### PR TITLE
Handle unset install-dir better

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -87,7 +87,7 @@ def check_registry_for_spel2():
     return None
 
 
-def guess_install_dir(exe_dir=None):
+def guess_install_dir(exe_dir: Optional[Path] = None):
     if exe_dir:
         logger.info("Checking if Spelunky 2 is installed in %s", exe_dir)
         if (exe_dir / EXE_NAME).exists():

--- a/src/modlunky2/ui/extract.py
+++ b/src/modlunky2/ui/extract.py
@@ -243,6 +243,9 @@ class ExtractTab(Tab):
         ToolTip(self.button_extract, ("Extract assets from EXE."))
 
     def open_extract_dir(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         extract_dir = self.modlunky_config.install_dir / MODS / EXTRACTED_DIR
         open_directory(extract_dir)
 
@@ -277,6 +280,9 @@ class ExtractTab(Tab):
 
     def get_exes(self):
         exes = []
+        if not self.modlunky_config.install_dir:
+            return exes
+
         # Don't recurse forever. 3 levels should be enough
         exes.extend(self.modlunky_config.install_dir.glob("*.exe"))
         exes.extend(self.modlunky_config.install_dir.glob("*/*.exe"))

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -107,6 +107,9 @@ class DestinationChooser(ttk.Frame):
         file_chooser_browse.grid(row=3, column=0, pady=5, padx=5, sticky="nsew")
 
     def browse(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         initial_dir = self.modlunky_config.install_dir / "Mods/Packs"
         if not initial_dir.exists():
             logger.critical("Expected Packs dir not found.")

--- a/src/modlunky2/ui/play/controls.py
+++ b/src/modlunky2/ui/play/controls.py
@@ -90,6 +90,9 @@ class ControlsFrame(ttk.Frame):
         self.play_tab.on_load()
 
     def open_packs(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         packs_dir = self.modlunky_config.install_dir / "Mods/Packs"
         if not packs_dir.exists():
             logger.info("Couldn't find Packs directory. Looked in %s", packs_dir)
@@ -107,6 +110,9 @@ class ControlsFrame(ttk.Frame):
         self.play_tab.packs_frame.cache_fyi_pack_details()
 
     def clear_cache(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         cache_dir = self.modlunky_config.install_dir / "Mods/Packs/.db"
         if not cache_dir.exists():
             logger.info("No cache directory found to remove. Looked in %s", cache_dir)

--- a/src/modlunky2/ui/play/pack.py
+++ b/src/modlunky2/ui/play/pack.py
@@ -15,6 +15,9 @@ logger = logging.getLogger("modlunky2")
 
 class Pack:
     def __init__(self, play_tab, parent, modlunky_config: Config, folder):
+        if not modlunky_config.install_dir:
+            raise ValueError("Config must have install-dir set")
+
         self.play_tab = play_tab
         self.modlunky_config = modlunky_config
         self.folder = folder
@@ -179,7 +182,7 @@ class Pack:
         self.buttons.grid(row=row, column=2, pady=0, padx=(5, 25), sticky="e")
 
     def render_buttons(self):
-        if not (self.modlunky_config.install_dir / "Mods/Packs" / self.folder).exists():
+        if (self.modlunky_config.install_dir / "Mods/Packs" / self.folder).exists():
             self.buttons.folder_button["state"] = tk.DISABLED
         else:
             self.buttons.folder_button["state"] = tk.NORMAL

--- a/src/modlunky2/ui/play/packs.py
+++ b/src/modlunky2/ui/play/packs.py
@@ -190,6 +190,9 @@ class PacksFrame(ScrollableLabelFrame):
 
     def get_packs(self):
         packs = []
+        if not self.modlunky_config.install_dir:
+            return packs
+
         packs_dir = self.modlunky_config.install_dir / "Mods/Packs"
         if not packs_dir.exists():
             return packs

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -1,5 +1,6 @@
 import configparser
 import logging
+from re import A
 import subprocess
 import tkinter as tk
 from tkinter import ttk
@@ -158,15 +159,17 @@ class PlayTab(Tab):
         self.button_play["state"] = tk.DISABLED
 
     def load_from_ini(self):
-        path = self.modlunky_config.install_dir / "playlunky.ini"
-        if path.exists():
-            with path.open() as ini_file:
-                try:
-                    self.ini = PlaylunkyConfig.from_ini(ini_file)
-                except configparser.Error:
-                    self.ini = PlaylunkyConfig()
-        else:
-            self.ini = PlaylunkyConfig()
+        self.ini = PlaylunkyConfig()
+        if self.modlunky_config.install_dir:
+            path = self.modlunky_config.install_dir / "playlunky.ini"
+            if path.exists():
+                with path.open() as ini_file:
+                    try:
+                        self.ini = PlaylunkyConfig.from_ini(ini_file)
+                    except configparser.Error:
+                        logger.warning(
+                            "Failed to parse playlunky config %s", path, exc_info=True
+                        )
 
         for options in SECTIONS.values():
             for option in options:
@@ -178,6 +181,9 @@ class PlayTab(Tab):
                 )
 
     def write_ini(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         path = self.modlunky_config.install_dir / "playlunky.ini"
 
         for options in SECTIONS.values():
@@ -229,6 +235,9 @@ class PlayTab(Tab):
                 load_order_file.write(f"--{pack}\n")
 
     def write_steam_appid(self):
+        if not self.modlunky_config.install_dir:
+            return
+
         path = self.modlunky_config.install_dir / "steam_appid.txt"
         with path.open("w") as handle:
             handle.write("418530")

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -1,6 +1,5 @@
 import configparser
 import logging
-from re import A
 import subprocess
 import tkinter as tk
 from tkinter import ttk

--- a/src/modlunky2/ui/settings.py
+++ b/src/modlunky2/ui/settings.py
@@ -108,7 +108,7 @@ class InstallDir(ttk.LabelFrame):
     def feeling_lucky(self):
         install_dir = guess_install_dir(self.modlunky_config.exe_dir)
         if install_dir:
-            self.install_dir_var.set(install_dir)
+            self.install_dir_var.set(str(install_dir))
             self.modlunky_config.install_dir = install_dir
             self.modlunky_config.save()
 

--- a/src/modlunky2/utils.py
+++ b/src/modlunky2/utils.py
@@ -1,9 +1,11 @@
 import contextlib
 import logging
+from pathlib import Path
 import sys
 import traceback
 import os
 import subprocess
+from typing import Optional
 import webbrowser
 import struct
 import zipfile
@@ -26,7 +28,9 @@ def is_windows():
     return "nt" in os.name
 
 
-def open_directory(directory):
+def open_directory(directory: Optional[Path]):
+    if not directory:
+        return
     if not directory.exists():
         return
 


### PR DESCRIPTION
This should fix #261 and hopefully fix some other latent bugs.

Notably, I've left a bunch of the packs code in its current state because it looks like packs usually shouldn't exist without `install_dir` set. I also suspect there's deeper issues if `install_dir` is set to `None` during a Pack object's lifetime.