### PR TITLE
Specify encodings most everywhere

### DIFF
--- a/src/modlunky2/levels/level_file.py
+++ b/src/modlunky2/levels/level_file.py
@@ -126,7 +126,7 @@ class LevelFile:
         self.level_templates.write(handle)
 
     def write_path(self, level_path: Path):
-        with level_path.open("w") as level_fh:
+        with level_path.open("w", encoding="cp1252") as level_fh:
             self.write(level_fh)
 
     def print(self):

--- a/src/modlunky2/ui/play/play.py
+++ b/src/modlunky2/ui/play/play.py
@@ -170,7 +170,7 @@ class PlayTab(Tab):
         if self.modlunky_config.install_dir:
             path = self.modlunky_config.install_dir / "playlunky.ini"
             if path.exists():
-                with path.open() as ini_file:
+                with path.open(encoding="utf-8") as ini_file:
                     try:
                         self.ini = PlaylunkyConfig.from_ini(ini_file)
                     except configparser.Error:
@@ -205,7 +205,7 @@ class PlayTab(Tab):
                         option,
                     )
 
-        with path.open("w") as handle:
+        with path.open("w", encoding="utf-8") as handle:
             self.ini.write(handle)
 
     def load_from_load_order(self):
@@ -246,7 +246,7 @@ class PlayTab(Tab):
             return
 
         path = self.modlunky_config.install_dir / "steam_appid.txt"
-        with path.open("w") as handle:
+        with path.open("w", encoding="utf-8") as handle:
             handle.write("418530")
 
     @property
@@ -296,7 +296,9 @@ class PlayTab(Tab):
             logger.info("No version info for current download. Updating to latest.")
             return True
 
-        with downloaded_version_path.open("r") as downloaded_version_file:
+        with downloaded_version_path.open(
+            "r", encoding="utf-8"
+        ) as downloaded_version_file:
             downloaded_version = downloaded_version_file.read().strip()
 
         if downloaded_version != release_version:

--- a/src/modlunky2/ui/play/releases.py
+++ b/src/modlunky2/ui/play/releases.py
@@ -65,7 +65,7 @@ def download_playlunky_release(call, tag, download_url, launch):
 
         version_path = dest_path / PLAYLUNKY_VERSION_FILENAME
         logger.debug("Writing version to %s", version_path)
-        with version_path.open("w") as version_file:
+        with version_path.open("w", encoding="utf-8") as version_file:
             version_file.write(version)
 
     except Exception:  # pylint: disable=broad-except

--- a/src/modlunky2/ui/trackers/common.py
+++ b/src/modlunky2/ui/trackers/common.py
@@ -226,7 +226,7 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
 
         TRACKERS_DIR.mkdir(parents=True, exist_ok=True)
         self.text_file = TRACKERS_DIR / file_name
-        with self.text_file.open("w") as handle:
+        with self.text_file.open("w", encoding="utf-8") as handle:
             handle.write(self.text)
 
         self.watcher_thread.start()
@@ -252,7 +252,7 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
             return
         self.text = new_text
         self.label.configure(text=self.text)
-        with self.text_file.open("w") as handle:
+        with self.text_file.open("w", encoding="utf-8") as handle:
             handle.write(new_text)
 
     def shut_down(self, level, message):
@@ -297,7 +297,7 @@ class TrackerWindow(tk.Toplevel, Generic[ConfigType]):
         if self.on_close:
             self.on_close()
 
-        with self.text_file.open("w") as handle:
+        with self.text_file.open("w", encoding="utf-8") as handle:
             handle.write("Not running")
 
         return super().destroy()


### PR DESCRIPTION
This is a follow-up to #532. After this PR, the only places that we don't specify an encoding in `open()`  are:
* Binary mode, where it should be irrelevant(?)
* `assets.py` in `extract()` writes a file, but I wasn't sure what reads it... other places referring to md5sums in files use binary mode