### PR TITLE
Make logging more standard/idiomatic

### DIFF
--- a/src/modlunky2/api.py
+++ b/src/modlunky2/api.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 import requests
 from requests import HTTPError
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class SpelunkyFYIClient:

--- a/src/modlunky2/assets/assets.py
+++ b/src/modlunky2/assets/assets.py
@@ -37,7 +37,7 @@ from modlunky2.assets.string_hashing import StringHashes
 from modlunky2.assets.hashing import md5sum_path
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/src/modlunky2/assets/patcher.py
+++ b/src/modlunky2/assets/patcher.py
@@ -22,7 +22,7 @@ RELEASE_AOB_PRODUCTION = b"\x00\x50\x72\x6F\x64\x75\x63\x74\x69\x6F\x6E\x00"
 RELEASE_AOB_REPLACE = b"\x00\x4D\x6F\x64\x6C\x75\x6E\x6B\x79\x32\x00\x00"
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class Patcher:

--- a/src/modlunky2/assets/soundbank.py
+++ b/src/modlunky2/assets/soundbank.py
@@ -9,7 +9,7 @@ from fsb5.utils import LibraryNotFoundException
 from .riff import RIFF
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class Extension(Enum):

--- a/src/modlunky2/category/chain/common.py
+++ b/src/modlunky2/category/chain/common.py
@@ -7,7 +7,7 @@ from modlunky2.mem.entities import Entity, EntityType, Player
 from modlunky2.mem.memrauder.model import PolyPointer
 from modlunky2.mem.state import State
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 # Status of the quest chain.
 # The properties are for convenience in 'if' condition

--- a/src/modlunky2/category/chain/eggplant.py
+++ b/src/modlunky2/category/chain/eggplant.py
@@ -8,7 +8,7 @@ from modlunky2.category.chain.common import (
 from modlunky2.mem.entities import EntityType
 from modlunky2.mem.state import Screen, State, Theme
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class EggplantChain(ChainMixin):

--- a/src/modlunky2/cli.py
+++ b/src/modlunky2/cli.py
@@ -8,7 +8,8 @@ from modlunky2.config import Config, make_user_dirs
 from modlunky2.utils import tb_info
 import modlunky2.web.service as web_service
 
-logger = logging.getLogger("modlunky2")
+# Explicit name since this module can be __main__
+logger = logging.getLogger("modlunky2.cli")
 
 
 def main():
@@ -37,7 +38,7 @@ def main():
     log_format = "%(asctime)s.%(msecs)03d: %(message)s"
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format=log_format, level=logging.INFO, datefmt="%H:%M:%S")
-    logger.setLevel(log_level)
+    logging.getLogger("modlunky2").setLevel(log_level)
 
     try:
         launch(args, log_level)

--- a/src/modlunky2/cli.py
+++ b/src/modlunky2/cli.py
@@ -38,7 +38,7 @@ def main():
     log_format = "%(asctime)s.%(msecs)03d: %(message)s"
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format=log_format, level=logging.INFO, datefmt="%H:%M:%S")
-    logging.getLogger("modlunky2").setLevel(log_level)
+    logging.getLogger().setLevel(log_level)
 
     try:
         launch(args, log_level)

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -53,7 +53,7 @@ LAST_INSTALL_BROWSE_DEFAULT = "/"
 
 DEFAULT_COLOR_KEY = "#ff00ff"
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 def make_user_dirs():

--- a/src/modlunky2/mem/memrauder/spelunky2.py
+++ b/src/modlunky2/mem/memrauder/spelunky2.py
@@ -20,7 +20,7 @@ from modlunky2.mem.memrauder.dsl import (
     sc_uint64,
 )
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/ui/__init__.py
+++ b/src/modlunky2/ui/__init__.py
@@ -32,7 +32,7 @@ if not IS_EXE:
     import pip_api
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 update_lock = threading.Lock()
 
 

--- a/src/modlunky2/ui/error.py
+++ b/src/modlunky2/ui/error.py
@@ -4,7 +4,7 @@ from tkinter import ttk
 
 from modlunky2.ui.widgets import Tab
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class ErrorTab(Tab):

