### PR TITLE
Tweak type annotations for pylint

### DIFF
--- a/src/modlunky2/levels/level_settings.py
+++ b/src/modlunky2/levels/level_settings.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from collections import OrderedDict
-from typing import ClassVar, Generic, Optional, TextIO, TypeVar
+from typing import ClassVar, Generic, Optional, TextIO, TypeVar, cast
 
 from modlunky2.levels.utils import (
     DirectivePrefixes,
@@ -115,7 +115,8 @@ class LevelSetting(Generic[T]):
             return
 
         if self.name == "size":
-            value = tuple(self.value.split())
+            # The cast is for pylint, which doesn't recognize the narrowing of isinstance
+            value = tuple(cast(self.value, str).split())
             if len(value) != 2:
                 raise ValueError("Directive `size` expects 2 values.")
         elif self.name == "liquid_gravity":

--- a/src/modlunky2/mem/memrauder/model.py
+++ b/src/modlunky2/mem/memrauder/model.py
@@ -259,7 +259,7 @@ class _StructField:
 @dataclass(frozen=True)
 class DataclassStruct(MemType[T]):
     path: FieldPath
-    dataclass: T
+    dataclass: Type[T]
 
     struct_fields: Dict[str, _StructField] = dataclasses.field(init=False)
 
@@ -358,7 +358,7 @@ class ScalarCValueConstructionError(Exception):
 @dataclass(frozen=True)
 class ScalarCType(BiMemType[T]):
     path: FieldPath
-    py_type: T
+    py_type: Type[T]
     c_type: type
 
     # Dict doesn't work correctly, presumably c_foo isn't hashable


### PR DESCRIPTION
I'm not sure what caused pylint to be more strict here, since all checks passed on each PR. Anyway... this seems to make it happy enough. Making a PR to verify fixes work across Python versions