### PR TITLE
Add co-op support to gem tracker and pacifist tracker; add yem count to gem tracker

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -160,9 +160,10 @@ class TimerTrackerConfig(CommonTrackerConfig):
 @deserialize(rename_all="kebabcase")
 @dataclass
 class GemTrackerConfig(CommonTrackerConfig):
-    show_total_gem_count: bool = field(default=True, skip_if_default=True)
-    show_colored_gem_count: bool = field(default=True, skip_if_default=True)
+    show_total_gem_count: bool = field(default=False, skip_if_default=True)
+    show_colored_gem_count: bool = field(default=False, skip_if_default=True)
     show_diamond_count: bool = field(default=True, skip_if_default=True)
+    show_yem_count: bool = field(default=True, skip_if_default=True)
     show_diamond_percentage: bool = field(default=True, skip_if_default=True)
 
 

--- a/src/modlunky2/mem/entities.py
+++ b/src/modlunky2/mem/entities.py
@@ -213,6 +213,7 @@ class Mount(Movable):
 
 @dataclass(frozen=True)
 class Inventory:
+    _size_as_element_: ClassVar[int] = 5412
     # Amount of money collected in the current level
     money: int = struct_field(0x00, sc_uint32, default=0)
     bombs: int = struct_field(0x04, sc_uint8, default=4)

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -3,7 +3,7 @@ import enum
 from typing import FrozenSet, Optional, Tuple
 from modlunky2.mem.arena_state import ArenaState
 
-from modlunky2.mem.entities import EntityType, Player
+from modlunky2.mem.entities import EntityType, Player, Inventory
 
 from modlunky2.mem.memrauder.dsl import (
     array,
@@ -141,6 +141,9 @@ class FeedcodeNotFound(Exception):
 class Items:
     players: Tuple[Optional[Player], ...] = struct_field(
         0x08, array(pointer(dc_struct), 4)
+    )
+    player_inventory: Tuple[Optional[Inventory], ...] = struct_field(
+        0x28, array(dc_struct, 4)
     )
 
 

--- a/src/modlunky2/mem/state.py
+++ b/src/modlunky2/mem/state.py
@@ -142,9 +142,7 @@ class Items:
     players: Tuple[Optional[Player], ...] = struct_field(
         0x08, array(pointer(dc_struct), 4)
     )
-    player_inventory: Tuple[Optional[Inventory], ...] = struct_field(
-        0x28, array(dc_struct, 4)
-    )
+    player_inventory: Tuple[Inventory, ...] = struct_field(0x28, array(dc_struct, 4))
 
 
 @dataclass(frozen=True)

--- a/src/modlunky2/ui/trackers/gem.py
+++ b/src/modlunky2/ui/trackers/gem.py
@@ -250,9 +250,9 @@ class GemTracker(Tracker[GemTrackerConfig, WindowData]):
             diamonds = 0
             yems = 0
 
-            for player in game_state.items.players:
-                if player is not None and player.inventory is not None:
-                    collected_money = player.inventory.collected_money
+            for inventory in game_state.items.player_inventory:
+                if inventory is not None:
+                    collected_money = inventory.collected_money
                     for entity in collected_money:
                         if entity in GEMS:
                             gems += 1

--- a/src/modlunky2/ui/trackers/pacifist.py
+++ b/src/modlunky2/ui/trackers/pacifist.py
@@ -120,11 +120,12 @@ class PacifistTracker(Tracker[PacifistTrackerConfig, WindowData]):
 
         run_recap_flags = game_state.run_recap_flags
 
-        player = None
         if game_state.items is not None:
-            player = game_state.items.players[0]
-        if player is not None and player.inventory is not None:
-            self.kills_total = player.inventory.kills_total
+            total_kills = 0
+            for inventory in game_state.items.player_inventory:
+                if inventory is not None:
+                    total_kills += inventory.kills_total
+            self.kills_total = total_kills
 
         is_pacifist = bool(run_recap_flags & RunRecapFlags.PACIFIST)
         label = self.get_text(is_pacifist, config)


### PR DESCRIPTION
- Both gem tracker and pacifist tracker kill count now work in co-op instead of only for player 1
- Player inventory is accessed directly instead of through pointer, fixing issues when a player is crushed
- Add yem count (Yems are gems that should have been ghosted (i.e. all colorful gems except those in levels where the ghost doesn't spawn))