### PR TITLE
Implement writing latest.json and polling for updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,6 +1801,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-tls",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tempfile",
@@ -2913,6 +2914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3459,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/src/libs/ml2_mods/Cargo.toml
+++ b/src/libs/ml2_mods/Cargo.toml
@@ -13,11 +13,12 @@ derivative = "2.2"
 http = "0.2"
 hyper = {version = "0.14", features = ["client", "http1", "http2", "tcp"]}
 hyper-tls = "0.5"
+rand = "0.8"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3"
 thiserror = "1.0"
-tokio = {version = "1.20", features = ["fs", "macros", "rt", "rt-multi-thread", "sync", "tracing"] }
+tokio = {version = "1.20", features = ["fs", "macros", "rt", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 tower = {version = "0.4", features = ["util"]}
 tower-http = {version = "0.3", features = ["follow-redirect", "sensitive-headers", "set-header", "trace", "util"]}
 tracing = "0.1"

--- a/src/libs/ml2_mods/src/local.rs
+++ b/src/libs/ml2_mods/src/local.rs
@@ -1,18 +1,24 @@
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use thiserror;
 use tokio::fs;
 use tracing::{debug, instrument};
 use zip::result::ZipError;
 use zip::ZipArchive;
 
-use crate::constants::{MANIFEST_FILENAME, MODS_SUBPATH, MOD_METADATA_SUBPATH};
+use crate::constants::{LATEST_FILENAME, MANIFEST_FILENAME, MODS_SUBPATH, MOD_METADATA_SUBPATH};
 use crate::data::{Manifest, ManifestModFile, Mod};
-use crate::spelunkyfyi::http::{DownloadedLogo, DownloadedMod};
+use crate::spelunkyfyi::http::{DownloadedLogo, DownloadedMod, Mod as ApiMod};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct LatestFile {
+    id: String,
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -23,12 +29,11 @@ pub enum Error {
     #[error("Mod {0} isn't in a directory")]
     NonDirectory(String),
 
-    #[error("Couldn't parse manifest for mod {0}")]
-    ManifestParseError(String, #[source] anyhow::Error),
     #[error("Problem with installation source")]
     SourceError(#[source] anyhow::Error),
     #[error("Problem with the destination")]
     DestinationError(#[source] anyhow::Error),
+
     #[error("I/O error")]
     IoError(#[from] std::io::Error),
 
@@ -45,6 +50,7 @@ pub trait LocalMods {
     async fn remove(&self, id: &str) -> Result<()>;
     async fn install_local(&self, source: &str, dest_id: &str) -> Result<Mod>;
     async fn install_remote(&self, downloaded: &DownloadedMod) -> Result<Mod>;
+    async fn update_latest(&self, id: &str, api_mod: &ApiMod) -> Result<bool>;
 }
 
 pub struct DiskMods {
@@ -62,14 +68,6 @@ impl DiskMods {
         self.install_path.join(MOD_METADATA_SUBPATH).join(id)
     }
 
-    fn manifest_json_path(&self, id: &str) -> PathBuf {
-        self.manifest_dir_path(id).join(MANIFEST_FILENAME)
-    }
-
-    fn logo_path(&self, id: &str, logo_filename: &OsStr) -> PathBuf {
-        self.manifest_dir_path(id).join(logo_filename)
-    }
-
     async fn create_manifest_dir(&self, id: &str) -> Result<PathBuf> {
         let manifest_dir = self.manifest_dir_path(id);
         debug!("Creating manifest dir {:?}", manifest_dir);
@@ -77,28 +75,33 @@ impl DiskMods {
         Ok(manifest_dir)
     }
 
+    async fn load_latest(&self, id: &str) -> Result<Option<String>> {
+        let path = self.manifest_dir_path(id).join(LATEST_FILENAME);
+        let json = if let Some(content) = try_read(path).await? {
+            content
+        } else {
+            return Ok(None);
+        };
+        let latest: LatestFile = serde_json::from_slice(&json[..])?;
+        Ok(Some(latest.id))
+    }
+
     #[instrument(skip(self))]
     async fn load_mod_manifest(&self, id: &str) -> Result<Option<Manifest>> {
-        let path = self.manifest_json_path(id);
-        let json_result = fs::read(&path).await;
-        if let Err(e) = json_result {
-            match e.kind() {
-                // It's OK if the metadata.json doesn't exist
-                io::ErrorKind::NotFound => return Ok(None),
-                _ => return Err(Error::UnknownError(e.into())),
-            }
-        }
-        let json = json_result.unwrap();
-        let manifest: Manifest = serde_json::from_slice(&json[..])
-            .map_err(|e| Error::ManifestParseError(id.to_string(), e.into()))?;
-        Ok(Some(manifest))
+        let path = self.manifest_dir_path(id).join(MANIFEST_FILENAME);
+        let json = if let Some(content) = try_read(path).await? {
+            content
+        } else {
+            return Ok(None);
+        };
+        Ok(serde_json::from_slice(&json[..])?)
     }
 
     #[instrument(skip(self))]
     async fn write_mod_manifest(&self, id: &str, manifest: &Manifest) -> Result<()> {
         debug!("Writing manifest");
         self.create_manifest_dir(id).await?;
-        let manifest_path = self.manifest_json_path(id);
+        let manifest_path = self.manifest_dir_path(id).join(MANIFEST_FILENAME);
         let json = serde_json::to_string(manifest).map_err(|e| Error::UnknownError(e.into()))?;
         debug!("Writing manifest JSON to {:?}", manifest_path);
         fs::write(manifest_path, json).await?;
@@ -154,7 +157,7 @@ impl DiskMods {
 
         let mut dest_name = OsString::from("mod_logo.");
         dest_name.push(extension);
-        let dest_path = self.logo_path(dest_id, &dest_name);
+        let dest_path = self.manifest_dir_path(dest_id).join(&dest_name);
         debug!("Installing logo to path {:?}", dest_path);
         fs::copy(&source.file, dest_path).await?;
 
@@ -294,11 +297,30 @@ impl LocalMods for DiskMods {
             mod_file,
         };
         self.write_mod_manifest(&dest_id, &manifest).await?;
+        self.update_latest(&dest_id, &downloaded.r#mod).await?;
 
         Ok(Mod {
             id: dest_id,
             manifest: Some(manifest),
         })
+    }
+
+    async fn update_latest(&self, id: &str, api_mod: &ApiMod) -> Result<bool> {
+        let latest = if let Some(mod_file) = api_mod.mod_files.first() {
+            mod_file.id.clone()
+        } else {
+            return Ok(false);
+        };
+        let prev_latest = self.load_latest(id).await?;
+
+        let different = prev_latest.as_ref().map(|p| p == &latest).unwrap_or(true);
+        if different {
+            let json = serde_json::to_string(&LatestFile { id: latest.clone() })?;
+            let path = self.create_manifest_dir(id).await?.join(LATEST_FILENAME);
+            fs::write(&path, json).await?;
+        }
+
+        Ok(different)
     }
 }
 
@@ -311,6 +333,17 @@ async fn path_metadata(path: impl AsRef<Path>) -> Result<Option<std::fs::Metadat
             _ => Err(Error::UnknownError(e.into())),
         },
     }
+}
+
+async fn try_read(path: impl AsRef<Path>) -> Result<Option<Vec<u8>>> {
+    let content = fs::read(path.as_ref()).await;
+    if let Err(e) = content {
+        match e.kind() {
+            io::ErrorKind::NotFound => return Ok(None),
+            _ => return Err(e.into()),
+        }
+    };
+    Ok(Some(content.unwrap()))
 }
 
 enum CopyType {
@@ -435,6 +468,12 @@ fn count_lua_paths(paths: &[PathBuf]) -> usize {
         .iter()
         .filter(|p| p.extension().map_or(false, |e| e == "lua"))
         .count()
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Self::UnknownError(err.into())
+    }
 }
 
 impl From<ZipError> for Error {

--- a/src/libs/ml2_mods/src/manager.rs
+++ b/src/libs/ml2_mods/src/manager.rs
@@ -304,7 +304,6 @@ impl From<LocalError> for Error {
             LocalError::AlreadyExists(_) => Error::ModExistsError(original),
             LocalError::NotFound(_) => Error::ModNotFoundError(original),
             LocalError::NonDirectory(_) => Error::ModNonDirectoryError(original),
-            LocalError::ManifestParseError(_m, _s) => Error::ManifestParseError(original),
             LocalError::SourceError(_) => Error::SourceError(original),
             LocalError::DestinationError(_) => Error::DestinationError(original),
             LocalError::IoError(_) => Error::UnknownError(original.into()),

--- a/src/libs/ml2_mods/src/spelunkyfyi/mod.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/mod.rs
@@ -1,1 +1,2 @@
 pub mod http;
+pub mod poll;

--- a/src/libs/ml2_mods/src/spelunkyfyi/poll.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/poll.rs
@@ -29,7 +29,7 @@ where
     step_dist: Uniform<Duration>,
 }
 
-#[derive(Derivative)]
+#[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub struct PollerHandle {
     #[derivative(Debug = "ignore")]
@@ -67,6 +67,7 @@ where
         tokio::spawn(async move { self.run().await })
     }
 
+    #[instrument(skip(self))]
     async fn run(&mut self) {
         let mut poll_interval = time::interval(self.poll_interval);
         // If we fall behind, delay further updates

--- a/src/libs/ml2_mods/src/spelunkyfyi/poll.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/poll.rs
@@ -1,0 +1,157 @@
+use std::{sync::Arc, time::Duration};
+
+use derivative::Derivative;
+use rand::{distributions::Uniform, Rng};
+use tokio::{
+    select,
+    sync::{broadcast, Notify},
+    task, time,
+};
+use tracing::{debug, instrument, trace, warn};
+
+use crate::manager::{ListResponse, ModManagerHandle};
+
+use super::http::{Api, Mod as ApiMod};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    ShutdownError(#[source] anyhow::Error),
+    #[error("{0}")]
+    RecvError(#[from] broadcast::error::RecvError),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct Poller<A>
+where
+    A: Api + Send + Sync + 'static,
+{
+    api_client: A,
+    manger_handle: ModManagerHandle,
+    #[derivative(Debug = "ignore")]
+    mods_tx: broadcast::Sender<ApiMod>,
+    poll_interval: Duration,
+    #[derivative(Debug = "ignore")]
+    shutdown: Arc<Notify>,
+    step_dist: Uniform<Duration>,
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct PollerHandle {
+    #[derivative(Debug = "ignore")]
+    shutdown: Arc<Notify>,
+    #[derivative(Debug = "ignore")]
+    mods_rx: broadcast::Receiver<ApiMod>,
+}
+
+impl<A> Poller<A>
+where
+    A: Api + Send + Sync + 'static,
+{
+    pub fn new(
+        api_client: A,
+        manger_handle: ModManagerHandle,
+        poll_interval: Duration,
+        step_max_delay: Duration,
+    ) -> (Self, PollerHandle) {
+        let (mods_tx, mods_rx) = broadcast::channel(10);
+
+        let poller = Poller {
+            api_client,
+            manger_handle,
+            mods_tx,
+            poll_interval,
+            shutdown: Arc::new(Notify::new()),
+            step_dist: Uniform::new(Duration::from_nanos(0), step_max_delay),
+        };
+        let handle = PollerHandle {
+            mods_rx,
+            shutdown: poller.shutdown.clone(),
+        };
+
+        (poller, handle)
+    }
+
+    /// Consumes the Poller, starting a task and returning its JoinHandle
+    pub fn spawn(mut self) -> task::JoinHandle<()> {
+        tokio::spawn(async move { self.run().await })
+    }
+
+    async fn run(&mut self) {
+        let mut poll_interval = time::interval(self.poll_interval);
+        // If we fall behind, delay further updates
+        poll_interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+        let mut ids: Vec<String> = Vec::new();
+        loop {
+            select! {
+                _ = self.shutdown.notified() => break,
+                _ = poll_interval.tick(), if ids.is_empty() => ids = self.list_mods().await,
+                _ = self.step_sleep(), if !ids.is_empty() => if !self.fetch_mod(ids.pop()).await {break},
+            }
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn list_mods(&self) -> Vec<String> {
+        debug!("Listing mods");
+        match self.manger_handle.list().await {
+            Ok(ListResponse { mods }) => mods
+                .into_iter()
+                .filter_map(|m| m.manifest.map(|mm| mm.slug))
+                .collect(),
+            Err(e) => {
+                warn!("Error listing mods: {}", e);
+                Vec::new()
+            }
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn step_sleep(&self) {
+        let t = rand::thread_rng().sample(self.step_dist);
+        trace!("Step sleeping for {:?}", t);
+        time::sleep(t).await
+    }
+
+    /// Fetches and broadcasts a mod. Returns false if all receivers have been dropped.
+    /// This function takes an Option for ease of use with Vec::pop.
+    #[instrument(skip(self))]
+    async fn fetch_mod(&self, id: Option<String>) -> bool {
+        let id = if let Some(id) = id {
+            id
+        } else {
+            warn!("No mod to fetch");
+            return true;
+        };
+        trace!("Fetching mod {}", id);
+        let m = match self.api_client.get_manifest(&id).await {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("Error fetching mod info for {}: {}", id, e);
+                return true;
+            }
+        };
+        match self.mods_tx.send(m) {
+            Ok(_) => true,
+            Err(_) => {
+                debug!("All receivers dropped");
+                false
+            }
+        }
+    }
+}
+
+impl PollerHandle {
+    pub async fn shutdown(self) {
+        self.shutdown.notify_one()
+    }
+
+    pub async fn recv(&mut self) -> Result<ApiMod> {
+        let m = self.mods_rx.recv().await?;
+        Ok(m)
+    }
+}


### PR DESCRIPTION
Some notes
* I expect the "updates" channel will also be used for other stuff (e.g. when mod installed via webchannel)
* I'm not happy about the cyclic data flow (poller → manager → poller) but it's probably fine
* `ModManagerHandle::duplicate()` dance is working around `broadcast::Receiver` being `!Clone`
* Similarly poll objects use `Notify` so `PollerHandle` can be `Clone`
* `Poller::run` method is a little tricky because it tries to be responsive to shutdown requests
* We wait a random amount of time between fetches. This is partially to be nice to the server if there's a lot of mods to poll, but also to defer to UI requests.
* I ditched `ManifestParseError` in favor of making all JSON errors into `UnknownError`; hard to imagine the client doing much with them