--- a/src/modlunky2/ui/extract.py
+++ b/src/modlunky2/ui/extract.py
@@ -18,7 +18,7 @@ from modlunky2.utils import open_directory
 from modlunky2.ui.widgets import Tab, ToolTip
 from modlunky2.assets.soundbank import Extension as SoundExtension
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 MODS = Path("Mods")

--- a/src/modlunky2/ui/install.py
+++ b/src/modlunky2/ui/install.py
@@ -18,7 +18,7 @@ from modlunky2.ui.widgets import Entry, Tab
 from modlunky2.utils import tb_info, zipinfo_fixup_filename
 from modlunky2.api import SpelunkyFYIClient
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class SourceChooser(ttk.Frame):

--- a/src/modlunky2/ui/levels/cli.py
+++ b/src/modlunky2/ui/levels/cli.py
@@ -12,7 +12,8 @@ from modlunky2.constants import BASE_DIR
 from modlunky2.ui.levels.tab import LevelsTab
 from modlunky2.utils import tb_info, temp_chdir
 
-logger = logging.getLogger("modlunky2")
+# Explicit name since this module can be __main__
+logger = logging.getLogger("modlunky2.ui.levels.cli")
 
 
 def exception_logger(type_, value, traceb):
@@ -168,7 +169,7 @@ def main():
     log_format = "%(asctime)s.%(msecs)03d: %(message)s"
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format=log_format, level=logging.INFO, datefmt="%H:%M:%S")
-    logger.setLevel(log_level)
+    logging.getLogger("modlunky2").setLevel(log_level)
 
     try:
         launch(args)

--- a/src/modlunky2/ui/levels/cli.py
+++ b/src/modlunky2/ui/levels/cli.py
@@ -169,7 +169,7 @@ def main():
     log_format = "%(asctime)s.%(msecs)03d: %(message)s"
     log_level = logging.getLevelName(args.log_level)
     logging.basicConfig(format=log_format, level=logging.INFO, datefmt="%H:%M:%S")
-    logging.getLogger("modlunky2").setLevel(log_level)
+    logging.getLogger().setLevel(log_level)
 
     try:
         launch(args)

--- a/src/modlunky2/ui/levels/tab.py
+++ b/src/modlunky2/ui/levels/tab.py
@@ -44,7 +44,7 @@ from modlunky2.sprites import SpelunkySpriteFetcher
 from modlunky2.ui.widgets import PopupWindow, ScrollableFrameLegacy, Tab
 from modlunky2.utils import is_windows, tb_info
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class EditorType(Enum):

--- a/src/modlunky2/ui/logs.py
+++ b/src/modlunky2/ui/logs.py
@@ -21,4 +21,4 @@ def register_queue_handler(queue_handler, log_level=logging.INFO):
     queue_handler.setFormatter(formatter)
 
     root_logger.addHandler(queue_handler)
-    logging.getLogger("modlunky2").setLevel(log_level)
+    root_logger.setLevel(log_level)

--- a/src/modlunky2/ui/logs.py
+++ b/src/modlunky2/ui/logs.py
@@ -1,7 +1,5 @@
 import logging
 
-logger = logging.getLogger("modlunky2")
-
 
 class QueueHandler(logging.Handler):
     def __init__(self, log_queue):
@@ -13,12 +11,14 @@ class QueueHandler(logging.Handler):
 
 
 def register_queue_handler(queue_handler, log_level=logging.INFO):
+    root_logger = logging.getLogger()
     # On linux this handler exists in a subprocess but not on windows.
-    for handler in logger.handlers:
+    for handler in root_logger.handlers:
         if isinstance(handler, QueueHandler):
             return
 
     formatter = logging.Formatter("%(asctime)s: %(message)s")
     queue_handler.setFormatter(formatter)
-    logger.addHandler(queue_handler)
-    logger.setLevel(log_level)
+
+    root_logger.addHandler(queue_handler)
+    logging.getLogger("modlunky2").setLevel(log_level)

