### PR TITLE
Continue chain when missing Ankh & stunned in CoG

### DIFF
--- a/src/modlunky2/category/chain/sunken.py
+++ b/src/modlunky2/category/chain/sunken.py
@@ -7,7 +7,7 @@ from modlunky2.category.chain.common import (
     ChainStepEvaluator,
     ChainStepResult,
 )
-from modlunky2.mem.entities import EntityType
+from modlunky2.mem.entities import CharState, EntityType
 from modlunky2.mem.state import Screen, State, Theme, WinState
 
 
@@ -190,10 +190,15 @@ class DuatChain(SunkenChain):
             return self.in_progress(self.visit_world44_theme)
 
         # The player is destroyed when sacrificed
-        if game_state.items.players[0] is None:
+        player = game_state.items.players[0]
+        if player is None:
             return self.in_progress(self.keep_ankh)
 
-        if EntityType.ITEM_POWERUP_ANKH not in player_item_types:
+        # There are frames where the player is stunned on the altar and no longer has the Ankh.
+        # So, we only check for the Ankh in CoG while they're not stunned.
+        if (player.state is not CharState.STUNNED) and (
+            EntityType.ITEM_POWERUP_ANKH not in player_item_types
+        ):
             return self.failed()
 
         return self.in_progress(self.keep_ankh)

--- a/src/tests/category/chain/sunken_test.py
+++ b/src/tests/category/chain/sunken_test.py
@@ -4,7 +4,7 @@ import pytest
 from modlunky2.category.chain.common import ChainStatus, ChainStepEvaluator
 from modlunky2.category.chain.sunken import AbzuChain, DuatChain, SunkenChain
 from modlunky2.category.chain.testing import make_player_with_hh_items
-from modlunky2.mem.entities import EntityType, Player
+from modlunky2.mem.entities import CharState, EntityType, Player
 from modlunky2.mem.state import Items, Screen, State, Theme, WinState
 from modlunky2.mem.testing import EntityMapBuilder
 
@@ -536,7 +536,7 @@ def test_visit_city_of_gold(
             ChainStatus.IN_PROGRESS,
             "keep_ankh",
         ),
-        # No Ankh, no Duat
+        # Can't reach Duat if Ankh was used early
         (
             4,
             3,
@@ -544,6 +544,15 @@ def test_visit_city_of_gold(
             {EntityType.ITEM_POWERUP_CROWN},
             ChainStatus.FAILED,
             None,
+        ),
+        # Missing Ankh, but stunned and potentially on altar
+        (
+            4,
+            3,
+            Player(state=CharState.STUNNED),
+            {EntityType.ITEM_POWERUP_CROWN},
+            ChainStatus.IN_PROGRESS,
+            "keep_ankh",
         ),
         # No player, we assume this is due to sacrifice
         (


### PR DESCRIPTION
The Ankh is removed when the player is stunned on the Altar in CoG. Apparently there are frames where they don't have Ankh and the sacrifice hasn't finished (i.e. there's still a player).

This fix removes that awkward time window, while still detecting non-altar death. We could check more stuff (e.g. `standing_on` altar) but this seems sufficient. Notably, the player is revived in a standing state