### PR TITLE
More Pillow 10 fixes/tweaks

### DIFF
--- a/src/modlunky2/sprites/base_classes/base_sprite_merger.py
+++ b/src/modlunky2/sprites/base_classes/base_sprite_merger.py
@@ -100,12 +100,13 @@ class BaseSpriteMerger(ABC):
             lines.reverse()
             current_height = 0
             for line in lines:
-                _line_left, _line_top, line_right, line_bottom = default_font.getbbox(
+                line_left, line_top, line_right, line_bottom = default_font.getbbox(
                     line
                 )
-                current_height = current_height + line_bottom
+                line_width = line_right - line_left
+                current_height += line_bottom - line_top
                 self._grid_image_draw.text(
-                    (image_size[0] - line_right, image_size[1] - current_height),
+                    (image_size[0] - line_width, image_size[1] - current_height),
                     line,
                     font=default_font,
                 )

--- a/src/modlunky2/sprites/sprite_fetcher.py
+++ b/src/modlunky2/sprites/sprite_fetcher.py
@@ -115,16 +115,16 @@ class SpelunkySpriteFetcher:
             new_font = ImageFont.truetype(
                 str(BASE_DIR / "static/fonts/FiraSans-SemiBold.ttf"), size=font_size
             )
-            dimensions = imgdraw.textsize(imgtxt, new_font)
-            if dimensions[0] > (w - (padding * 2)) or dimensions[1] > (
-                h - (padding * 2) - padding
-            ):
+            dimensions = imgdraw.textbbox((0, 0), imgtxt, new_font)
+            if (dimensions[2] - dimensions[0]) > (w - (padding * 2)) or (
+                dimensions[3] - dimensions[1]
+            ) > (h - (padding * 2) - padding):
                 break
             font = new_font
 
-        txt_dimensions = imgdraw.textsize(imgtxt, font)
-        x_padding = (w - txt_dimensions[0]) / 2
-        y_padding = (h - txt_dimensions[1]) / 2
+        txt_dimensions = imgdraw.textbbox((0, 0), imgtxt, font)
+        x_padding = (w - (txt_dimensions[2] - txt_dimensions[0])) / 2
+        y_padding = (h - (txt_dimensions[3] - txt_dimensions[1])) / 2
 
         imgdraw.multiline_text(
             (x_padding, y_padding),


### PR DESCRIPTION
* Correct size calculation. Might not matter in practice, but I found a [migration example](https://pillow.readthedocs.io/en/stable/releasenotes/9.2.0.html) and it seems worth fixing while we're here
* Replace uses of `textsize` with `textbbox`. In addition to the bounding box change, it also takes a new position parameter