--- a/src/modlunky2/ui/overlunky.py
+++ b/src/modlunky2/ui/overlunky.py
@@ -12,7 +12,7 @@ from modlunky2.config import Config
 from modlunky2.ui.widgets import Tab
 from modlunky2.utils import tb_info
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 OVERLUNKY_RELEASE_URL = "https://github.com/spelunky-fyi/overlunky/releases/download/whip/Overlunky_WHIP.zip"
 OVERLUNKY_EXE = "Overlunky/Overlunky.exe"

--- a/src/modlunky2/ui/pack.py
+++ b/src/modlunky2/ui/pack.py
@@ -16,7 +16,7 @@ from modlunky2.constants import BASE_DIR
 from modlunky2.ui.widgets import ScrollableLabelFrame, Tab, ToolTip
 from modlunky2.utils import is_patched
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 MODS = Path("Mods")
 

--- a/src/modlunky2/ui/play/controls.py
+++ b/src/modlunky2/ui/play/controls.py
@@ -8,7 +8,7 @@ from modlunky2.config import Config
 from modlunky2.ui.widgets import ToolTip
 from modlunky2.utils import open_directory
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class ControlsFrame(ttk.Frame):

--- a/src/modlunky2/ui/play/filters.py
+++ b/src/modlunky2/ui/play/filters.py
@@ -5,7 +5,7 @@ from tkinter import ttk
 from modlunky2.ui.widgets import DebounceEntry
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class FiltersFrame(ttk.LabelFrame):

--- a/src/modlunky2/ui/play/load_order.py
+++ b/src/modlunky2/ui/play/load_order.py
@@ -3,7 +3,7 @@ import logging
 import tkinter as tk
 from tkinter import ttk
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class LoadOrderFrame(ttk.LabelFrame):

