### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           # Python 3.8 is the latest version supporting Windows 7
           python-version: 3.8

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           python build-exe.py
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: modlunky2.exe
           path: target/release/modlunky2.exe

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10", 3.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: ./src/tauri
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -15,11 +15,6 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ["16.13.2"]
-        npm-version: ["8.5.1"]
 
     defaults:
       run:

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
 
       - name: Setup Rust caching
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - run: npm install
 


### PR DESCRIPTION
Bump action versions, motivated by deprecation warnings.

This also moves UI testing from Node 16 to 18