### PR TITLE
Set 5s timeout for connect+read

### DIFF
--- a/src/modlunky2/ui/overlunky.py
+++ b/src/modlunky2/ui/overlunky.py
@@ -23,7 +23,7 @@ def download_overlunky_release(call, install_dir, launch):
 
     try:
         download_file = BytesIO()
-        response = requests.get(OVERLUNKY_RELEASE_URL, stream=True)
+        response = requests.get(OVERLUNKY_RELEASE_URL, stream=True, timeout=5)
         amount_downloaded = 0
         block_size = 102400
 

--- a/src/modlunky2/ui/play/releases.py
+++ b/src/modlunky2/ui/play/releases.py
@@ -49,7 +49,7 @@ def download_playlunky_release(call, tag, download_url, launch):
             raise ValueError("Expected .zip but didn't find one")
 
         download_file = BytesIO()
-        response = requests.get(download_url, stream=True)
+        response = requests.get(download_url, stream=True, timeout=5)
         amount_downloaded = 0
         block_size = 102400
 
@@ -216,7 +216,7 @@ def cache_playlunky_releases(call):
     )
     try:
         logger.debug("Downloading releases to %s", temp_path)
-        response = requests.get(PLAYLUNKY_RELEASES_URL, allow_redirects=True)
+        response = requests.get(PLAYLUNKY_RELEASES_URL, allow_redirects=True, timeout=5)
         if not response.ok:
             logger.warning(
                 "Failed to cache playlunky releases... Will try again later."

--- a/src/modlunky2/version.py
+++ b/src/modlunky2/version.py
@@ -12,7 +12,8 @@ def latest_version():
     try:
         return version.parse(
             requests.get(
-                "https://api.github.com/repos/spelunky-fyi/modlunky2/releases/latest"
+                "https://api.github.com/repos/spelunky-fyi/modlunky2/releases/latest",
+                timeout=5,
             ).json()["tag_name"]
         )
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
This is motivated by the new pylint check. I did some manual testing and this seems fine. [Relevant docs](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts)