### PR TITLE
Catch exceptions when loading mod logos

### DIFF
--- a/src/modlunky2/ui/play/pack.py
+++ b/src/modlunky2/ui/play/pack.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import shutil
+import sys
 import tkinter as tk
+import traceback
 from tkinter import ttk
 
 from PIL import Image, ImageTk
@@ -158,15 +160,20 @@ class Pack:
             self.manifest.get("logo")
             and (self.pack_metadata_path / self.manifest["logo"]).exists()
         ):
-            self.logo_img = ImageTk.PhotoImage(
-                Image.open(self.pack_metadata_path / self.manifest["logo"]).resize(
-                    (40, 40), Image.Resampling.LANCZOS
+            try:
+                self.logo_img = ImageTk.PhotoImage(
+                    Image.open(self.pack_metadata_path / self.manifest["logo"]).resize(
+                        (40, 40), Image.Resampling.LANCZOS
+                    )
                 )
-            )
-            self.logo.configure(image=self.logo_img)
-        else:
-            self.logo_img = None
-            self.logo.configure(image=None)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.error(
+                    "Failed to load logo for %s: %s",
+                    self.name,
+                    "".join(traceback.format_exception(*sys.exc_info())).strip(),
+                )
+
+        self.logo.configure(image=self.logo_img)
 
         self.check_needs_update()
         self.render_buttons()


### PR DESCRIPTION
This mitigates a problem [reported on Reddit](https://www.reddit.com/r/spelunky/comments/14zr3ho/problems_with_modlunky/) where an error loading the image prevents the entire Playluynky tab from loading. Presumably this is because the image is corrupt (or a bug in Pillow).

This PR doesn't offer a way to redownload the image, but at least they can find out which pack needs to be reinstalled.