### PR TITLE
Cargo deny

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -37,3 +37,5 @@ jobs:
         run: cargo clippy --workspace --all-targets --exclude launcher --locked -- -D warnings
       - name: cargo test
         run: cargo test --workspace --all-targets --exclude launcher --locked
+      - name: cargo deny check
+        uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -29,13 +29,18 @@ jobs:
         with:
           toolchain: ${{matrix.rust}}
           components: clippy rustfmt
-      - name: cargo check
-        run: cargo check --workspace --all-targets --exclude launcher --locked
       - name: cargo fmt
         run: cargo fmt --all --check
+      - name: cargo check
+        run: cargo check --workspace --all-targets --exclude launcher --locked
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets --exclude launcher --locked -- -D warnings
       - name: cargo test
         run: cargo test --workspace --all-targets --exclude launcher --locked
+  # cargo deny only works on Linux due to using a container
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: cargo deny check
         uses: EmbarkStudios/cargo-deny-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 
 # Note: src-tauri doesn't use these
 [workspace.package]
+license = "Apache-2.0"
 edition = "2021"
 # Reminder: update workflows when increasing
 rust-version = "1.64"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+# Configuration for cargo-deny
+# https://embarkstudios.github.io/cargo-deny/index.html
+targets = [{ triple = "x86_64-pc-windows-msvc" }]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+feature-depth = 1
+
+[advisories]
+unsound = "deny"
+yanked = "deny"
+
+[licenses]
+copyleft = "deny"
+allow-osi-fsf-free = "both"
+# The confidence threshold for detecting a license from license text.
+confidence-threshold = 0.8
+allow = ["CC0-1.0", "MIT-0", "MPL-2.0", "Unicode-DFS-2016"]
+
+[sources]
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/src/launcher/Cargo.toml
+++ b/src/launcher/Cargo.toml
@@ -3,6 +3,7 @@ name = "launcher"
 version = "0.1.0"
 authors = ["garebear <mail@spelunky.fyi>"]
 edition.workspace = true
+license.workspace = true
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/libs/ml2_assets/Cargo.toml
+++ b/src/libs/ml2_assets/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ml2_assets"
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/libs/ml2_chacha/Cargo.toml
+++ b/src/libs/ml2_chacha/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ml2_chacha"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/libs/ml2_entity_data/Cargo.toml
+++ b/src/libs/ml2_entity_data/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ml2_entity_data"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/libs/ml2_mods/Cargo.toml
+++ b/src/libs/ml2_mods/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ml2_mods"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/libs/ml2_net/Cargo.toml
+++ b/src/libs/ml2_net/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ml2_net"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/libs/ml2_types/Cargo.toml
+++ b/src/libs/ml2_types/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ml2_types"
 version = "0.1.0"
+license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 

--- a/src/libs/ml2_vorbis_header/Cargo.toml
+++ b/src/libs/ml2_vorbis_header/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ml2_vorbis_header"
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 rust-version.workspace = true
 
 [dependencies]

--- a/src/tauri/src-tauri/Cargo.toml
+++ b/src/tauri/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "modlunky2"
 version = "0.1.0"
 description = "A tool for creating and using mods related to Spelunky 2"
 # Using worskspace inheritence breaks Tauri's build script
+license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.64"
 


### PR DESCRIPTION
This sets up [cargo deny](https://embarkstudios.github.io/cargo-deny/index.html) to check:
* All crates have a compatible license
* No crates have security advisories
* All crates come from crates.io

I started fiddling with it mostly for `cargo deny check bans`, which can check for multiple versions of the same crate. The other functionality seems nice to have though, and more reasonable to enforce.

Re: licensing: most of the allow-list is for single crates. MPL-2.0 is the only one used by several, and the only copyleft one (albeit minimally copyleft). I elected to deny copyleft, since most conflict with the spirit of Apache 2.0 license. I don't feel strongly about it, though.