### PR TITLE
Inline formatting params

### DIFF
--- a/src/launcher/build.rs
+++ b/src/launcher/build.rs
@@ -39,7 +39,7 @@ where
         // Write file or directory explicitly
         // Some unzip tools unzip files with directory paths correctly, some do not!
         if path.is_file() {
-            println!("adding file {:?} as {:?} ...", path, name);
+            println!("adding file {path:?} as {name:?} ...");
             #[allow(deprecated)]
             zip.start_file_from_path(name, options)?;
             let mut f = File::open(path)?;
@@ -48,11 +48,11 @@ where
             zip.write_all(&buffer)?;
             let digest = Sha256::digest(&buffer);
             buffer.clear();
-            hashes.insert(name.to_str().unwrap().into(), format!("{:x}", digest));
+            hashes.insert(name.to_str().unwrap().into(), format!("{digest:x}"));
         } else if !name.as_os_str().is_empty() {
             // Only if not root! Avoids path spec / warning
             // and mapname conversion failed error on unzip
-            println!("adding dir {:?} as {:?} ...", path, name);
+            println!("adding dir {path:?} as {name:?} ...");
             #[allow(deprecated)]
             zip.add_directory_from_path(name, options)?;
         }
@@ -97,7 +97,7 @@ fn main() -> io::Result<()> {
 
     writeln!(out_file, "static KNOWN_FILES: &[&str] = &[")?;
     for key in hashes.keys() {
-        writeln!(out_file, "    r\"{}\",", key)?;
+        writeln!(out_file, "    r\"{key}\",")?;
     }
     write!(out_file, "];\n\n")?;
 
@@ -115,7 +115,7 @@ fn main() -> io::Result<()> {
             continue;
         }
 
-        writeln!(out_file, "        r\"{}\" => Some(r\"{}\"),", key, value)?;
+        writeln!(out_file, "        r\"{key}\" => Some(r\"{value}\"),")?;
     }
 
     writeln!(out_file, "        _ => None,")?;

--- a/src/launcher/src/main.rs
+++ b/src/launcher/src/main.rs
@@ -73,10 +73,7 @@ fn verify_release_cache(release_dir: &PathBuf, verify_hashes: bool) -> Result<()
             io::copy(&mut file, &mut sha256)?;
             let file_hash = format!("{:x}", sha256.finalize());
             if file_hash != expected_hash {
-                println!(
-                    "Expected hash didn't match for {}. Invalidating cache...",
-                    known_file
-                );
+                println!("Expected hash didn't match for {known_file}. Invalidating cache...");
                 should_invalidate = true;
                 break;
             }
@@ -84,7 +81,7 @@ fn verify_release_cache(release_dir: &PathBuf, verify_hashes: bool) -> Result<()
     }
 
     if should_invalidate {
-        println!("Clearing cached directory at {:?}", release_dir);
+        println!("Clearing cached directory at {release_dir:?}");
         std::fs::remove_dir_all(release_dir)?;
     }
 
