### PR TITLE
Tidy the ol' Launcher, upgrade to Clap 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,25 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9484ccdc4cb8e7b117cbd0eb150c7c0f04464854e4679aeb50ef03b32d003"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex 0.3.0",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -416,6 +429,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1608,7 +1630,7 @@ name = "launcher"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 4.0.2",
  "directories",
  "sha2",
  "walkdir",
@@ -1810,7 +1832,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "chrono",
- "clap",
+ "clap 3.2.22",
  "derivative",
  "futures-util",
  "http",

--- a/src/launcher/Cargo.toml
+++ b/src/launcher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "launcher"
 version = "0.1.0"
 authors = ["garebear <mail@spelunky.fyi>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/launcher/Cargo.toml
+++ b/src/launcher/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 directories = "4.0.1"
 zip = "0.6.2"
 anyhow = "1.0.65"
-clap = "3.2.21"
+clap = "4.0.2"
 sha2 = "0.10.6"
 
 [build-dependencies]

--- a/src/launcher/src/main.rs
+++ b/src/launcher/src/main.rs
@@ -6,8 +6,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use clap::AppSettings;
 use clap::Arg;
+use clap::ArgAction;
 use clap::Command;
 use directories::ProjectDirs;
 use sha2::Digest;
@@ -93,35 +93,37 @@ fn verify_release_cache(release_dir: &PathBuf, verify_hashes: bool) -> Result<()
 
 fn main() -> Result<()> {
     let launcher_matches = Command::new("modlunky2")
-        .setting(AppSettings::TrailingVarArg)
-        .setting(AppSettings::DontDelimitTrailingValues)
-        .setting(AppSettings::AllowLeadingHyphen)
-        .setting(AppSettings::DisableVersion)
-        .setting(AppSettings::DisableHelpFlags)
-        .setting(AppSettings::DisableHelpSubcommand)
+        .trailing_var_arg(true)
+        .dont_delimit_trailing_values(true)
+        .allow_hyphen_values(true)
+        .disable_version_flag(true)
+        .disable_help_flag(true)
+        .disable_help_subcommand(true)
         .arg(
-            Arg::with_name("clear-cache")
+            Arg::new("clear-cache")
                 .long("clear-cache")
                 .required(false)
-                .takes_value(false),
+                .takes_value(false)
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name("verify-hashes")
+            Arg::new("verify-hashes")
                 .long("verify-hashes")
                 .required(false)
+                .action(ArgAction::SetTrue)
                 .takes_value(false),
         )
         .arg(
-            Arg::with_name("remainder")
-                .multiple(true)
+            Arg::new("remainder")
+                .multiple_values(true)
                 .allow_hyphen_values(true),
         )
         .get_matches();
 
-    let should_clear_cache: bool = launcher_matches.is_present("clear-cache");
-    let should_verify_hashes: bool = launcher_matches.is_present("verify-hashes");
+    let should_clear_cache: bool = launcher_matches.get_flag("clear-cache");
+    let should_verify_hashes: bool = launcher_matches.get_flag("verify-hashes");
     let remainder: Vec<_> = launcher_matches
-        .values_of("remainder")
+        .get_many::<String>("remainder")
         .map_or_else(std::vec::Vec::new, |v| v.collect());
 
     let project_dirs = ProjectDirs::from("", "spelunky.fyi", "modlunky2")

--- a/src/launcher/src/main.rs
+++ b/src/launcher/src/main.rs
@@ -6,9 +6,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use clap::App;
 use clap::AppSettings;
 use clap::Arg;
+use clap::Command;
 use directories::ProjectDirs;
 use sha2::Digest;
 use sha2::Sha256;
@@ -29,7 +29,7 @@ fn unzip(dest: &Path) -> Result<()> {
             None => continue,
         };
 
-        if (&*file.name()).ends_with('/') {
+        if (*file.name()).ends_with('/') {
             println!("File {} extracted to \"{}\"", i, outpath.display());
             fs::create_dir_all(&outpath)?;
         } else {
@@ -92,7 +92,7 @@ fn verify_release_cache(release_dir: &PathBuf, verify_hashes: bool) -> Result<()
 }
 
 fn main() -> Result<()> {
-    let launcher_matches = App::new("modlunky2")
+    let launcher_matches = Command::new("modlunky2")
         .setting(AppSettings::TrailingVarArg)
         .setting(AppSettings::DontDelimitTrailingValues)
         .setting(AppSettings::AllowLeadingHyphen)

--- a/src/launcher/src/main.rs
+++ b/src/launcher/src/main.rs
@@ -93,9 +93,7 @@ fn verify_release_cache(release_dir: &PathBuf, verify_hashes: bool) -> Result<()
 
 fn main() -> Result<()> {
     let launcher_matches = Command::new("modlunky2")
-        .trailing_var_arg(true)
         .dont_delimit_trailing_values(true)
-        .allow_hyphen_values(true)
         .disable_version_flag(true)
         .disable_help_flag(true)
         .disable_help_subcommand(true)
@@ -103,20 +101,19 @@ fn main() -> Result<()> {
             Arg::new("clear-cache")
                 .long("clear-cache")
                 .required(false)
-                .takes_value(false)
                 .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("verify-hashes")
                 .long("verify-hashes")
                 .required(false)
-                .action(ArgAction::SetTrue)
-                .takes_value(false),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("remainder")
-                .multiple_values(true)
-                .allow_hyphen_values(true),
+                .trailing_var_arg(true)
+                .allow_hyphen_values(true)
+                .action(ArgAction::Append),
         )
         .get_matches();
 


### PR DESCRIPTION
This is prompted by the Clap 4.x release, which removes deprecated functionality

* Update edition to 2021
* Fix clippy lint
* Replace clap::App with clap::Command
* Migrate from `AppSetting` with various `Command` methods
* Use shiny new `Arg::action` method
* Switch to Clap 4, with remaining updates that couldn't be applied to Clap 3