### PR TITLE
Fix enabled mods drag-n-drop (tauri)

### DIFF
--- a/src/tauri/src/lib/pages/playlunky/EnabledMods.svelte
+++ b/src/tauri/src/lib/pages/playlunky/EnabledMods.svelte
@@ -8,11 +8,11 @@
   let dragDisabled = true;
 
   function handleConsider(event: CustomEvent) {
-    $mods = [...event.detail.items];
+    $enabledMods = [...event.detail.items];
   }
 
   function handleFinalize(event: CustomEvent) {
-    $mods = [...event.detail.items];
+    $enabledMods = [...event.detail.items];
     dragDisabled = true;
   }
 
@@ -28,7 +28,7 @@
 <ModListHeader count={$enabledMods.length}>Enabled</ModListHeader>
 <ul
   use:dndzone={{
-    items: $mods,
+    items: $enabledMods,
     dragDisabled,
     flipDurationMs,
     dropTargetStyle: {},

--- a/src/tauri/src/store.ts
+++ b/src/tauri/src/store.ts
@@ -24,9 +24,27 @@ export const mods: Writable<Mod[]> = writable([
   },
 ]);
 
-export const enabledMods = derived(mods, ($mods) =>
-  $mods.filter((mod) => mod.enabled)
-);
+export const enabledMods: Writable<Mod[]> = writable([]);
+mods.subscribe((mods) => {
+  // Update enabled mods without changing order
+  enabledMods.update((enabledMods) => {
+    const newEnabledMods = mods.filter((mod) => mod.enabled);
+    // Update enabled mods references and add new enabled mods
+    for (let newEnabledMod of newEnabledMods) {
+      let enabledModIndex = enabledMods.findIndex(
+        (enabledMod) => enabledMod.id === newEnabledMod.id
+      );
+
+      if (enabledModIndex !== -1) {
+        enabledMods[enabledModIndex] = newEnabledMod;
+      } else if (newEnabledMod.enabled) {
+        enabledMods.push(newEnabledMod);
+      }
+    }
+    // Remove disabled or no longer existant mods
+    return enabledMods.filter((mod) => newEnabledMods.includes(mod));
+  });
+});
 
 export const installedMods = derived(mods, ($mods) =>
   $mods.filter((mod) => !mod.enabled)

--- a/src/tauri/vite.config.ts
+++ b/src/tauri/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import Unocss from "unocss/vite";
 import { presetIcons, presetWebFonts } from "unocss";
-import extractorSvelte from '@unocss/extractor-svelte';
+import extractorSvelte from "@unocss/extractor-svelte";
 import { presetWind } from "@unocss/preset-wind";
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Using the `mods` array for the dnd, when the only movable mods where the enabled ones caused some issues. This fixes it by making `enabledMods` a writable, so it works with the dnd, and gets updated every time `mods` change, while preserving the order.
I guess another solution would be to save the mod order in some variable and just filter and sort `mods` to update `enabledMods`.
Also, should `enabledMods` hold a copy of the mods, or just a reference like what I did?