### PR TITLE
Make mod manager errors serialize nicely

### DIFF
--- a/src/libs/ml2_mods/src/data.rs
+++ b/src/libs/ml2_mods/src/data.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::manager::Error;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Mod {
     pub id: String,
@@ -20,4 +22,43 @@ pub struct Manifest {
     pub description: String,
     pub logo: String,
     pub mod_file: ManifestModFile,
+}
+
+#[derive(Debug, Serialize, Deserialize, thiserror::Error)]
+pub enum ManagerError {
+    #[error("{0}")]
+    ModExistsError(String),
+    #[error("{0}")]
+    ModNotFoundError(String),
+    #[error("{0}")]
+    ModNonDirectoryError(String),
+    #[error("{0}")]
+    ManifestParseError(String),
+    #[error("{0}")]
+    SourceError(String),
+    #[error("{0}")]
+    DestinationError(String),
+    #[error("{0}")]
+    ChannelError(String),
+    #[error("{0}")]
+    UnknownError(String),
+}
+
+impl From<&Error> for ManagerError {
+    fn from(original: &Error) -> Self {
+        match original {
+            Error::ModExistsError(_) => ManagerError::ModExistsError(format!("{}", original)),
+            Error::ModNotFoundError(_) => ManagerError::ModNotFoundError(format!("{}", original)),
+            Error::ModNonDirectoryError(_) => {
+                ManagerError::ModNonDirectoryError(format!("{}", original))
+            }
+            Error::ManifestParseError(_m, _e) => {
+                ManagerError::ManifestParseError(format!("{}", original))
+            }
+            Error::SourceError(_) => ManagerError::SourceError(format!("{}", original)),
+            Error::DestinationError(_) => ManagerError::DestinationError(format!("{}", original)),
+            Error::ChannelError(_) => ManagerError::ChannelError(format!("{}", original)),
+            Error::UnknownError(_) => ManagerError::UnknownError(format!("{}", original)),
+        }
+    }
 }

--- a/src/libs/ml2_mods/src/manager.rs
+++ b/src/libs/ml2_mods/src/manager.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use derivative::Derivative;
+use serde::Serialize;
 use thiserror;
 use tokio::fs;
 use tokio::sync::{mpsc, oneshot};
@@ -12,7 +13,7 @@ use tracing::{debug, info, instrument};
 use zip::ZipArchive;
 
 use crate::constants::{MANIFEST_FILENAME, MODS_SUBPATH, MOD_METADATA_SUBPATH};
-use crate::data::{Manifest, Mod};
+use crate::data::{ManagerError, Manifest, Mod};
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -376,6 +377,16 @@ impl ModManagerHandle {
             .await
             .map_err(|e| Error::ChannelError(e.into()))?;
         Ok(())
+    }
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let e: ManagerError = self.into();
+        e.serialize(serializer)
     }
 }
 


### PR DESCRIPTION
I suspected that `#[tauri::command]` will require errors are `serde::Serialize`, and indeed it does. I'm not sure this is worthwhile (vs just using `String`), but it makes it possible for the frontend to identify the error-variant.

Example
```
let e = Error::ModExistsError("hi".to_string());
println!("{}", serde_json::to_string(&e)?);
```
Outputs `{"ModExistsError":"Mod hi already exists"}`