### PR TITLE
[Level editor] Add keyboard shortcut for selecting tiles

### DIFF
--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -689,7 +689,7 @@ class CustomLevelEditor(ttk.Frame):
 
             self.log_codes_left()
             self.changes_made()
-            
+
             return True
         else:
             return False

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -657,16 +657,16 @@ class CustomLevelEditor(ttk.Frame):
         return ref_tile
 
     def delete_tilecode(self, tile_name, tile_code):
+        if tile_name == r"empty":
+            tkMessageBox.showinfo("Uh Oh!", "Can't delete empty!")
+            return False
+
         msg_box = tk.messagebox.askquestion(
             "Delete Tilecode?",
             "Are you sure you want to delete this Tilecode?\nAll of its placements will be replaced with air.",
             icon="warning",
         )
         if msg_box == "yes":
-            if tile_name == r"empty":
-                tkMessageBox.showinfo("Uh Oh!", "Can't delete empty!")
-                return
-
             new_tile = self.tile_palette_map["0"]
             for matrix_index, tile_code_matrix in enumerate(self.tile_codes):
                 for row in range(len(tile_code_matrix)):
@@ -689,6 +689,10 @@ class CustomLevelEditor(ttk.Frame):
 
             self.log_codes_left()
             self.changes_made()
+            
+            return True
+        else:
+            return False
 
     def log_codes_left(self):
         codes = ""

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -102,7 +102,7 @@ class SelectedTilecodeView(ttk.Frame):
 
         self.delete_button = tk.Button(
             self,
-            text="Del",
+            text="Delete",
             bg="red",
             fg="white",
             width=10,
@@ -143,9 +143,10 @@ class SelectedTilecodeView(ttk.Frame):
     def tile_code(self):
         return self.name.split(" ", 1)[1]
 
-    def reset(self):
+    def reset(self, disable=True):
         self.select_tile("empty 0", None)
-        self.disable()
+        if disable:
+            self.disable()
 
     def enable(self):
         self.delete_button["state"] = tk.NORMAL
@@ -193,11 +194,12 @@ class PalettePanel(ttk.Frame):
         self.new_tile_panel.grid(row=3, column=0, sticky="swne")
 
     def delete_tilecode(self, tile_name, tile_code):
-        self.on_delete_tilecode(tile_name, tile_code)
-        if self.primary_tile_view.tile_code() == tile_code:
-            self.primary_tile_view.reset()
-        if self.secondary_tile_view.tile_code() == tile_code:
-            self.secondary_tile_view.reset()
+        deleted = self.on_delete_tilecode(tile_name, tile_code)
+        if deleted:
+            if self.primary_tile_view.tile_code() == tile_code:
+                self.primary_tile_view.reset(disable=False)
+            if self.secondary_tile_view.tile_code() == tile_code:
+                self.secondary_tile_view.reset(disable=False)
 
     def update_with_palette(self, new_palette, suggestions, biome, lvl):
         for widget in self.palette.scrollable_frame.winfo_children():

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -164,7 +164,7 @@ class PalettePanel(ttk.Frame):
         texture_fetcher,
         sprite_fetcher,
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(parent, *args, **kwargs)
 
@@ -205,15 +205,19 @@ class PalettePanel(ttk.Frame):
         for widget in self.palette.scrollable_frame.winfo_children():
             widget.destroy()
 
+        TILES_PER_ROW = 8
+
         count_row = 0
         count_col = -1
         self.tile_images = []
         used_tile_names = []
+
         for tile_keep in new_palette:
-            if count_col == 7:
-                count_col = -1
+            count_col += 1
+            if count_col == TILES_PER_ROW:
+                count_col = 0
                 count_row = count_row + 1
-            count_col = count_col + 1
+
             tile_name = tile_keep[0].split(" ", 2)[0]
             used_tile_names.append(tile_name)
 
@@ -236,6 +240,18 @@ class PalettePanel(ttk.Frame):
                 lambda event, r=count_row, c=count_col: self.tile_pick(event, r, c),
             )
 
+            # Bind first ten tiles to number keys
+            tile_index = count_col + (count_row * TILES_PER_ROW) + 1
+            if tile_index <= 10:
+                self.bind_all(
+                    f"{tile_index%10}",
+                    lambda event, r=count_row, c=count_col: self.tile_pick(event, r, c),
+                )
+                self.bind_all(
+                    f"<Alt-Key-{tile_index%10}>",
+                    lambda event, r=count_row, c=count_col: self.tile_pick(event, r, c),
+                )
+
         if suggestions and len(suggestions):
             count_col = -1
             self.palette.scrollable_frame.rowconfigure(count_row + 1, minsize=15)
@@ -250,10 +266,12 @@ class PalettePanel(ttk.Frame):
                 if suggestion in used_tile_names:
                     # Do not suggest a tile that already exists in the palette.
                     continue
-                if count_col == 7:
-                    count_col = -1
+
+                count_col += 1
+                if count_col == TILES_PER_ROW:
+                    count_col = 0
                     count_row = count_row + 1
-                count_col = count_col + 1
+
                 tile_image = ImageTk.PhotoImage(
                     self.texture_fetcher.get_texture(suggestion, biome, lvl, 40)
                 )
@@ -284,8 +302,11 @@ class PalettePanel(ttk.Frame):
         self.new_tile_panel.enable()
 
     def tile_pick(self, event, row, col):
+        if not self.palette.scrollable_frame.grid_slaves(row, col):
+            return
         selected_tile = self.palette.scrollable_frame.grid_slaves(row, col)[0]
-        self.select_tile(selected_tile["text"], selected_tile["image"], event.num == 1)
+        is_primary = (event.num == 1) or (event.state & 0x20000 == 0)
+        self.select_tile(selected_tile["text"], selected_tile["image"], is_primary)
 
     def suggested_tile_pick(self, event, suggested_tile, tile_image):
         tile = self.on_add_tilecode(suggested_tile, 100, "empty")


### PR DESCRIPTION
- For the first ten tiles in the palette, press a _number key_ to set the primary tile or _alt + number key_ to set the secondary tile.
Inspired by https://github.com/spelunky-fyi/modlunky2/issues/78 but does something different. Would be even more useful with https://github.com/spelunky-fyi/modlunky2/issues/64.


- Also fixes tile-deletion-buttons being disabled after clicking them