### PR TITLE
Fix Olmec Ship cutscene gem tracker issue

### DIFF
--- a/src/modlunky2/ui/trackers/gem.py
+++ b/src/modlunky2/ui/trackers/gem.py
@@ -210,6 +210,7 @@ class GemTracker(Tracker[GemTrackerConfig, WindowData]):
             return None
 
         level_has_ghost = game_state.theme not in [
+            Theme.BASE_CAMP,
             Theme.OLMEC,
             Theme.ABZU,
             Theme.DUAT,
@@ -223,7 +224,9 @@ class GemTracker(Tracker[GemTrackerConfig, WindowData]):
         level = game_state.level
 
         # On level change
-        if world != self.world or level != self.level:
+        if (
+            world != self.world or level != self.level
+        ) and game_state.theme != Theme.BASE_CAMP:
             # Update world and level
             self.world = world
             self.level = level

--- a/src/modlunky2/ui/trackers/pacino_golf_tracker.py
+++ b/src/modlunky2/ui/trackers/pacino_golf_tracker.py
@@ -248,7 +248,9 @@ class PacinoGolfTracker(Tracker[PacinoGolfTrackerConfig, WindowData]):
         level = game_state.level
 
         # Save treasure strokes on level change
-        if world != self.world or level != self.level:
+        if (
+            world != self.world or level != self.level
+        ) and game_state.theme != Theme.BASE_CAMP:
             self.world = world
             self.level = level
             self.treasure_strokes += self.treasure_strokes_level


### PR DESCRIPTION
Going from Tiamat to Sunken City does two extra level transitions (6-4 => 6-1 => 6-4 => 7-1).
This adds the number of gems collected in Tiamat twice (even to the yem counter). [(Video of bug)](https://www.twitch.tv/videos/1995902836?t=02h51m55s)
These are now excluded (they have the BASE_CAMP theme).