@@ -126,7 +123,7 @@ fn main() -> Result<()> {
     let project_dirs = ProjectDirs::from("", "spelunky.fyi", "modlunky2")
         .ok_or_else(|| anyhow!("Failed initialize project dirs..."))?;
 
-    println!("Launching modlunky2 v{}", MODLUNKY2_VERSION);
+    println!("Launching modlunky2 v{MODLUNKY2_VERSION}");
     let cache_dir = Path::new(project_dirs.cache_dir()).join("modlunky2-releases");
     if !cache_dir.exists() {
         println!(
@@ -139,7 +136,7 @@ fn main() -> Result<()> {
     let release_dir = cache_dir.join(MODLUNKY2_VERSION);
     if release_dir.exists() {
         if should_clear_cache {
-            println!("Clearing cached directory at {:?}", release_dir);
+            println!("Clearing cached directory at {release_dir:?}");
             std::fs::remove_dir_all(&release_dir)?;
         } else {
             verify_release_cache(&release_dir, should_verify_hashes)?;

--- a/src/libs/ml2_assets/src/bin/extract-soundbank.rs
+++ b/src/libs/ml2_assets/src/bin/extract-soundbank.rs
@@ -10,14 +10,14 @@ fn main() -> anyhow::Result<()> {
     let soundbank = Soundbank::from_path(soundbank_path)?;
     for fsb in soundbank.fsbs {
         let extension = fsb.header.mode.file_extension();
-        create_dir_all(format!("test-extract/soundbank/{}", extension))?;
+        create_dir_all(format!("test-extract/soundbank/{extension}"))?;
 
         for track in fsb.tracks {
             let filename = format!(
                 "test-extract/soundbank/{}/{}.{}",
                 extension, &track.name, extension
             );
-            println!("{:?}", filename);
+            println!("{filename:?}");
 
             let out = track.rebuild_as(&fsb.header.mode)?;
             let mut f = File::create(filename)?;

--- a/src/libs/ml2_assets/src/strings.rs
+++ b/src/libs/ml2_assets/src/strings.rs
@@ -35,7 +35,7 @@ impl StringHasher {
                 hasher.update(to_hash.as_bytes());
                 let checksum = hasher.finalize();
 
-                string_hash = Some(format!("0x{:08x}", checksum));
+                string_hash = Some(format!("0x{checksum:08x}"));
             }
 
             hashes.push(string_hash);
@@ -57,7 +57,7 @@ impl StringHasher {
             if let Some(hash) = hash {
                 writer.write_all(format!("{}: {}\n", &hash, line).as_bytes())?;
             } else {
-                writer.write_all(format!("{}\n", line).as_bytes())?;
+                writer.write_all(format!("{line}\n").as_bytes())?;
             }
         }
         Ok(())

--- a/src/libs/ml2_assets/src/vorbis_data/rebuild.rs
+++ b/src/libs/ml2_assets/src/vorbis_data/rebuild.rs
@@ -105,7 +105,7 @@ pub(crate) fn rebuild_vorbis(track: &Track) -> Result<Vec<u8>, RebuildError> {
 
     let setup_packet_buff = match VORBIS_HEADER_LOOKUP.get(&crc32) {
         Some(val) => *val,
-        _ => panic!("Unknown Vorbis Header: {}", crc32),
+        _ => panic!("Unknown Vorbis Header: {crc32}"),
     };
 
     let mut info = VorbisInfo::new();

--- a/src/libs/ml2_mods/examples/api.rs
+++ b/src/libs/ml2_mods/examples/api.rs
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Info { code } => {
             let manifest = http_api_mods.get_manifest(&code).await?;
-            println!("{:#?}", manifest)
+            println!("{manifest:#?}")
         }
         Commands::DownloadMod { code, dir } => {
             let (main_tx, mut main_rx) = watch::channel(DownloadProgress::Waiting());

--- a/src/libs/ml2_mods/examples/mods.rs
+++ b/src/libs/ml2_mods/examples/mods.rs
@@ -181,7 +181,7 @@ async fn run(
         Commands::Run {} => loop {
             select! {
                 _ = subsystem.on_shutdown_requested() => break,
-                Ok(change) = mods_rx.recv() => println!("{:#?}", change),
+                Ok(change) = mods_rx.recv() => println!("{change:#?}"),
             }
         },
     }

--- a/src/libs/ml2_mods/src/data.rs
+++ b/src/libs/ml2_mods/src/data.rs
@@ -84,18 +84,16 @@ pub enum ManagerError {
 impl From<Error> for ManagerError {
     fn from(original: Error) -> Self {
         match original {
-            Error::ModExistsError(_) => ManagerError::ModExistsError(format!("{}", original)),
-            Error::ModNotFoundError(_) => ManagerError::ModNotFoundError(format!("{}", original)),
+            Error::ModExistsError(_) => ManagerError::ModExistsError(format!("{original}")),
+            Error::ModNotFoundError(_) => ManagerError::ModNotFoundError(format!("{original}")),
             Error::ModNonDirectoryError(_) => {
-                ManagerError::ModNonDirectoryError(format!("{}", original))
+                ManagerError::ModNonDirectoryError(format!("{original}"))
             }
-            Error::ManifestParseError(_) => {
-                ManagerError::ManifestParseError(format!("{}", original))
-            }
-            Error::SourceError(_) => ManagerError::SourceError(format!("{}", original)),
-            Error::DestinationError(_) => ManagerError::DestinationError(format!("{}", original)),
-            Error::ChannelError(_) => ManagerError::ChannelError(format!("{}", original)),
-            Error::UnknownError(_) => ManagerError::UnknownError(format!("{}", original)),
+            Error::ManifestParseError(_) => ManagerError::ManifestParseError(format!("{original}")),
+            Error::SourceError(_) => ManagerError::SourceError(format!("{original}")),
+            Error::DestinationError(_) => ManagerError::DestinationError(format!("{original}")),
+            Error::ChannelError(_) => ManagerError::ChannelError(format!("{original}")),
+            Error::UnknownError(_) => ManagerError::UnknownError(format!("{original}")),
         }
     }
 }

--- a/src/libs/ml2_mods/src/local/disk.rs
+++ b/src/libs/ml2_mods/src/local/disk.rs
@@ -222,9 +222,10 @@ impl LocalMods for DiskMods {
             if entry.file_name() == ".db" {
                 continue;
             }
-            let id = entry.file_name().into_string().map_err(|e| {
-                Error::UnknownError(anyhow!("Couldn't convert to unicode: {:?}", e))
-            })?;
+            let id = entry
+                .file_name()
+                .into_string()
+                .map_err(|e| Error::UnknownError(anyhow!("Couldn't convert to unicode: {e:?}")))?;
             let res = self.get(&id).await;
             match res {
                 Ok(r#mod) => mods.push(r#mod),
@@ -293,7 +294,7 @@ impl LocalMods for DiskMods {
             let logo = logo
                 .to_str()
                 .ok_or_else(|| {
-                    Error::UnknownError(anyhow!("Failed to convert logo filename {:?}", logo))
+                    Error::UnknownError(anyhow!("Failed to convert logo filename {logo:?}"))
                 })?
                 .to_string();
             Some(logo)
@@ -370,25 +371,23 @@ impl LocalMods for DiskMods {
         let logo_name = self
             .load_mod_manifest(id)
             .await?
-            .ok_or_else(|| anyhow!("Mod {:?} has no manifest. Therefore it has no logo", id))?
+            .ok_or_else(|| anyhow!("Mod {id:?} has no manifest. Therefore it has no logo"))?
             .logo
-            .ok_or_else(|| anyhow!("Mod {:?} has no logo", id))?;
+            .ok_or_else(|| anyhow!("Mod {id:?} has no logo"))?;
         let logo_path = self.manifest_dir_path(id).join(&logo_name);
 
         let ext = logo_path
             .extension()
-            .ok_or_else(|| anyhow!("No extenison in {:?} for mod {:?}", logo_name, id))?
+            .ok_or_else(|| anyhow!("No extenison in {logo_name:?} for mod {id:?}"))?
             .to_str()
-            .ok_or_else(|| anyhow!("Non-unicode extension in {:?} for mod {:?}", logo_name, id))?;
+            .ok_or_else(|| anyhow!("Non-unicode extension in {logo_name:?} for mod {id:?}"))?;
         let mime_type = match ext {
             "jpg" => "imag/jpeg",
             "gif" => "imag/gif",
             "png" => "image/png",
-            _ => {
-                return Err(
-                    anyhow!("Unexpected extension in {:?} for mod {:?}", logo_name, id).into(),
-                )
-            }
+            _ => Err(anyhow!(
+                "Unexpected extension in {logo_name:?} for mod {id:?}"
+            ))?,
         }
         .to_string();
 
@@ -504,7 +503,7 @@ fn zip_enclosed_paths(zip: &mut ZipArchive<std::fs::File>) -> Result<Vec<PathBuf
     for i in 0..zip.len() {
         let f = zip
             .by_index_raw(i)
-            .map_err(|e| Error::SourceError(anyhow!("Reading zip file {:?}", e)))?;
+            .map_err(|e| Error::SourceError(anyhow!("Reading zip file {e:?}")))?;
         let p = f
             .enclosed_name()
             .ok_or_else(|| Error::SourceError(anyhow!("Invalid file name")))?;

--- a/src/libs/ml2_mods/src/manager.rs
+++ b/src/libs/ml2_mods/src/manager.rs
@@ -246,7 +246,7 @@ where
 
     #[instrument(skip(self))]
     async fn install_remote_mod(&self, code: &str) -> Result<Mod> {
-        let id = format!("fyi.{}", code);
+        let id = format!("fyi.{code}");
         self.send_change(Change::Add {
             progress: ModProgress::Started { id },
         });
@@ -293,7 +293,7 @@ where
 
     #[instrument(skip(self))]
     async fn update_remote_mod(&self, code: &str) -> Result<Mod> {
-        let id = format!("fyi.{}", code);
+        let id = format!("fyi.{code}");
         self.send_change(Change::Update {
             progress: ModProgress::Started { id },
         });
@@ -330,7 +330,7 @@ where
 
     #[instrument]
     async fn download_mod(&self, code: &str, op_kind: OpKind) -> Result<DownloadedMod> {
-        let id = format!("fyi.{}", code);
+        let id = format!("fyi.{code}");
         // TODO send  updates
         let api_client = self.api_client.as_ref().ok_or_else(|| {
             Error::UnknownError(anyhow!(

--- a/src/libs/ml2_mods/src/spelunkyfyi/http.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/http.rs
@@ -132,7 +132,7 @@ impl HttpApiMods {
         let path = Path::new(self.base_uri.path()).join(path);
         let path = path
             .to_str()
-            .ok_or_else(|| Error::InvalidUri(anyhow!("Failed to convert {:?}", path)))?;
+            .ok_or_else(|| Error::InvalidUri(anyhow!("Failed to convert {path:?}")))?;
 
         let mut parts = self.base_uri.clone().into_parts();
         parts.path_and_query = Some(path.try_into()?);
@@ -182,7 +182,7 @@ impl HttpApiMods {
         let content_type = res
             .headers()
             .get(CONTENT_TYPE)
-            .ok_or_else(|| Error::GenericHttpError(anyhow!("No content type for URI {}", uri)))?
+            .ok_or_else(|| Error::GenericHttpError(anyhow!("No content type for URI {uri}")))?
             .to_str()?
             .to_string();
         let expected_bytes = if let Some(val) = res.headers().get(CONTENT_LENGTH) {

--- a/src/libs/ml2_mods/src/spelunkyfyi/web_socket.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/web_socket.rs
@@ -77,7 +77,7 @@ impl WebSocketClient {
             .build();
 
         Ok(WebSocketClient {
-            authz_value: HeaderValue::from_str(&format!("Token {}", auth_token))?,
+            authz_value: HeaderValue::from_str(&format!("Token {auth_token}"))?,
             manager_handle,
             ping_interval_dist,
             pong_timeout,

--- a/src/libs/ml2_mods/src/spelunkyfyi/web_socket.rs
+++ b/src/libs/ml2_mods/src/spelunkyfyi/web_socket.rs
@@ -333,7 +333,7 @@ fn root_to_service_uri(service_root: &str) -> Result<Uri, Error> {
     let path = Path::new(service_root.path()).join("ws/gateway/ml/");
     let path = path
         .to_str()
-        .ok_or_else(|| Error::InvalidUri(anyhow!("Failed to convert {:?}", path)))?;
+        .ok_or_else(|| Error::InvalidUri(anyhow!("Failed to convert {path:?}")))?;
 
     let mut parts = service_root.into_parts();
     parts.scheme = Some(scheme.try_into()?);

--- a/src/libs/ml2_mods/tests/manager.rs
+++ b/src/libs/ml2_mods/tests/manager.rs
@@ -190,7 +190,7 @@ async fn assert_exits_in(dir: &TempDir, mod_id: &str, path: &str) {
     let path = dir.path().join(MODS_SUBPATH).join(mod_id).join(path);
     fs::metadata(&path)
         .await
-        .map_err(|e| anyhow!("checking for {:?}: {:?}", path, e))
+        .map_err(|e| anyhow!("checking for {path:?}: {e:?}"))
         .unwrap();
 }
 

--- a/src/libs/ml2_mods/tests/manager.rs
+++ b/src/libs/ml2_mods/tests/manager.rs
@@ -85,7 +85,7 @@ async fn test_get() {
     if let Error::ModNotFoundError(LocalError::NotFound(id)) = err {
         assert_eq!(id, "does-not-exist")
     } else {
-        panic!("Unexpected error from manager: {:?}", err)
+        panic!("Unexpected error from manager: {err:?}")
     }
 }
 
@@ -148,15 +148,15 @@ async fn test_remove() {
     if let Error::ModNotFoundError(LocalError::NotFound(id)) = err {
         assert_eq!(id, "does-not-exist")
     } else {
-        panic!("Unexpected error from manager: {:?}", err)
+        panic!("Unexpected error from manager: {err:?}")
     }
 
     for p in [mod_path, lua_path, metadata_dir_path, manifest_path] {
         match fs::metadata(&p).await {
-            Ok(_) => panic!("File/dir still exists: {:?}", p),
+            Ok(_) => panic!("File/dir still exists: {p:?}"),
             Err(e) => match e.kind() {
                 io::ErrorKind::NotFound => (),
-                _ => panic!("Unexpected IO error: {:?}", e),
+                _ => panic!("Unexpected IO error: {e:?}"),
             },
         }
     }


### PR DESCRIPTION
This has been available [since 1.58](https://caniuse.rs/features/format_args_capture) and clippy will complain in 1.66 ([demo](https://play.rust-lang.org/?version=beta&mode=debug&edition=2021&gist=30a62696edbc5c7cb6bb6f286f664fc8)). Note that this isn't as powerful as f-strings in Python: neither expressions nor field access are supported