### PR TITLE
Fix empty Overlunky console and add new launcher options

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -183,6 +183,7 @@ class Config:
     )
     playlunky_version: Optional[str] = field(default=None, skip_if_default=True)
     playlunky_console: bool = field(default=False, skip_if_default=True)
+    playlunky_overlunky: bool = field(default=False, skip_if_default=True)
     playlunky_shortcut: bool = field(default=False, skip_if_default=True)
     geometry: str = field(default=f"{MIN_WIDTH}x{MIN_HEIGHT}", skip_if_default=True)
     spelunky_fyi_root: str = field(

--- a/src/modlunky2/ui/overlunky.py
+++ b/src/modlunky2/ui/overlunky.py
@@ -103,7 +103,9 @@ def launch_overlunky(_call, exe_path, command_prefix: Optional[List[str]]):
     cmd = [f"{exe_path}"]
     if command_prefix:
         cmd = command_prefix + cmd
-    proc = subprocess.Popen(cmd, cwd=working_dir)
+    proc = subprocess.Popen(
+        cmd, cwd=working_dir, creationflags=subprocess.CREATE_NEW_CONSOLE
+    )
     proc.communicate()
 
 

--- a/src/modlunky2/ui/play/options.py
+++ b/src/modlunky2/ui/play/options.py
@@ -40,6 +40,16 @@ class OptionsFrame(ttk.Frame):
             command=self.handle_console_checkbutton,
         )
 
+        self.enable_overlunky_var = tk.BooleanVar()
+        self.enable_overlunky_var.set(self.modlunky_config.playlunky_overlunky)
+        self.enable_overlunky_checkbox = ttk.Checkbutton(
+            self,
+            text="Load Overlunky",
+            variable=self.enable_overlunky_var,
+            compound="left",
+            command=self.handle_overlunky_checkbutton,
+        )
+
         self.desktop_shortcut_var = tk.BooleanVar()
         self.desktop_shortcut_var.set(self.modlunky_config.playlunky_shortcut)
         self.desktop_shortcut_checkbox = ttk.Checkbutton(
@@ -102,6 +112,10 @@ class OptionsFrame(ttk.Frame):
                     row=row_num, column=0, padx=3, sticky="w"
                 )
                 row_num += 1
+                self.enable_overlunky_checkbox.grid(
+                    row=row_num, column=0, padx=3, sticky="w"
+                )
+                row_num += 1
 
     @staticmethod
     def format_text(text):
@@ -109,6 +123,10 @@ class OptionsFrame(ttk.Frame):
 
     def handle_console_checkbutton(self):
         self.modlunky_config.playlunky_console = self.enable_console_var.get()
+        self.modlunky_config.save()
+
+    def handle_overlunky_checkbutton(self):
+        self.modlunky_config.playlunky_overlunky = self.enable_overlunky_var.get()
         self.modlunky_config.save()
 
     @property

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -28,7 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 def launch_playlunky(
-    _call, install_dir, exe_path, use_console, command_prefix: Optional[List[str]]
+    _call,
+    install_dir,
+    exe_path,
+    use_console,
+    use_overlunky,
+    command_prefix: Optional[List[str]],
 ):
     logger.info(
         "Executing Playlunky Launcher with %s", exe_path.relative_to(PLAYLUNKY_DATA_DIR)
@@ -41,6 +46,9 @@ def launch_playlunky(
 
     if use_console:
         cmd.append("--console")
+
+    if use_overlunky:
+        cmd.append("--overlunky")
 
     proc = subprocess.Popen(cmd, cwd=working_dir)
     proc.communicate()
@@ -327,6 +335,7 @@ class PlayTab(Tab):
             install_dir=self.modlunky_config.install_dir,
             exe_path=exe_path,
             use_console=self.modlunky_config.playlunky_console,
+            use_overlunky=self.modlunky_config.playlunky_overlunky,
             command_prefix=self.modlunky_config.command_prefix,
         )
 


### PR DESCRIPTION
Better late than never to fix more things in tk version.

This depends on both https://github.com/spelunky-fyi/overlunky/pull/283 and https://github.com/spelunky-fyi/Playlunky/pull/40 to roll out first.