### PR TITLE
Upgrade tokio-tungstenite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -4625,9 +4625,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
  "bytes",

--- a/src/libs/ml2_mods/Cargo.toml
+++ b/src/libs/ml2_mods/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.32", features = [
     "tracing",
 ] }
 tokio-graceful-shutdown = "0.13"
-tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
 tower = { version = "0.4", features = ["util"] }
 tracing = "0.1"
 zip = "0.6"


### PR DESCRIPTION
Tungstenite, and therefore tokio-tungstenite, had some notable API changes:
* Buffers are now in terms of bytes
* Implicit flushes have generally been removed

The default send buffer is 128KiB, which seems more than enough for our needs. Note that writes will fail if the buffer is full, but I'd wrather do that than consume unbounded memory. Also we flush a lot, maybe too much.

Generally, the websocket stuff could probably use some more thought. This is just enough to keep it working roughly the same.