--- a/src/modlunky2/ui/play/options.py
+++ b/src/modlunky2/ui/play/options.py
@@ -15,7 +15,7 @@ from .constants import (
 if is_windows():
     import winshell  # type: ignore
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class OptionsFrame(ttk.Frame):

--- a/src/modlunky2/ui/play/pack.py
+++ b/src/modlunky2/ui/play/pack.py
@@ -10,7 +10,7 @@ from modlunky2.config import Config
 from modlunky2.utils import open_directory
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class Pack:

--- a/src/modlunky2/ui/play/packs.py
+++ b/src/modlunky2/ui/play/packs.py
@@ -17,7 +17,7 @@ from modlunky2.ui.widgets import (
 
 from .pack import Pack
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 ICON_PATH = BASE_DIR / "static/images"
 

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -24,7 +24,7 @@ from modlunky2.ui.play.options import OptionsFrame
 from modlunky2.ui.play.packs import PacksFrame
 from modlunky2.ui.play.releases import VersionFrame, parse_download_url
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 def launch_playlunky(

--- a/src/modlunky2/ui/play/releases.py
+++ b/src/modlunky2/ui/play/releases.py
@@ -24,7 +24,7 @@ from .constants import (
     PLAYLUNKY_VERSION_FILENAME,
 )
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 cache_releases_lock = threading.Lock()
 
 

--- a/src/modlunky2/ui/settings.py
+++ b/src/modlunky2/ui/settings.py
@@ -8,7 +8,7 @@ from modlunky2.config import CACHE_DIR, CONFIG_DIR, DATA_DIR, Config, guess_inst
 from modlunky2.ui.widgets import Entry, Link, PopupWindow, Tab
 from modlunky2.utils import open_directory
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class Theme(ttk.LabelFrame):

--- a/src/modlunky2/ui/tasks.py
+++ b/src/modlunky2/ui/tasks.py
@@ -10,7 +10,7 @@ from modlunky2.utils import tb_info
 
 from .logs import register_queue_handler, QueueHandler
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 PING_INTERVAL = 1

--- a/src/modlunky2/ui/trackers/__init__.py
+++ b/src/modlunky2/ui/trackers/__init__.py
@@ -8,7 +8,7 @@ from modlunky2.ui.widgets import Tab
 from .options import OptionsFrame
 from .pacifist import PacifistButtons
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class TrackersFrame(ttk.LabelFrame):

--- a/src/modlunky2/ui/trackers/category.py
+++ b/src/modlunky2/ui/trackers/category.py
@@ -15,7 +15,7 @@ from modlunky2.ui.trackers.common import (
 )
 from modlunky2.ui.trackers.runstate import RunState
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 ICON_PATH = BASE_DIR / "static/images"

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -15,7 +15,7 @@ from modlunky2.mem import FeedcodeNotFound, find_spelunky2_pid, Spel2Process
 from modlunky2.mem.memrauder.model import ScalarCValueConstructionError
 from modlunky2.utils import tb_info
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 TRACKERS_DIR = DATA_DIR / "trackers"
 

--- a/src/modlunky2/ui/trackers/options.py
+++ b/src/modlunky2/ui/trackers/options.py
@@ -9,7 +9,7 @@ from modlunky2.utils import open_directory
 from modlunky2.ui.trackers.utils import get_text_color
 from modlunky2.ui.trackers.common import TRACKERS_DIR
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 COLOR_GREEN = "#00ff00"

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -12,7 +12,7 @@ from modlunky2.ui.trackers.common import (
     WindowData,
 )
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class PacifistButtons(ttk.Frame):

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -40,7 +40,7 @@ from modlunky2.ui.trackers.label import Label, RunLabel
 from modlunky2.config import CategoryTrackerConfig
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/ui/websocket.py
+++ b/src/modlunky2/ui/websocket.py
@@ -17,7 +17,7 @@ from modlunky2.config import Config
 from modlunky2.utils import tb_info
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 class WebSocketThread(threading.Thread):

--- a/src/modlunky2/updater.py
+++ b/src/modlunky2/updater.py
@@ -5,7 +5,7 @@ from subprocess import Popen
 from .constants import IS_EXE
 
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 LATEST_EXE = (
     "https://github.com/spelunky-fyi/modlunky2/releases/latest/download/modlunky2.exe"

--- a/src/modlunky2/utils.py
+++ b/src/modlunky2/utils.py
@@ -12,7 +12,7 @@ import zipfile
 
 from modlunky2.assets.patcher import Patcher
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 def is_patched(exe_filename):

--- a/src/modlunky2/version.py
+++ b/src/modlunky2/version.py
@@ -4,7 +4,7 @@ from packaging import version
 
 from modlunky2.constants import BASE_DIR
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 def latest_version():

--- a/src/modlunky2/web/api/framework/multiplexing.py
+++ b/src/modlunky2/web/api/framework/multiplexing.py
@@ -27,7 +27,7 @@ from modlunky2.web.api.framework.session import (
     SessionManager,
 )
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 ParamType = TypeVar("ParamType")
 

--- a/src/modlunky2/web/api/framework/pubsub.py
+++ b/src/modlunky2/web/api/framework/pubsub.py
@@ -27,7 +27,7 @@ from modlunky2.web.api.framework.multiplexing import SendConnection, WSMultiplex
 from modlunky2.web.api.framework.serde_tag import to_tagged_dict
 from modlunky2.web.api.framework.session import SessionId
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 @serde

--- a/src/modlunky2/web/api/framework/session.py
+++ b/src/modlunky2/web/api/framework/session.py
@@ -5,7 +5,7 @@ from starlette.datastructures import Address
 from starlette.websockets import WebSocket
 from typing import Dict, Generator, NewType
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 SessionId = NewType("SessionId", str)
 

--- a/src/modlunky2/web/demo.py
+++ b/src/modlunky2/web/demo.py
@@ -17,7 +17,7 @@ from modlunky2.web.api.framework.pubsub import PubSubManager, PubSubTopic, Servi
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 async def hello_world(_request: Request):

--- a/src/tests/web/api/framework/multiplexing_test.py
+++ b/src/tests/web/api/framework/multiplexing_test.py
@@ -13,7 +13,7 @@ from modlunky2.web.api.framework.multiplexing import (
     WSMultiplexerRoute,
 )
 
-logger = logging.getLogger("modlunky2")
+logger = logging.getLogger(__name__)
 
 
 @serde


### PR DESCRIPTION
These changes are vaguely motivated by my intention to use a logging handler in the new "tasks" API with a multiprocessing-ish implementation on anyio process handler. In that context, I want to be more confident the handler catches everything.

The switch to use `__name__` is tangential, but seems nice. Like, there have been times when I want to set the level to "debug" on a single module.

I've made sure logs still appear in the UI.