### PR TITLE
Add origin check to websocket API

### DIFF
--- a/src/modlunky2/web/api/framework/multiplexing.py
+++ b/src/modlunky2/web/api/framework/multiplexing.py
@@ -84,6 +84,7 @@ class WSMultiplexer:
                     while True:
                         await self._dispatch_one(websocket, session_id, tg)
         except SessionException as ex:
+            logger.warning("Rejected websocket session", exc_info=ex)
             await websocket.close(reason=str(ex))
         except WebSocketDisconnect:
             # We swallow disconnect since it's OK for clients to close the connection.

--- a/src/modlunky2/web/api/framework/session.py
+++ b/src/modlunky2/web/api/framework/session.py
@@ -4,6 +4,7 @@ import logging
 from starlette.datastructures import Address
 from starlette.websockets import WebSocket
 from typing import Dict, Generator, NewType
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +22,15 @@ class SessionManager:
 
     @contextmanager
     def session_for(self, websocket: WebSocket) -> Generator[SessionId, None, None]:
+        # If there's no origin, this isn't a browser request.
+        # We assume it's from a local process and allow it.
+        if "origin" in websocket.headers:
+            _validate_origin(websocket.headers["origin"])
+
         sid = SessionId(websocket.path_params[self.route_sid_param_name])
         addr = websocket.client
+        if addr is None:
+            raise SessionException(f"Session {sid} has no client address")
 
         if sid in self.sid_to_addr:
             logger.warning(
@@ -40,3 +48,40 @@ class SessionManager:
             yield sid
         finally:
             del self.sid_to_addr[sid]
+
+
+# Allow the most common localhost 'spellings.' This doesn't bother with
+# supporting alternative IPv4 loopbacks (e.g. 127.0.0.2). Notably IPv6 gets
+# canonicalized elsewhere; we'll never see (e.g.) "[0:0:0:0:0:0:000:1]"
+_ALLOWED_ORIGINS = frozenset(["localhost", "127.0.0.1", "[::1]"])
+
+
+def _validate_origin(origin: str) -> None:
+    # It might be nice to allow file: scheme, but we'd also have to allow the others.
+    # Unfortunately, it's possible to construct (e.g.) a data: URL from any origin
+    if origin == "null":
+        raise SessionException(
+            "Connection from privacy-sensitive origin (e.g. file:, data:)"
+        )
+
+    try:
+        parsed = urlsplit(origin)
+    except ValueError as err:
+        raise SessionException("Failed to parse origin") from err
+
+    hostname = _extract_hostname(parsed.netloc)
+    if hostname not in _ALLOWED_ORIGINS:
+        raise SessionException(f"Unauthorized hostname ({hostname}) in origin {origin}")
+
+
+def _extract_hostname(netloc: str) -> str:
+    # Try to ignore the port. For IPv6 addresses, there may be ":" in the address
+    colon_index = netloc.rfind(":")
+    close_index = netloc.rfind("]")
+    if colon_index < 0:
+        return netloc
+    if close_index >= 0 and close_index > colon_index:
+        return netloc
+    if colon_index < 0:
+        return netloc
+    return netloc[0:colon_index]

--- a/src/modlunky2/web/service.py
+++ b/src/modlunky2/web/service.py
@@ -27,7 +27,7 @@ def launch_in_thread(config: Config) -> Callable[[], None]:
 def _async_worker(config: Config, shutting_down: threading.Event):
     app = make_asgi_app()
     hypercorn_conf = HypercornConfig()
-    hypercorn_conf.bind = f"127.0.0.1:{config.api_port}"
+    hypercorn_conf.bind = f"localhost:{config.api_port}"
     hypercorn_conf.websocket_ping_interval = 30.0
 
     async def shutdown_trigger():

--- a/src/tests/web/api/framework/session_test.py
+++ b/src/tests/web/api/framework/session_test.py
@@ -1,10 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import pytest
 from starlette.datastructures import Address
 from starlette.websockets import WebSocket, WebSocketDisconnect
 from typing import Dict, cast
 
 from modlunky2.web.api.framework.session import (
+    _extract_hostname,
+    _validate_origin,
     SessionException,
     SessionId,
     SessionManager,
@@ -15,6 +17,7 @@ from modlunky2.web.api.framework.session import (
 class FakeWebSocket:
     path_params: Dict[str, str]
     client: Address
+    headers: Dict[str, str] = field(default_factory=dict)
 
 
 PARAM_NAME = "sid"
@@ -93,3 +96,66 @@ def test_two_sessions_conflict(sid: SessionId, client1: Address, client2: Addres
             assert got_sid1 == sid
             with manager.session_for(websocket2):
                 pass
+
+
+def test_session_with_origin_accepted():
+    websocket = cast(
+        WebSocket,
+        FakeWebSocket(
+            {PARAM_NAME: SessionId("2001")},
+            Address("local", 456),
+            {"origin": "http://[::1]:9526"},
+        ),
+    )
+
+    manager = SessionManager(PARAM_NAME)
+    with manager.session_for(websocket) as got_sid:
+        assert got_sid == "2001"
+
+
+def test_session_with_origin_rejected():
+    websocket = cast(
+        WebSocket,
+        FakeWebSocket(
+            {PARAM_NAME: SessionId("2002")},
+            Address("local", 456),
+            {"origin": "null"},
+        ),
+    )
+
+    manager = SessionManager(PARAM_NAME)
+    with pytest.raises(SessionException):
+        with manager.session_for(websocket):
+            pass
+
+
+@pytest.mark.parametrize(
+    "origin", ["http://localhost", "https://localhost:3000", "http://127.0.0.1:3000"]
+)
+def test_validate_origin_accepted(origin):
+    # Just checking that no exception is thrown
+    _validate_origin(origin)
+
+
+@pytest.mark.parametrize("origin", ["null", "foo", "http://example.com"])
+def test_validate_origin_rejected(origin):
+    with pytest.raises(SessionException):
+        _validate_origin(origin)
+
+
+@pytest.mark.parametrize(
+    "netloc,expected",
+    [
+        ("example1.com", "example1.com"),
+        ("example2.com:443", "example2.com"),
+        ("localhost", "localhost"),
+        ("localhost:3000", "localhost"),
+        ("1.2.3.4", "1.2.3.4"),
+        ("5.6.7.8:99", "5.6.7.8"),
+        ("[::1]", "[::1]"),
+        ("[::1]:80", "[::1]"),
+    ],
+)
+def test_extract_hostname(netloc, expected):
+    actual = _extract_hostname(netloc)
+    assert actual == expected


### PR DESCRIPTION
Since WebSocket doesn't apply SOP (Same Origin Policy) and doesn't implement CORS, it's possible for any website to open a connection to Modlunky2. This validates the origin, if present, is from a localhost-like origin. If the origin header isn't present, we assume it's a local process and therefore OK.

Originally, I was going to add a check that the origin matched the service itself. However, that wouldn't work with the current UI served by Node.JS; it seems desirable to keep that working.

I considered adding a flag to allow-list additional origins, but it seems more error-prone and would require plumbing the value through. OTOH, checking for various localhost-like origins was more complicated than I expected.