### PR TITLE
Replace the full level viewer with a full level editor

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -7,7 +7,7 @@ import logging
 import shutil
 import time
 from enum import Enum
-from typing import List, Optional, TypeVar, Set
+from typing import Dict, List, Optional, TypeVar, Set
 
 try:
     import winreg
@@ -181,6 +181,21 @@ class CustomLevelSaveFormat:
     def vanilla(cls):
         return cls("Vanilla setroom [warning]", "setroom{y}-{x}", False)
 
+@serialize(rename_all="kebabcase")
+@deserialize(rename_all="kebabcase")
+@dataclass
+class CustomRoomMapSegment:
+    name: str
+    templates: List[List[str]]
+
+
+@serialize(rename_all="kebabcase")
+@deserialize(rename_all="kebabcase")
+@dataclass
+class CustomRoomMap:
+    name: str
+    segments: List[CustomRoomMapSegment]
+
 
 @serialize(rename_all="kebabcase")
 @deserialize(rename_all="kebabcase")
@@ -222,6 +237,12 @@ class Config:
     )
     custom_level_editor_default_save_format: Optional[CustomLevelSaveFormat] = field(
         default=None, skip_if_default=True
+    )
+    custom_room_maps: Dict[str, List[CustomRoomMap]] = field(
+        default_factory=dict, skip_if_default=True
+    )
+    default_custom_room_maps: Dict[str, int] = field(
+        default_factory=dict, skip_if_default=True
     )
     command_prefix: Optional[List[str]] = field(default=None, skip_if_default=True)
     api_port: int = field(default=9526)

--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -181,6 +181,7 @@ class CustomLevelSaveFormat:
     def vanilla(cls):
         return cls("Vanilla setroom [warning]", "setroom{y}-{x}", False)
 
+
 @serialize(rename_all="kebabcase")
 @deserialize(rename_all="kebabcase")
 @dataclass

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -15,7 +15,10 @@ from modlunky2.ui.levels.custom_levels.save_level import save_level
 from modlunky2.ui.levels.custom_levels.tile_sets import suggested_tiles_for_theme
 from modlunky2.ui.levels.shared.biomes import BIOME
 from modlunky2.ui.levels.shared.files_tree import FilesTree, PACK_LIST_TYPE, LEVEL_TYPE
-from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
+from modlunky2.ui.levels.shared.multi_canvas_container import (
+    MultiCanvasContainer,
+    CanvasIndex,
+)
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom
 from modlunky2.utils import tb_info
@@ -120,6 +123,7 @@ class CustomLevelEditor(ttk.Frame):
             editor_view,
             textures_dir,
             ["Foreground", "Background"],
+            [],
             self.zoom_level,
             self.canvas_click,
             self.canvas_shiftclick,
@@ -549,7 +553,7 @@ class CustomLevelEditor(ttk.Frame):
                     )
 
         for index, tileset in enumerate(self.tile_codes):
-            draw_layer(index, tileset)
+            draw_layer(CanvasIndex(index, 0), tileset)
 
     # Click event on a canvas for either left or right click to replace the tile at the cursor's position with
     # the selected tile.
@@ -565,11 +569,11 @@ class CustomLevelEditor(ttk.Frame):
             x_offset,
             y_offset,
         )
-        self.tile_codes[canvas_index][row][column] = tile_code
+        self.tile_codes[canvas_index.tab_index][row][column] = tile_code
         self.changes_made()
 
     def canvas_shiftclick(self, index, row, column, is_primary):
-        tile_code = self.tile_codes[index][row][column]
+        tile_code = self.tile_codes[index.tab_index][row][column]
         tile = self.tile_palette_map[tile_code]
 
         self.palette_panel.select_tile(tile[0], tile[2], is_primary)
@@ -674,7 +678,7 @@ class CustomLevelEditor(ttk.Frame):
                     for column in range(len(tile_code_matrix[row])):
                         if str(tile_code_matrix[row][column]) == str(tile_code):
                             self.canvas.replace_tile_at(
-                                matrix_index, row, column, new_tile[1]
+                                CanvasIndex(matrix_index, 0), row, column, new_tile[1]
                             )
                             tile_code_matrix[row][column] = "0"
             self.usable_codes.append(str(tile_code))

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -555,6 +555,8 @@ class CustomLevelEditor(ttk.Frame):
         for index, tileset in enumerate(self.tile_codes):
             draw_layer(CanvasIndex(index, 0), tileset)
 
+        self.canvas.update_scroll_region()
+
     # Click event on a canvas for either left or right click to replace the tile at the cursor's position with
     # the selected tile.
     def canvas_click(self, canvas_index, row, column, is_primary):

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -159,6 +159,7 @@ class CustomLevelEditor(ttk.Frame):
             side_panel_tab_control,
             self.delete_tilecode,
             self.add_tilecode,
+            None,
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )

--- a/src/modlunky2/ui/levels/shared/level_canvas.py
+++ b/src/modlunky2/ui/levels/shared/level_canvas.py
@@ -194,7 +194,7 @@ class LevelCanvas(tk.Canvas):
 
     def draw_room_grid(self, width=1, special_room_sizes: GridRoom=None):
         def create_room_boundary_box(row, col, w, h):
-            self.create_rectangle(
+            return self.create_rectangle(
                 col * 10 * self.zoom_level,
                 row * 8 * self.zoom_level,
                 (col + w) * 10 * self.zoom_level - 1 + (width - 1),

--- a/src/modlunky2/ui/levels/shared/level_canvas.py
+++ b/src/modlunky2/ui/levels/shared/level_canvas.py
@@ -17,6 +17,7 @@ class GridRoom:
     width: int
     height: int
 
+
 class LevelCanvas(tk.Canvas):
     def __init__(
         self, parent, textures_dir, zoom_level, on_click, on_pull_tile, *args, **kwargs
@@ -167,7 +168,6 @@ class LevelCanvas(tk.Canvas):
             anchor="nw",
         )
 
-
     def draw_grid(self, width=1):
         self.grid_lines = [
             self.create_line(
@@ -192,7 +192,7 @@ class LevelCanvas(tk.Canvas):
         ]
         self.hide_grid_lines(self.grid_hidden)
 
-    def draw_room_grid(self, width=1, special_room_sizes: GridRoom=None):
+    def draw_room_grid(self, width=1, special_room_sizes: GridRoom = None):
         def create_room_boundary_box(row, col, w, h):
             return self.create_rectangle(
                 col * 10 * self.zoom_level,
@@ -202,14 +202,17 @@ class LevelCanvas(tk.Canvas):
                 outline="#30F030",
                 width=width,
             )
+
         if special_room_sizes is not None:
             self.room_lines = [
-                create_room_boundary_box(r.row, r.column, r.width, r.height) for r in special_room_sizes
+                create_room_boundary_box(r.row, r.column, r.width, r.height)
+                for r in special_room_sizes
             ]
         else:
             self.room_lines = [
                 create_room_boundary_box(row, col, 1, 1)
-                for row in range(0, int(self.height / 8)) for col in range(0, int(self.width / 10))
+                for row in range(0, int(self.height / 8))
+                for col in range(0, int(self.width / 10))
             ]
         self.hide_room_lines(self.rooms_hidden)
 

--- a/src/modlunky2/ui/levels/shared/level_canvas.py
+++ b/src/modlunky2/ui/levels/shared/level_canvas.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import logging
 import math
 import tkinter as tk
@@ -8,6 +9,13 @@ from modlunky2.ui.levels.shared.biomes import BIOME
 
 logger = logging.getLogger(__name__)
 
+
+@dataclass
+class GridRoom:
+    row: int
+    column: int
+    width: int
+    height: int
 
 class LevelCanvas(tk.Canvas):
     def __init__(
@@ -184,29 +192,25 @@ class LevelCanvas(tk.Canvas):
         ]
         self.hide_grid_lines(self.grid_hidden)
 
-    def draw_room_grid(self, width=1):
-        self.room_lines = [
-            self.create_line(
-                i * 10 * self.zoom_level,
-                0,
-                i * 10 * self.zoom_level,
-                self.height * self.zoom_level,
-                fill="#30F030",
+    def draw_room_grid(self, width=1, special_room_sizes: GridRoom=None):
+        def create_room_boundary_box(row, col, w, h):
+            self.create_rectangle(
+                col * 10 * self.zoom_level,
+                row * 8 * self.zoom_level,
+                (col + w) * 10 * self.zoom_level - 1 + (width - 1),
+                (row + h) * 8 * self.zoom_level - 1 + (width - 1),
+                outline="#30F030",
                 width=width,
             )
-            for i in range(0, int(self.width / 10))
-        ] + [
-            # for i in range(0, rows * 8):
-            self.create_line(
-                0,
-                i * 8 * self.zoom_level,
-                self.zoom_level * self.width,
-                i * 8 * self.zoom_level,
-                fill="#30F030",
-                width=width,
-            )
-            for i in range(0, int(self.height / 8))
-        ]
+        if special_room_sizes is not None:
+            self.room_lines = [
+                create_room_boundary_box(r.row, r.column, r.width, r.height) for r in special_room_sizes
+            ]
+        else:
+            self.room_lines = [
+                create_room_boundary_box(row, col, 1, 1)
+                for row in range(0, int(self.height / 8)) for col in range(0, int(self.width / 10))
+            ]
         self.hide_room_lines(self.rooms_hidden)
 
     def hide_grid_lines(self, hide):

--- a/src/modlunky2/ui/levels/shared/level_canvas.py
+++ b/src/modlunky2/ui/levels/shared/level_canvas.py
@@ -28,6 +28,7 @@ class LevelCanvas(tk.Canvas):
         self.room_lines = []
 
         self.cached_bgs = {}
+        self.cached_bg_overs = {}
 
         self.width = 0
         self.height = 0
@@ -93,6 +94,7 @@ class LevelCanvas(tk.Canvas):
     def set_zoom(self, zoom_level):
         self.zoom_level = zoom_level
         self.cached_bgs = {}
+        self.cached_bg_overs = {}
 
     def replace_tile_at(self, row, column, image, offset_x=0, offset_y=0):
         if len(self.tile_images) <= row or len(self.tile_images[row]) <= column:
@@ -137,7 +139,28 @@ class LevelCanvas(tk.Canvas):
                     anchor="nw",
                 )
 
-    def draw_grid(self):
+    def draw_background_over_room(self, theme, row, col):
+        bg_img = self.cached_bg_overs.get(theme)
+        if not bg_img:
+            background = self.background_for_theme(theme)
+            image = Image.open(background).convert("RGBA")
+            image = image.resize(
+                (self.zoom_level * 10, self.zoom_level * 8), Image.BILINEAR
+            )
+            enhancer = ImageEnhance.Brightness(image)
+            im_output = enhancer.enhance(0.2)
+            bg_img = ImageTk.PhotoImage(im_output)
+            self.cached_bg_overs[theme] = bg_img
+
+        self.create_image(
+            col * self.zoom_level * 10,
+            row * self.zoom_level * 8,
+            image=bg_img,
+            anchor="nw",
+        )
+
+
+    def draw_grid(self, width=1):
         self.grid_lines = [
             self.create_line(
                 i * self.zoom_level,
@@ -145,21 +168,23 @@ class LevelCanvas(tk.Canvas):
                 i * self.zoom_level,
                 self.height * self.zoom_level,
                 fill="#F0F0F0",
+                width=width,
             )
             for i in range(0, self.width + 2)
         ] + [
             self.create_line(
                 0,
-                i * self.zoom_level,
+                i * self.zoom_level - 1,
                 self.zoom_level * (self.width + 2),
                 i * self.zoom_level,
                 fill="#F0F0F0",
+                width=width,
             )
             for i in range(0, self.height)
         ]
         self.hide_grid_lines(self.grid_hidden)
 
-    def draw_room_grid(self):
+    def draw_room_grid(self, width=1):
         self.room_lines = [
             self.create_line(
                 i * 10 * self.zoom_level,
@@ -167,6 +192,7 @@ class LevelCanvas(tk.Canvas):
                 i * 10 * self.zoom_level,
                 self.height * self.zoom_level,
                 fill="#30F030",
+                width=width,
             )
             for i in range(0, int(self.width / 10))
         ] + [
@@ -177,6 +203,7 @@ class LevelCanvas(tk.Canvas):
                 self.zoom_level * self.width,
                 i * 8 * self.zoom_level,
                 fill="#30F030",
+                width=width,
             )
             for i in range(0, int(self.height / 8))
         ]

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -1,8 +1,16 @@
+from dataclasses import dataclass
 import tkinter as tk
 from tkinter import ttk
+from typing import List
 
 from modlunky2.ui.levels.shared.level_canvas import LevelCanvas, GridRoom
 from modlunky2.utils import is_windows
+
+
+@dataclass
+class CanvasIndex:
+    tab_index: int
+    canvas_index: int
 
 
 class MultiCanvasContainer(tk.Frame):
@@ -10,12 +18,12 @@ class MultiCanvasContainer(tk.Frame):
         self,
         parent,
         textures_dir,
+        tab_titles,
         canvas_titles,
         zoom_level,
         on_click=None,
         on_shiftclick=None,
         intro_text=None,
-        side_by_side=False,
         *args,
         **kwargs
     ):
@@ -23,10 +31,14 @@ class MultiCanvasContainer(tk.Frame):
 
         self.on_click = on_click
         self.on_shiftclick = on_shiftclick
-        self.side_by_side = side_by_side
 
         self.columnconfigure(1, weight=1)
         self.rowconfigure(1, weight=1)
+
+        if tab_titles is None or len(tab_titles) == 0:
+            tab_titles = [""]
+        if canvas_titles is None or len(canvas_titles) == 0:
+            canvas_titles = [""]
 
         scrollable_canvas = tk.Canvas(self, bg="#292929")
         scrollable_canvas.grid(row=0, column=0, rowspan=2, columnspan=2, sticky="news")
@@ -48,7 +60,7 @@ class MultiCanvasContainer(tk.Frame):
 
         scrollable_frame.columnconfigure(0, minsize=int(int(width) / 2))
         scrollable_frame.columnconfigure(1, weight=1)
-        canvas_gaps = side_by_side and len(canvas_titles) - 1 or 1
+        canvas_gaps = len(canvas_titles) - 1
         for column in range(canvas_gaps):
             scrollable_frame.columnconfigure((column + 1) * 2, minsize=50)
         scrollable_frame.columnconfigure(
@@ -84,6 +96,7 @@ class MultiCanvasContainer(tk.Frame):
         )
 
         scrollable_canvas.config(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
+        self.scrollable_canvas = scrollable_canvas
 
         switches_container = tk.Frame(self, bg="#343434")
         switches_container.grid(row=0, column=0, sticky="nw")
@@ -92,6 +105,7 @@ class MultiCanvasContainer(tk.Frame):
         self.canvases = []
         self.labels = []
         self.radio_buttons = []
+        self.hidden_tabs = []
         self.hidden_canvases = []
 
         # Buttons to switch the active layer.
@@ -101,38 +115,42 @@ class MultiCanvasContainer(tk.Frame):
         def switch_layer():
             nonlocal switch_variable
             layer = switch_variable.get()
-            for index, canvas in enumerate(self.canvases):
-                if index == int(layer):
-                    canvas.grid()
+            for tab_index, tab_of_canvases in enumerate(self.canvases):
+                if tab_index == int(layer):
+                    for canvas in tab_of_canvases:
+                        canvas.grid()
                 else:
-                    canvas.grid_remove()
+                    for canvas in tab_of_canvases:
+                        canvas.grid_remove()
 
-        for index, canvas_title in enumerate(canvas_titles):
-            new_canvas = LevelCanvas(
-                scrollable_frame,
-                textures_dir,
-                zoom_level,
-                on_click
-                and (
-                    lambda row, column, is_primary, i=index: self.on_click(
-                        i, row, column, is_primary
-                    )
-                ),
-                on_shiftclick
-                and (
-                    lambda row, column, is_primary, i=index: self.on_shiftclick(
-                        i, row, column, is_primary
-                    )
-                ),
-                bg="#343434",
-            )
-            new_canvas.grid(row=1, column=(side_by_side and (index * 2) or 0) + 1)
-            if index != 0 and not side_by_side:
-                new_canvas.grid_remove()
-            self.canvases.append(new_canvas)
+        for tab_index, tab_title in enumerate(tab_titles):
+            tab_canvases = []
+            self.canvases.append(tab_canvases)
+            for index, canvas_title in enumerate(canvas_titles):
+                new_canvas = LevelCanvas(
+                    scrollable_frame,
+                    textures_dir,
+                    zoom_level,
+                    on_click
+                    and (
+                        lambda row, column, is_primary, i=CanvasIndex(
+                            tab_index, index
+                        ): self.on_click(i, row, column, is_primary)
+                    ),
+                    on_shiftclick
+                    and (
+                        lambda row, column, is_primary, i=CanvasIndex(
+                            tab_index, index
+                        ): self.on_shiftclick(i, row, column, is_primary)
+                    ),
+                    bg="#343434",
+                )
+                new_canvas.grid(row=1, column=index * 2 + 1)
+                if tab_index != 0:
+                    new_canvas.grid_remove()
+                tab_canvases.append(new_canvas)
 
-            if len(canvas_titles) > 1:
-                if side_by_side:
+                if len(canvas_titles) > 1:
                     label = tk.Label(
                         scrollable_frame,
                         text=canvas_title,
@@ -142,19 +160,20 @@ class MultiCanvasContainer(tk.Frame):
                     label.grid(row=2, column=index * 2 + 1, sticky="news")
                     # label.grid_remove()
                     self.labels.append(label)
-                else:
-                    switch_button = tk.Radiobutton(
-                        switches_container,
-                        text=canvas_title,
-                        variable=switch_variable,
-                        indicatoron=False,
-                        value=str(index),
-                        width=max(len(canvas_title), 10),
-                        command=switch_layer,
-                    )
-                    self.radio_buttons.append(switch_button)
 
-                    switch_button.grid(column=index, row=0, sticky="new")
+            if len(tab_titles) > 1:
+                switch_button = tk.Radiobutton(
+                    switches_container,
+                    text=tab_title,
+                    variable=switch_variable,
+                    indicatoron=False,
+                    value=str(tab_index),
+                    width=max(len(tab_title), 10),
+                    command=switch_layer,
+                )
+                self.radio_buttons.append(switch_button)
+
+                switch_button.grid(column=tab_index, row=0, sticky="new")
 
         switch_variable.set("0")
 
@@ -189,17 +208,9 @@ class MultiCanvasContainer(tk.Frame):
             self._scroll_vertical(scroll_dir, vbar, canvas)
 
     def _scroll_vertical(self, scroll_dir, scrollbar, canvas):
-        # If the scrollbar is max size don't bother scrolling
-        if scrollbar.get() == (0.0, 1.0):
-            return
-
         canvas.yview_scroll(scroll_dir, "units")
 
     def _scroll_horizontal(self, scroll_dir, scrollbar, canvas):
-        # If the scrollbar is max size don't bother scrolling
-        if scrollbar.get() == (0.0, 1.0):
-            return
-
         canvas.xview_scroll(scroll_dir, "units")
 
     def _bind_to_mousewheel(self, _event, hbar, vbar, canvas):
@@ -226,42 +237,64 @@ class MultiCanvasContainer(tk.Frame):
             canvas.unbind_all("<Button-5>")
 
     def replace_tile_at(self, index, row, column, image, offset_x=0, offset_y=0):
-        self.canvases[index].replace_tile_at(row, column, image, offset_x, offset_y)
+        self.canvases[index.tab_index][index.canvas_index].replace_tile_at(
+            row, column, image, offset_x, offset_y
+        )
 
-    def configure_size(self, width, height):
-        for canvas in self.canvases:
-            canvas.configure_size(width, height)
+    def configure_size(self, width, height, index=None):
+        if index is None:
+            for tab_of_canvases in self.canvases:
+                for canvas in tab_of_canvases:
+                    canvas.configure_size(width, height)
+        else:
+            self.canvases[index.tab_index][index.canvas_index].configure_size(
+                width, height
+            )
 
     def set_zoom(self, zoom_level):
-        for canvas in self.canvases:
-            canvas.set_zoom(zoom_level)
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.set_zoom(zoom_level)
 
     def clear(self):
-        for canvas in self.canvases:
-            canvas.clear()
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.clear()
 
     def hide_grid_lines(self, hide_grid_lines):
-        for canvas in self.canvases:
-            canvas.hide_grid_lines(hide_grid_lines)
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.hide_grid_lines(hide_grid_lines)
 
     def hide_room_lines(self, hide_room_lines):
-        for canvas in self.canvases:
-            canvas.hide_room_lines(hide_room_lines)
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.hide_room_lines(hide_room_lines)
 
     def draw_background(self, theme):
-        for canvas in self.canvases:
-            canvas.draw_background(theme)
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.draw_background(theme)
 
-    def draw_background_over_room(self, canvas_index, theme, row, col):
-        self.canvases[canvas_index].draw_background_over_room(theme, row, col)
+    def draw_background_over_room(self, index, theme, row, col):
+        self.canvases[index.tab_index][index.canvas_index].draw_background_over_room(
+            theme, row, col
+        )
 
     def draw_grid(self, width=None):
-        for canvas in self.canvases:
-            canvas.draw_grid(width)
+        for tab_of_canvases in self.canvases:
+            for canvas in tab_of_canvases:
+                canvas.draw_grid(width)
 
-    def draw_room_grid(self, width=1, special_room_sizes: GridRoom = None):
-        for canvas in self.canvases:
-            canvas.draw_room_grid(width, special_room_sizes)
+    def draw_room_grid(self, width=1, special_room_sizes: List[GridRoom] = None):
+        for tab_of_canvases in self.canvases:
+            for canvas_index, canvas in enumerate(tab_of_canvases):
+                canvas.draw_room_grid(
+                    width,
+                    None
+                    if special_room_sizes is None
+                    else special_room_sizes[canvas_index],
+                )
 
     def show_intro(self):
         if self.intro:
@@ -271,48 +304,60 @@ class MultiCanvasContainer(tk.Frame):
         if self.intro:
             self.intro.grid_remove()
 
+    def hide_tab(self, tab_index, hide):
+        if hide:
+            if tab_index in self.hidden_tabs:
+                return
+            self.hidden_tabs.append(tab_index)
+            selected_tab = int(self.switch_variable.get())
+
+            for canvas in self.canvases[tab_index]:
+                canvas.grid_remove()
+
+            self.radio_buttons[tab_index].grid_remove()
+            if tab_index == selected_tab:
+                for ind, tab_of_canvases in enumerate(self.canvases):
+                    if ind != tab_index and ind not in self.hidden_tabs:
+                        for canvas in tab_of_canvases:
+                            canvas.grid()
+                            self.switch_variable.set(str(ind))
+                            break
+            if len(self.hidden_tabs) >= len(self.canvases) - 1:
+                self.switches_container.grid_remove()
+        else:
+            if tab_index not in self.hidden_tabs:
+                return
+            self.hidden_tabs.remove(tab_index)
+            if len(self.canvases) - len(self.hidden_tabs) == 1:
+                for canvas in self.canvases[tab_index]:
+                    canvas.grid()
+            self.radio_buttons[tab_index].grid()
+            if len(self.hidden_tabs) < len(self.canvases) - 1:
+                self.switches_container.grid()
+
     def hide_canvas(self, canvas_index, hide):
         if hide:
             if canvas_index in self.hidden_canvases:
                 return
             self.hidden_canvases.append(canvas_index)
-            selected_canvas = int(self.switch_variable.get())
 
-            self.canvases[canvas_index].grid_remove()
-            if self.side_by_side:
-                self.labels[canvas_index].grid_remove()
+            for canvases in self.canvases:
+                canvases[canvas_index].grid_remove()
 
-                if len(self.hidden_canvases) >= len(self.canvases) - 1:
-                    for label in self.labels:
-                        label.grid_remove()
-            else:
-                self.radio_buttons[canvas_index].grid_remove()
-                if canvas_index == selected_canvas:
-                    for ind, canv in enumerate(self.canvases):
-                        if ind != canvas_index and not ind in self.hidden_canvases:
-                            canv.grid()
-                            self.switch_variable.set(str(ind))
-                            break
-                if len(self.hidden_canvases) >= len(self.canvases) - 1:
-                    self.switches_container.grid_remove()
+            self.labels[canvas_index].grid_remove()
 
-        elif self.side_by_side:
-            if not canvas_index in self.hidden_canvases:
+            if len(self.hidden_canvases) >= len(self.labels) - 1:
+                for label in self.labels:
+                    label.grid_remove()
+
+        else:
+            if canvas_index not in self.hidden_canvases:
                 return
             self.hidden_canvases.remove(canvas_index)
-            self.canvases[canvas_index].grid()
+            for canvases in self.canvases:
+                canvases[canvas_index].grid()
             self.labels[canvas_index].grid()
-            if len(self.hidden_canvases) < len(self.canvases) - 1:
+            if len(self.hidden_canvases) < len(self.labels) - 1:
                 for index, label in enumerate(self.labels):
                     if not index in self.hidden_canvases:
                         label.grid()
-        else:
-            if not canvas_index in self.hidden_canvases:
-                return
-            self.hidden_canvases.remove(canvas_index)
-            if len(self.canvases) - len(self.hidden_canvases) == 1:
-                self.canvaes[canvas_index].grid()
-
-            self.radio_buttons[canvas_index].grid()
-            if len(self.hidden_canvases) < len(self.canvases) - 1:
-                self.switches_container.grid()

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -24,6 +24,7 @@ class MultiCanvasContainer(tk.Frame):
         on_click=None,
         on_shiftclick=None,
         intro_text=None,
+        vertical = False,
         *args,
         **kwargs
     ):
@@ -62,14 +63,20 @@ class MultiCanvasContainer(tk.Frame):
         scrollable_frame.columnconfigure(1, weight=1)
         canvas_gaps = len(canvas_titles) - 1
         for column in range(canvas_gaps):
-            scrollable_frame.columnconfigure((column + 1) * 2, minsize=50)
+            if vertical:
+                scrollable_frame.rowconfigure((column + 1) * 2, minsize=50)
+            else:
+                scrollable_frame.columnconfigure((column + 1) * 2, minsize=50)
         scrollable_frame.columnconfigure(
-            (canvas_gaps + 1) * 2, minsize=int(int(width) / 2)
+            (canvas_gaps + 1) * 2 if not vertical else 4, minsize=int(int(width) / 2)
         )
         scrollable_frame.rowconfigure(0, minsize=int(int(height) / 2))
         scrollable_frame.rowconfigure(1, weight=1)
-        scrollable_frame.rowconfigure(2, minsize=100)
-        scrollable_frame.rowconfigure(4, minsize=int(int(height) / 2))
+        if not vertical:
+            scrollable_frame.rowconfigure(2, minsize=100)
+        if vertical:
+            scrollable_frame.rowconfigure((canvas_gaps + 1) * 2, minsize=50)
+        scrollable_frame.rowconfigure((canvas_gaps + 1) * 2 + 1 if vertical else 4, minsize=int(int(height) / 2))
 
         # Scroll bars for scrolling the canvases.
         hbar = ttk.Scrollbar(self, orient="horizontal", command=scrollable_canvas.xview)
@@ -145,7 +152,10 @@ class MultiCanvasContainer(tk.Frame):
                     ),
                     bg="#343434",
                 )
-                new_canvas.grid(row=1, column=index * 2 + 1)
+                if vertical:
+                    new_canvas.grid(row=index * 2 + 1, column=1, sticky="sw")
+                else:
+                    new_canvas.grid(row=1, column=index * 2 + 1, sticky="sw")
                 if tab_index != 0:
                     new_canvas.grid_remove()
                 tab_canvases.append(new_canvas)
@@ -157,7 +167,10 @@ class MultiCanvasContainer(tk.Frame):
                         fg="white",
                         bg="#343434",
                     )
-                    label.grid(row=2, column=index * 2 + 1, sticky="news")
+                    if vertical:
+                        label.grid(row=(index + 1) * 2, column=1, sticky="nw")
+                    else:
+                        label.grid(row=2, column=index * 2 + 1, sticky="news")
                     # label.grid_remove()
                     self.labels.append(label)
 

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -24,7 +24,7 @@ class MultiCanvasContainer(tk.Frame):
         on_click=None,
         on_shiftclick=None,
         intro_text=None,
-        vertical = False,
+        vertical=False,
         *args,
         **kwargs
     ):
@@ -76,7 +76,9 @@ class MultiCanvasContainer(tk.Frame):
             scrollable_frame.rowconfigure(2, minsize=100)
         if vertical:
             scrollable_frame.rowconfigure((canvas_gaps + 1) * 2, minsize=50)
-        scrollable_frame.rowconfigure((canvas_gaps + 1) * 2 + 1 if vertical else 4, minsize=int(int(height) / 2))
+        scrollable_frame.rowconfigure(
+            (canvas_gaps + 1) * 2 + 1 if vertical else 4, minsize=int(int(height) / 2)
+        )
 
         # Scroll bars for scrolling the canvases.
         hbar = ttk.Scrollbar(self, orient="horizontal", command=scrollable_canvas.xview)
@@ -205,7 +207,6 @@ class MultiCanvasContainer(tk.Frame):
             )
             intro_label.place(relx=0.5, rely=0.5, anchor="center")
 
-
     def _on_mousewheel(self, event, hbar, vbar, canvas):
         scroll_dir = None
         if event.num == 5 or event.delta == -120:
@@ -285,7 +286,7 @@ class MultiCanvasContainer(tk.Frame):
             for canvas in tab_of_canvases:
                 canvas.hide_room_lines(hide_room_lines)
 
-    def draw_background(self, theme, index = None):
+    def draw_background(self, theme, index=None):
         if index is None:
             for tab_of_canvases in self.canvases:
                 for canvas in tab_of_canvases:
@@ -315,7 +316,10 @@ class MultiCanvasContainer(tk.Frame):
                     if special_room_sizes is None
                     else special_room_sizes[canvas_index],
                 )
-    def draw_canvas_room_grid(self, canvas_index, width=1, special_room_sizes: GridRoom = None):
+
+    def draw_canvas_room_grid(
+        self, canvas_index, width=1, special_room_sizes: GridRoom = None
+    ):
         canvas = self.canvases[canvas_index.tab_index][canvas_index.canvas_index]
         canvas.draw_room_grid(width, special_room_sizes)
 

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 
-from modlunky2.ui.levels.shared.level_canvas import LevelCanvas
+from modlunky2.ui.levels.shared.level_canvas import LevelCanvas, GridRoom
 from modlunky2.utils import is_windows
 
 
@@ -259,9 +259,9 @@ class MultiCanvasContainer(tk.Frame):
         for canvas in self.canvases:
             canvas.draw_grid(width)
 
-    def draw_room_grid(self, width=None):
+    def draw_room_grid(self, width=1, special_room_sizes: GridRoom=None):
         for canvas in self.canvases:
-            canvas.draw_room_grid(width)
+            canvas.draw_room_grid(width, special_room_sizes)
 
     def show_intro(self):
         if self.intro:

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -212,6 +212,9 @@ class MultiCanvasContainer(tk.Frame):
         self.scrollable_canvas.update_idletasks()
         self.scrollable_canvas.config(scrollregion=self.scrollable_frame.bbox("all"))
 
+        self.scrollable_canvas.xview_moveto(.5)
+        self.scrollable_canvas.yview_moveto(.2)
+
     def _on_mousewheel(self, event, hbar, vbar, canvas):
         scroll_dir = None
         if event.num == 5 or event.delta == -120:

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -192,6 +192,7 @@ class MultiCanvasContainer(tk.Frame):
             )
             intro_label.place(relx=0.5, rely=0.5, anchor="center")
 
+
     def _on_mousewheel(self, event, hbar, vbar, canvas):
         scroll_dir = None
         if event.num == 5 or event.delta == -120:
@@ -271,20 +272,26 @@ class MultiCanvasContainer(tk.Frame):
             for canvas in tab_of_canvases:
                 canvas.hide_room_lines(hide_room_lines)
 
-    def draw_background(self, theme):
-        for tab_of_canvases in self.canvases:
-            for canvas in tab_of_canvases:
-                canvas.draw_background(theme)
+    def draw_background(self, theme, index = None):
+        if index is None:
+            for tab_of_canvases in self.canvases:
+                for canvas in tab_of_canvases:
+                    canvas.draw_background(theme)
+        else:
+            self.canvases[index.tab_index][index.canvas_index].draw_background(theme)
 
     def draw_background_over_room(self, index, theme, row, col):
         self.canvases[index.tab_index][index.canvas_index].draw_background_over_room(
             theme, row, col
         )
 
-    def draw_grid(self, width=None):
-        for tab_of_canvases in self.canvases:
-            for canvas in tab_of_canvases:
-                canvas.draw_grid(width)
+    def draw_grid(self, width=None, index=None):
+        if index is None:
+            for tab_of_canvases in self.canvases:
+                for canvas in tab_of_canvases:
+                    canvas.draw_grid(width)
+        else:
+            self.canvases[index.tab_index][index.canvas_index].draw_grid(width)
 
     def draw_room_grid(self, width=1, special_room_sizes: List[GridRoom] = None):
         for tab_of_canvases in self.canvases:
@@ -295,6 +302,9 @@ class MultiCanvasContainer(tk.Frame):
                     if special_room_sizes is None
                     else special_room_sizes[canvas_index],
                 )
+    def draw_canvas_room_grid(self, canvas_index, width=1, special_room_sizes: GridRoom = None):
+        canvas = self.canvases[canvas_index.tab_index][canvas_index.canvas_index]
+        canvas.draw_room_grid(width, special_room_sizes)
 
     def show_intro(self):
         if self.intro:

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -252,13 +252,16 @@ class MultiCanvasContainer(tk.Frame):
         for canvas in self.canvases:
             canvas.draw_background(theme)
 
-    def draw_grid(self):
-        for canvas in self.canvases:
-            canvas.draw_grid()
+    def draw_background_over_room(self, canvas_index, theme, row, col):
+        self.canvases[canvas_index].draw_background_over_room(theme, row, col)
 
-    def draw_room_grid(self):
+    def draw_grid(self, width=None):
         for canvas in self.canvases:
-            canvas.draw_room_grid()
+            canvas.draw_grid(width)
+
+    def draw_room_grid(self, width=None):
+        for canvas in self.canvases:
+            canvas.draw_room_grid(width)
 
     def show_intro(self):
         if self.intro:

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -212,8 +212,8 @@ class MultiCanvasContainer(tk.Frame):
         self.scrollable_canvas.update_idletasks()
         self.scrollable_canvas.config(scrollregion=self.scrollable_frame.bbox("all"))
 
-        self.scrollable_canvas.xview_moveto(.5)
-        self.scrollable_canvas.yview_moveto(.2)
+        self.scrollable_canvas.xview_moveto(0.5)
+        self.scrollable_canvas.yview_moveto(0.2)
 
     def _on_mousewheel(self, event, hbar, vbar, canvas):
         scroll_dir = None

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -259,7 +259,7 @@ class MultiCanvasContainer(tk.Frame):
         for canvas in self.canvases:
             canvas.draw_grid(width)
 
-    def draw_room_grid(self, width=1, special_room_sizes: GridRoom=None):
+    def draw_room_grid(self, width=1, special_room_sizes: GridRoom = None):
         for canvas in self.canvases:
             canvas.draw_room_grid(width, special_room_sizes)
 

--- a/src/modlunky2/ui/levels/shared/multi_canvas_container.py
+++ b/src/modlunky2/ui/levels/shared/multi_canvas_container.py
@@ -48,6 +48,7 @@ class MultiCanvasContainer(tk.Frame):
 
         scrollable_frame = tk.Frame(scrollable_canvas, bg="#343434")
         scrollable_frame.grid(row=0, column=0, sticky="nswe")
+        self.scrollable_frame = scrollable_frame
 
         width = scrollable_canvas.winfo_screenwidth()
         height = scrollable_canvas.winfo_screenheight()
@@ -206,6 +207,10 @@ class MultiCanvasContainer(tk.Frame):
                 wraplength=600,
             )
             intro_label.place(relx=0.5, rely=0.5, anchor="center")
+
+    def update_scroll_region(self):
+        self.scrollable_canvas.update_idletasks()
+        self.scrollable_canvas.config(scrollregion=self.scrollable_frame.bbox("all"))
 
     def _on_mousewheel(self, event, hbar, vbar, canvas):
         scroll_dir = None

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -285,7 +285,9 @@ class PalettePanel(ttk.Frame):
 
     def tile_pick(self, event, row, col):
         selected_tile = self.palette.scrollable_frame.grid_slaves(row, col)[0]
-        self.select_tile(selected_tile["text"], selected_tile["image"], event.num == 1, True)
+        self.select_tile(
+            selected_tile["text"], selected_tile["image"], event.num == 1, True
+        )
 
     def suggested_tile_pick(self, event, suggested_tile, tile_image):
         tile = self.on_add_tilecode(suggested_tile, 100, "empty")
@@ -293,7 +295,7 @@ class PalettePanel(ttk.Frame):
             return
         self.select_tile(tile[0], tile_image, event.num == 1, True)
 
-    def select_tile(self, tile_name, tile_image, is_primary, tell_delegate = False):
+    def select_tile(self, tile_name, tile_image, is_primary, tell_delegate=False):
         tile_view = self.primary_tile_view
         if not is_primary:
             tile_view = self.secondary_tile_view

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -160,6 +160,7 @@ class PalettePanel(ttk.Frame):
         parent,
         on_delete_tilecode,
         on_add_tilecode,
+        on_select_tile,
         texture_fetcher,
         sprite_fetcher,
         *args,
@@ -170,6 +171,7 @@ class PalettePanel(ttk.Frame):
         self.texture_fetcher = texture_fetcher
         self.on_delete_tilecode = on_delete_tilecode
         self.on_add_tilecode = on_add_tilecode
+        self.on_select_tile = on_select_tile
 
         # The tile palettes are loaded into here as buttons with their image
         # as a tile and text as their value to grab when needed.
@@ -283,19 +285,22 @@ class PalettePanel(ttk.Frame):
 
     def tile_pick(self, event, row, col):
         selected_tile = self.palette.scrollable_frame.grid_slaves(row, col)[0]
-        self.select_tile(selected_tile["text"], selected_tile["image"], event.num == 1)
+        self.select_tile(selected_tile["text"], selected_tile["image"], event.num == 1, True)
 
     def suggested_tile_pick(self, event, suggested_tile, tile_image):
         tile = self.on_add_tilecode(suggested_tile, 100, "empty")
         if not tile:
             return
-        self.select_tile(tile[0], tile_image, event.num == 1)
+        self.select_tile(tile[0], tile_image, event.num == 1, True)
 
-    def select_tile(self, tile_name, tile_image, is_primary):
+    def select_tile(self, tile_name, tile_image, is_primary, tell_delegate = False):
         tile_view = self.primary_tile_view
         if not is_primary:
             tile_view = self.secondary_tile_view
         tile_view.select_tile(tile_name, tile_image)
+
+        if tell_delegate and self.on_select_tile:
+            self.on_select_tile(tile_name, tile_image, is_primary)
 
     def reset(self):
         for widget in self.palette.scrollable_frame.winfo_children():

--- a/src/modlunky2/ui/levels/shared/setrooms.py
+++ b/src/modlunky2/ui/levels/shared/setrooms.py
@@ -1,10 +1,15 @@
+from dataclasses import dataclass
 from collections import namedtuple
 from enum import Enum
 import re
 
 RoomCoords = namedtuple("RoomCoords", ["x", "y"])
-MatchedSetroom = namedtuple("MatchedSetroom", ["name", "coords"])
+MatchedSetroom = namedtuple("MatchedSetroom", ["name", "template", "coords"])
 
+@dataclass
+class BaseTemplateData:
+    name: str
+    template: str
 
 class VANILLA_SETROOM_TYPE(Enum):
     NONE = "none"
@@ -14,9 +19,12 @@ class VANILLA_SETROOM_TYPE(Enum):
 
 
 class BaseTemplate:
-    setroom = "setroom{y}-{x}"
-    challenge = "challenge_{y}-{x}"
-    palace = "palaceofpleasure_{y}-{x}"
+    setroom = BaseTemplateData("setroom", "setroom{y}-{x}")
+    challenge = BaseTemplateData("challenge", "challenge_{y}-{x}")
+    palace = BaseTemplateData("palace of pleasure", "palaceofpleasure_{y}-{x}")
+    # setroom = {"name":"setroom", "template":"setroom{y}-{x}"}
+    # challenge = {"name":"challenge", "template":"challenge_{y}-{x}"}
+    # palace = {"name":"palace of pleasure", "template":"palaceofpleasure_{y}-{x}"}
 
 
 class Setroom:
@@ -36,9 +44,9 @@ class Setroom:
     @staticmethod
     def find_setroom_in_list(template_list, room):
         for setroom in template_list:
-            match = Setroom.match_setroom(setroom, room)
+            match = Setroom.match_setroom(setroom.template, room)
             if match:
-                return MatchedSetroom(setroom, match)
+                return MatchedSetroom(setroom.name, setroom.template, match)
         return None
 
     @staticmethod

--- a/src/modlunky2/ui/levels/shared/setrooms.py
+++ b/src/modlunky2/ui/levels/shared/setrooms.py
@@ -6,10 +6,12 @@ import re
 RoomCoords = namedtuple("RoomCoords", ["x", "y"])
 MatchedSetroom = namedtuple("MatchedSetroom", ["name", "template", "coords"])
 
+
 @dataclass
 class BaseTemplateData:
     name: str
     template: str
+
 
 class VANILLA_SETROOM_TYPE(Enum):
     NONE = "none"

--- a/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
@@ -90,7 +90,7 @@ class LevelsTree(ttk.Treeview):
             item_index = self.index(item_iid)
             parent_index = self.index(parent_iid)
             new_room = self.on_duplicate_room(parent_index, item_index)
-            self.insert(parent_iid, "end", text=new_room.name)
+            self.insert(parent_iid, "end", text=new_room.name or "room")
 
     def copy(self):
         item_iid = self.selection()[0]
@@ -109,7 +109,7 @@ class LevelsTree(ttk.Treeview):
                 item_index = self.index(parent_iid)
                 item_iid = parent_iid
             new_room = self.on_paste_room(item_index)
-            self.insert(item_iid, "end", text=new_room.name)
+            self.insert(item_iid, "end", text=new_room.name or "room")
 
     def delete_selected(self):
         item_iid = self.selection()[0]
@@ -145,7 +145,7 @@ class LevelsTree(ttk.Treeview):
             return
 
         new_room = self.on_add_room(self.index(parent))
-        self.insert(parent, "end", text=new_room.name)
+        self.insert(parent, "end", text=new_room.name or "room")
 
     def rename_dialog(self):
         item_iid = self.selection()[0]
@@ -211,7 +211,7 @@ class LevelsTree(ttk.Treeview):
                 room_display_name += "   // " + room.comment
             entry = self.insert("", "end", text=room_display_name)
             for layout in room.rooms:
-                self.insert(entry, "end", text=layout.name)
+                self.insert(entry, "end", text=layout.name or "room")
 
     def get_selected_room(self):
         selection = self.selection()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -151,6 +151,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.clear()
         self.show_intro()
         self.template_draw_map = find_roommap(room_templates)
+        self.options_panel.set_templates(self.template_draw_map)
         self.draw_canvas()
 
     def redraw(self):
@@ -203,12 +204,12 @@ class MultiRoomEditorTab(ttk.Frame):
                     template_row[col] = new_draw_item
                     replaced = True
         if replaced:
+            self.options_panel.set_templates(self.template_draw_map)
             self.redraw()
 
 
     def canvas_click(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10
-        # template_draw_item = self.template_draw_map[room_row][room_col]
         template_draw_item, room_row, room_col = self.template_item_at(room_row, room_col)
 
         if template_draw_item is None:
@@ -243,7 +244,6 @@ class MultiRoomEditorTab(ttk.Frame):
 
     def canvas_shiftclick(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10
-        # template_draw_item = self.template_draw_map[room_row][room_col]
         template_draw_item, room_row, room_col = self.template_item_at(room_row, room_col)
 
         if template_draw_item is None:

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -160,6 +160,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.clear()
         self.show_intro()
         self.template_draw_map = find_roommap(room_templates)
+        self.options_panel.reset()
         self.options_panel.set_templates(self.template_draw_map, room_templates)
         self.draw_canvas()
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -11,7 +11,10 @@ from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContain
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.multi_room.options_panel import OptionsPanel
-from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap, get_template_draw_item
+from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import (
+    find_roommap,
+    get_template_draw_item,
+)
 from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
 )
@@ -138,9 +141,11 @@ class MultiRoomEditorTab(ttk.Frame):
         if tile_name in self.tile_image_map:
             return self.tile_image_map[tile_name]
 
-        new_tile_image = ImageTk.PhotoImage(self.texture_fetcher.get_texture(
-            tile_name, self.lvl_biome, self.lvl, self.zoom_level
-        ))
+        new_tile_image = ImageTk.PhotoImage(
+            self.texture_fetcher.get_texture(
+                tile_name, self.lvl_biome, self.lvl, self.zoom_level
+            )
+        )
 
         self.tile_image_map[tile_name] = new_tile_image
         return new_tile_image
@@ -181,7 +186,11 @@ class MultiRoomEditorTab(ttk.Frame):
         chunk_index = None
         if len(template.rooms) == 0:
             return None
-        valid_rooms = [index for index, room in enumerate(template.rooms) if TemplateSetting.IGNORE not in room.settings]
+        valid_rooms = [
+            index
+            for index, room in enumerate(template.rooms)
+            if TemplateSetting.IGNORE not in room.settings
+        ]
 
         if row is not None and column is not None:
             for i in valid_rooms:
@@ -192,7 +201,10 @@ class MultiRoomEditorTab(ttk.Frame):
                             continue
                         if r == row and c == column:
                             continue
-                        if room.template_index == template_index and room.room_index == i:
+                        if (
+                            room.template_index == template_index
+                            and room.room_index == i
+                        ):
                             room_used = True
                             break
                     if room_used:
@@ -221,12 +233,17 @@ class MultiRoomEditorTab(ttk.Frame):
         )
 
     def change_template_at(self, row, col, template, template_index):
-        template_draw_item = self.__get_template_draw_item(template, template_index, row, col)
+        template_draw_item = self.__get_template_draw_item(
+            template, template_index, row, col
+        )
         if template_draw_item:
             if template_draw_item.width_in_rooms + col > 10:
                 # TODO: add error dialog.
                 win = PopupWindow("Cannot use this room template", self.modlunky_config)
-                lbl = ttk.Label(win, text="Using this template here will result in the map exceeding the maximum width.")
+                lbl = ttk.Label(
+                    win,
+                    text="Using this template here will result in the map exceeding the maximum width.",
+                )
                 lbl.grid(row=0, column=0)
 
                 ok_button = ttk.Button(win, text="OK", command=win.destroy)
@@ -238,8 +255,14 @@ class MultiRoomEditorTab(ttk.Frame):
                 for col_offset in range(template_draw_item.width_in_rooms):
                     if row_offset == 0 and col_offset == 0:
                         continue
-                    template, overlapping_row, overlapping_column = self.template_item_at(row + row_offset, col + col_offset)
-                    if template is not None and (overlapping_row != row or overlapping_column != col):
+                    (
+                        template,
+                        overlapping_row,
+                        overlapping_column,
+                    ) = self.template_item_at(row + row_offset, col + col_offset)
+                    if template is not None and (
+                        overlapping_row != row or overlapping_column != col
+                    ):
                         overlaps_room = True
 
             def update_template():
@@ -257,16 +280,24 @@ class MultiRoomEditorTab(ttk.Frame):
                             for _ in range(width - len(row)):
                                 row.append(None)
 
-                expand_to_height_if_necessary(self.template_draw_map, row + template_draw_item.height_in_rooms)
-                expand_to_width_if_necessary(self.template_draw_map, col + template_draw_item.width_in_rooms)
+                expand_to_height_if_necessary(
+                    self.template_draw_map, row + template_draw_item.height_in_rooms
+                )
+                expand_to_width_if_necessary(
+                    self.template_draw_map, col + template_draw_item.width_in_rooms
+                )
                 for row_offset in range(template_draw_item.height_in_rooms):
                     for col_offset in range(template_draw_item.width_in_rooms):
                         if row_offset == 0 and col_offset == 0:
                             continue
-                        _, overlapping_row, overlapping_column = self.template_item_at(row + row_offset, col + col_offset)
+                        _, overlapping_row, overlapping_column = self.template_item_at(
+                            row + row_offset, col + col_offset
+                        )
                         if overlapping_row is None or overlapping_column is None:
                             continue
-                        self.template_draw_map[overlapping_row][overlapping_column] = None
+                        self.template_draw_map[overlapping_row][
+                            overlapping_column
+                        ] = None
 
                 self.template_draw_map[row][col] = template_draw_item
                 while len(self.template_draw_map) > 0:
@@ -282,7 +313,10 @@ class MultiRoomEditorTab(ttk.Frame):
 
                     self.template_draw_map.pop()
 
-                while len(self.template_draw_map) > 0 and len(self.template_draw_map[0]) > 0:
+                while (
+                    len(self.template_draw_map) > 0
+                    and len(self.template_draw_map[0]) > 0
+                ):
                     has_room = False
                     for r in range(len(self.template_draw_map)):
                         c = len(self.template_draw_map[r]) - 1
@@ -296,18 +330,22 @@ class MultiRoomEditorTab(ttk.Frame):
                     for r in self.template_draw_map:
                         r.pop()
 
-
-                self.options_panel.set_templates(self.template_draw_map, self.room_templates)
+                self.options_panel.set_templates(
+                    self.template_draw_map, self.room_templates
+                )
                 self.redraw()
-
 
             if overlaps_room:
                 win = PopupWindow("Warning", self.modlunky_config)
+
                 def update_then_destroy():
                     update_template()
                     win.destroy()
 
-                lbl = ttk.Label(win, text="Using this template here will remove some other templates.")
+                lbl = ttk.Label(
+                    win,
+                    text="Using this template here will remove some other templates.",
+                )
                 lbl.grid(row=0, column=0)
                 lbl2 = ttk.Label(win, text="Proceed anyway?")
                 lbl2.grid(row=1, column=0)
@@ -320,7 +358,9 @@ class MultiRoomEditorTab(ttk.Frame):
                 buttons.columnconfigure(0, weight=1)
                 buttons.columnconfigure(1, weight=1)
 
-                ok_button = ttk.Button(buttons, text="Proceed", command=update_then_destroy)
+                ok_button = ttk.Button(
+                    buttons, text="Proceed", command=update_then_destroy
+                )
                 ok_button.grid(row=0, column=0, pady=5, sticky="news")
 
                 cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
@@ -388,18 +428,24 @@ class MultiRoomEditorTab(ttk.Frame):
             for col, template in enumerate(template_row):
                 if template is None:
                     continue
-                if template.template_index == template_index and template.room_index == chunk_index:
-                    new_draw_item = get_template_draw_item(template.template, template_index)
+                if (
+                    template.template_index == template_index
+                    and template.room_index == chunk_index
+                ):
+                    new_draw_item = get_template_draw_item(
+                        template.template, template_index
+                    )
                     template_row[col] = new_draw_item
                     replaced = True
         if replaced:
             self.options_panel.set_templates(self.template_draw_map)
             self.redraw()
 
-
     def canvas_click(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10
-        template_draw_item, room_row, room_col = self.template_item_at(room_row, room_col)
+        template_draw_item, room_row, room_col = self.template_item_at(
+            room_row, room_col
+        )
 
         if template_draw_item is None:
             # Do not draw on empty room.
@@ -426,7 +472,12 @@ class MultiRoomEditorTab(ttk.Frame):
             for c, other_template_draw_item in enumerate(room_rows):
                 if other_template_draw_item is None:
                     continue
-                if template_draw_item.template_index == other_template_draw_item.template_index and template_draw_item.room_index == other_template_draw_item.room_index:
+                if (
+                    template_draw_item.template_index
+                    == other_template_draw_item.template_index
+                    and template_draw_item.room_index
+                    == other_template_draw_item.room_index
+                ):
                     self.canvas.replace_tile_at(
                         canvas_index,
                         tile_row + r * 8,
@@ -438,7 +489,9 @@ class MultiRoomEditorTab(ttk.Frame):
 
     def canvas_shiftclick(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10
-        template_draw_item, room_row, room_col = self.template_item_at(room_row, room_col)
+        template_draw_item, room_row, room_col = self.template_item_at(
+            room_row, room_col
+        )
 
         if template_draw_item is None:
             # Do not attempt to pull tile from empty room.
@@ -456,8 +509,6 @@ class MultiRoomEditorTab(ttk.Frame):
         if TemplateSetting.ONLYFLIP in chunk.settings:
             tile_col = 9 - tile_col
 
-
-
         tile_code = layer[tile_row][tile_col]
         tile = self.tile_palette_map[tile_code]
 
@@ -469,7 +520,7 @@ class MultiRoomEditorTab(ttk.Frame):
         # tile_ref = self.tile_palette_map[tile_code]
         img = self.image_for_tile_code(tile_code)
         # if tile_ref:
-            # img = tile_ref[1]
+        # img = tile_ref[1]
         if img:
             return self.texture_fetcher.adjust_texture_xy(
                 img.width(), img.height(), tile_name, tile_size
@@ -505,12 +556,14 @@ class MultiRoomEditorTab(ttk.Frame):
             for room_column_index, template_draw_item in enumerate(room_row):
                 if template_draw_item is None:
                     continue
-                grid_sizes.append(GridRoom(
-                    room_row_index,
-                    room_column_index,
-                    template_draw_item.width_in_rooms,
-                    template_draw_item.height_in_rooms,
-                ))
+                grid_sizes.append(
+                    GridRoom(
+                        room_row_index,
+                        room_column_index,
+                        template_draw_item.width_in_rooms,
+                        template_draw_item.height_in_rooms,
+                    )
+                )
 
         self.canvas.draw_room_grid(2, grid_sizes)
 
@@ -558,12 +611,23 @@ class MultiRoomEditorTab(ttk.Frame):
                     else:
                         for r in range(template_draw_item.height_in_rooms):
                             for c in range(template_draw_item.width_in_rooms):
-                                self.canvas.draw_background_over_room(1, self.lvl_biome, room_row_index + r, room_column_index + c)
+                                self.canvas.draw_background_over_room(
+                                    1,
+                                    self.lvl_biome,
+                                    room_row_index + r,
+                                    room_column_index + c,
+                                )
                 else:
-                    template, _, _ = self.template_item_at(room_row_index, room_column_index)
+                    template, _, _ = self.template_item_at(
+                        room_row_index, room_column_index
+                    )
                     if template is None:
-                        self.canvas.draw_background_over_room(0, self.lvl_biome, room_row_index, room_column_index)
-                        self.canvas.draw_background_over_room(1, self.lvl_biome, room_row_index, room_column_index)
+                        self.canvas.draw_background_over_room(
+                            0, self.lvl_biome, room_row_index, room_column_index
+                        )
+                        self.canvas.draw_background_over_room(
+                            1, self.lvl_biome, room_row_index, room_column_index
+                        )
 
     def template_item_at(self, row, col):
         for room_row_index, room_row in enumerate(self.template_draw_map):
@@ -574,7 +638,10 @@ class MultiRoomEditorTab(ttk.Frame):
                     break
                 if template_draw_item is None:
                     continue
-                if room_row_index + template_draw_item.height_in_rooms - 1 >= row and room_column_index + template_draw_item.width_in_rooms - 1 >= col:
+                if (
+                    room_row_index + template_draw_item.height_in_rooms - 1 >= row
+                    and room_column_index + template_draw_item.width_in_rooms - 1 >= col
+                ):
                     return template_draw_item, room_row_index, room_column_index
 
         return None, None, None

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -10,7 +10,7 @@ from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContain
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.multi_room.options_panel import OptionsPanel
-from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap
+from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap, get_template_draw_item
 from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
 )
@@ -191,6 +191,42 @@ class MultiRoomEditorTab(ttk.Frame):
 
     def delete_tilecode(self, tile_name, tile_code):
         self.on_delete_tilecode(tile_name, tile_code)
+
+    def room_was_deleted(self, template_index, chunk_index):
+        replaced = False
+        for row, template_row in enumerate(self.template_draw_map):
+            for col, template in enumerate(template_row):
+                if template is None:
+                    continue
+                if template.template_index == template_index and template.room_index == chunk_index:
+                    new_draw_item = get_template_draw_item(template.template, template_index)
+                    template_row[col] = new_draw_item
+                    replaced = True
+                    # new_chunk_index = None
+                    # if len(template.rooms) == 0:
+                    #     return None
+                    # for i, c in enumerate(room_template.rooms):
+                    #     if TemplateSetting.IGNORE not in c.settings:
+                    #         chunk_index = i
+                    #         break
+
+                    # if chunk_index is None:
+                    #     return None
+
+                    # chunk = room_template.rooms[chunk_index]
+                    # if chunk is None or len(chunk.front) == 0:
+                    #     return None
+                    # return TemplateDrawItem(
+                    #     room_template,
+                    #     index,
+                    #     chunk,
+                    #     chunk_index,
+                    #     int(math.ceil(len(chunk.front[0]) / 10)),
+                    #     int(math.ceil(len(chunk.front) / 8)),
+                    # )
+        if replaced:
+            self.redraw()
+
 
     def canvas_click(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -267,7 +267,36 @@ class MultiRoomEditorTab(ttk.Frame):
                         if overlapping_row is None or overlapping_column is None:
                             continue
                         self.template_draw_map[overlapping_row][overlapping_column] = None
+
                 self.template_draw_map[row][col] = template_draw_item
+                while len(self.template_draw_map) > 0:
+                    has_room = False
+                    r = len(self.template_draw_map) - 1
+                    for c in range(len(self.template_draw_map[r])):
+                        t, _, _ = self.template_item_at(r, c)
+                        if t is not None:
+                            has_room = True
+                            break
+                    if has_room:
+                        break
+
+                    self.template_draw_map.pop()
+
+                while len(self.template_draw_map) > 0 and len(self.template_draw_map[0]) > 0:
+                    has_room = False
+                    for r in range(len(self.template_draw_map)):
+                        c = len(self.template_draw_map[r]) - 1
+                        t, _, _ = self.template_item_at(r, c)
+                        if t is not None:
+                            has_room = True
+                            break
+                    if has_room:
+                        break
+
+                    for r in self.template_draw_map:
+                        r.pop()
+
+
                 self.options_panel.set_templates(self.template_draw_map, self.room_templates)
                 self.redraw()
 
@@ -302,6 +331,34 @@ class MultiRoomEditorTab(ttk.Frame):
 
     def clear_template_at(self, row, col):
         self.template_draw_map[row][col] = None
+
+        while len(self.template_draw_map) > 0:
+            has_room = False
+            r = len(self.template_draw_map) - 1
+            for c in range(len(self.template_draw_map[r])):
+                t, _, _ = self.template_item_at(r, c)
+                if t is not None:
+                    has_room = True
+                    break
+            if has_room:
+                break
+
+            self.template_draw_map.pop()
+
+        while len(self.template_draw_map) > 0 and len(self.template_draw_map[0]) > 0:
+            has_room = False
+            for r in range(len(self.template_draw_map)):
+                c = len(self.template_draw_map[r]) - 1
+                t, _, _ = self.template_item_at(r, c)
+                if t is not None:
+                    has_room = True
+                    break
+            if has_room:
+                break
+
+            for r in self.template_draw_map:
+                r.pop()
+
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
         self.redraw()
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -39,6 +39,7 @@ class MultiRoomEditorTab(ttk.Frame):
         on_delete_tilecode,
         on_select_palette_tile,
         on_modify_room,
+        on_change_filetree,
         on_add_room,
         on_duplicate_room,
         on_rename_room,
@@ -55,6 +56,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.on_delete_tilecode = on_delete_tilecode
         self.on_select_palette_tile = on_select_palette_tile
         self.on_modify_room = on_modify_room
+        self.on_change_filetree = on_change_filetree
         self.on_add_room = on_add_room
         self.on_duplicate_room = on_duplicate_room
         self.on_rename_room = on_rename_room
@@ -497,6 +499,8 @@ class MultiRoomEditorTab(ttk.Frame):
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
         self.redraw()
 
+        self.on_change_filetree()
+
     def rename_room(self, row, col):
         win = PopupWindow("Edit Name", self.modlunky_config)
 
@@ -522,6 +526,8 @@ class MultiRoomEditorTab(ttk.Frame):
                     self.template_draw_map, self.room_templates
                 )
 
+                self.on_change_filetree()
+
                 win.destroy()
 
         separator = ttk.Separator(win)
@@ -546,16 +552,8 @@ class MultiRoomEditorTab(ttk.Frame):
         def delete_then_destroy():
             self.on_delete_room(template_item.template_index, template_item.room_index)
 
-            # chunk_index, chunk = self.__get_chunk_for_template_draw_item(template_item.template, template_item.template_index, row, col)
+            self.on_change_filetree()
 
-            # if chunk_index is not None and chunk is not None:
-            #     template_item.chunk_index = chunk_index
-            #     template_item.chunk = chunk
-
-            #     self.options_panel.set_templates(self.template_draw_map, self.room_templates)
-            #     self.redraw()
-            # else:
-            #     self.clear_template_at(row, col)
             win.destroy()
 
         lbl2 = ttk.Label(win, text="Are you sure you want to delete this room?")

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -13,7 +13,7 @@ from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomT
 
 
 class MultiRoomEditorTab(ttk.Frame):
-    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, *args, **kwargs):
+    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, on_select_palette_tile, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
         self.modlunky_config = modlunky_config
         self.texture_fetcher = texture_fetcher
@@ -21,6 +21,7 @@ class MultiRoomEditorTab(ttk.Frame):
      #   self.on_edit_room = on_edit_room
         self.on_add_tilecode = on_add_tilecode
         self.on_delete_tilecode = on_delete_tilecode
+        self.on_select_palette_tile = on_select_palette_tile
 
         self.lvl = None
         self.lvl_biome = None
@@ -85,6 +86,7 @@ class MultiRoomEditorTab(ttk.Frame):
             side_panel_tab_control,
             self.delete_tilecode,
             self.add_tilecode,
+            self.palette_selected_tile,
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )
@@ -120,6 +122,12 @@ class MultiRoomEditorTab(ttk.Frame):
             self.lvl_biome,
             self.lvl,
         )
+
+    def palette_selected_tile(self, tile_name, image, is_primary):
+        self.on_select_palette_tile(tile_name, image, is_primary)
+
+    def select_tile(self, tile_name, image, is_primary):
+        self.palette_panel.select_tile(tile_name, image, is_primary)
 
     def add_tilecode(self, tile, percent, alt_tile):
         print("Add")

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -5,6 +5,7 @@ from tkinter import ttk
 
 from modlunky2.config import Config
 from modlunky2.levels.level_templates import TemplateSetting
+from modlunky2.ui.levels.shared.level_canvas import GridRoom
 from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
@@ -137,15 +138,6 @@ class MultiRoomEditorTab(ttk.Frame):
             tile_name, self.lvl_biome, self.lvl, self.zoom_level
         ))
 
-        # original_size_tile = self.tile_palette_map[tile_code][1]
-        # new_tile_image = ImageTk.PhotoImage(
-        #     ImageTk.getimage(original_size_tile)
-        #     .resize(
-        #         (self.zoom_level, self.zoom_level),
-        #         Image.Resampling.LANCZOS,
-        #     )
-        #     .convert("RGBA")
-        # )
         self.tile_image_map[tile_name] = new_tile_image
         return new_tile_image
 
@@ -296,8 +288,19 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.configure_size(width * 10, height * 8)
 
         self.canvas.draw_background(self.lvl_biome)
-        self.canvas.draw_grid(2)
-        self.canvas.draw_room_grid(2)
+        self.canvas.draw_grid()
+
+        grid_sizes = []
+        for room_row_index, room_row in enumerate(self.template_draw_map):
+            for room_column_index, template_draw_item in enumerate(room_row):
+                grid_sizes.append(GridRoom(
+                    room_row_index,
+                    room_column_index,
+                    template_draw_item.width_in_rooms,
+                    template_draw_item.height_in_rooms,
+                ))
+
+        self.canvas.draw_room_grid(2, grid_sizes)
 
         # Draws all of the images of a layer on its canvas, and stores the images in
         # the proper index of tile_images so they can be removed from the grid when

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -127,6 +127,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.canvas.hide_room_lines,
             self.__update_zoom_internal,
             self.change_template_at,
+            self.clear_template_at,
         )
         side_panel_tab_control.add(self.palette_panel, text="Tiles")
         side_panel_tab_control.add(self.options_panel, text="Settings")
@@ -296,6 +297,10 @@ class MultiRoomEditorTab(ttk.Frame):
             else:
                 update_template()
 
+    def clear_template_at(self, row, col):
+        self.template_draw_map[row][col] = None
+        self.options_panel.set_templates(self.template_draw_map, self.room_templates)
+        self.redraw()
 
     def populate_tilecode_palette(self, tile_palette, suggestions):
         self.palette_panel.update_with_palette(

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -39,6 +39,7 @@ class MultiRoomEditorTab(ttk.Frame):
         on_delete_tilecode,
         on_select_palette_tile,
         on_modify_room,
+        on_add_room,
         *args,
         **kwargs
     ):
@@ -51,6 +52,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.on_delete_tilecode = on_delete_tilecode
         self.on_select_palette_tile = on_select_palette_tile
         self.on_modify_room = on_modify_room
+        self.on_add_room = on_add_room
 
         self.lvl = None
         self.lvl_biome = None
@@ -244,7 +246,6 @@ class MultiRoomEditorTab(ttk.Frame):
         )
         if template_draw_item:
             if template_draw_item.width_in_rooms + col > 10:
-                # TODO: add error dialog.
                 win = PopupWindow("Cannot use this room template", self.modlunky_config)
                 lbl = ttk.Label(
                     win,
@@ -412,6 +413,55 @@ class MultiRoomEditorTab(ttk.Frame):
         template_item = self.template_draw_map[row][col]
 
         if template_item is None:
+            return
+
+        if room_index >= len(template_item.template.rooms):
+
+            win = PopupWindow("Add Room", self.modlunky_config)
+
+
+            lbl = ttk.Label(
+                win,
+                text="Create a new room in " + template_item.template.name + ".",
+            )
+            lbl.grid(row=0, column=0)
+
+            values_frame = tk.Frame(win)
+            values_frame.grid(row=1, column=0, sticky="nw")
+
+            name_label = tk.Label(values_frame, text="Name: ")
+            name_label.grid(row=0, column=0, sticky="ne", pady=2)
+
+            name_entry = tk.Entry(values_frame)
+            name_entry.grid(row=0, column=1, sticky="nwe", pady=2)
+
+            separator = ttk.Separator(win)
+            separator.grid(row=2, column=0, columnspan=3, pady=5, sticky="news")
+
+            buttons = ttk.Frame(win)
+            buttons.grid(row=3, column=0, columnspan=2, sticky="news")
+            buttons.columnconfigure(0, weight=1)
+            buttons.columnconfigure(1, weight=1)
+
+            def insert_then_destroy():
+                name = name_entry.get()
+                new_room = self.on_add_room(template_item.template_index, None if name == "" else name)
+
+                template_item.room_index = room_index
+                template_item.room_chunk = new_room
+
+                self.options_panel.set_templates(self.template_draw_map, self.room_templates)
+                self.redraw()
+                win.destroy()
+
+            ok_button = ttk.Button(
+                buttons, text="Create", command=insert_then_destroy
+            )
+            ok_button.grid(row=0, column=0, pady=5, sticky="news")
+
+            cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
+            cancel_button.grid(row=0, column=1, pady=5, sticky="news")
+
             return
 
         template_item.room_index = room_index

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -131,6 +131,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.__update_zoom_internal,
             self.change_template_at,
             self.clear_template_at,
+            self.change_room_at,
         )
         side_panel_tab_control.add(self.palette_panel, text="Tiles")
         side_panel_tab_control.add(self.options_panel, text="Settings")
@@ -399,6 +400,18 @@ class MultiRoomEditorTab(ttk.Frame):
 
             for r in self.template_draw_map:
                 r.pop()
+
+        self.options_panel.set_templates(self.template_draw_map, self.room_templates)
+        self.redraw()
+
+    def change_room_at(self, room_index, row, col):
+        template_item = self.template_draw_map[row][col]
+
+        if template_item is None:
+            return
+
+        template_item.room_index = room_index
+        template_item.room_chunk = template_item.template.rooms[room_index]
 
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
         self.redraw()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -919,6 +919,8 @@ class MultiRoomEditorTab(ttk.Frame):
                                 room_column_index,
                             )
 
+        self.canvas.update_scroll_region()
+
     def template_item_at(self, map_index, row, col):
         for room_row_index, room_row in enumerate(
             self.template_draw_map[map_index].rooms

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -223,7 +223,7 @@ class MultiRoomEditorTab(ttk.Frame):
     def change_template_at(self, row, col, template, template_index):
         template_draw_item = self.__get_template_draw_item(template, template_index, row, col)
         if template_draw_item:
-            if template_draw_item.width_in_rooms + col > 8:
+            if template_draw_item.width_in_rooms + col > 10:
                 # TODO: add error dialog.
                 win = PopupWindow("Cannot use this room template", self.modlunky_config)
                 lbl = ttk.Label(win, text="Using this template here will result in the map exceeding the maximum width.")
@@ -264,6 +264,8 @@ class MultiRoomEditorTab(ttk.Frame):
                         if row_offset == 0 and col_offset == 0:
                             continue
                         _, overlapping_row, overlapping_column = self.template_item_at(row + row_offset, col + col_offset)
+                        if overlapping_row is None or overlapping_column is None:
+                            continue
                         self.template_draw_map[overlapping_row][overlapping_column] = None
                 self.template_draw_map[row][col] = template_draw_item
                 self.options_panel.set_templates(self.template_draw_map, self.room_templates)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -183,7 +183,6 @@ class MultiRoomEditorTab(ttk.Frame):
         self.template_draw_map = find_roommap(room_templates)
         self.canvas.grid_remove()
 
-
         self.canvas = MultiCanvasContainer(
             self.editor_container,
             self.textures_dir,
@@ -193,7 +192,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.canvas_click,
             self.canvas_shiftclick,
             intro_text="Select a level file to begin viewing",
-            vertical = True,
+            vertical=True,
         )
         self.canvas.grid(row=0, column=0, columnspan=3, rowspan=2, sticky="news")
         self.canvas.show_intro()
@@ -230,7 +229,9 @@ class MultiRoomEditorTab(ttk.Frame):
         self.tile_image_map = {}
         self.redraw()
 
-    def __get_chunk_for_template_draw_item(self, template, template_index, map_index, row, column):
+    def __get_chunk_for_template_draw_item(
+        self, template, template_index, map_index, row, column
+    ):
         chunk_index = None
         if len(template.rooms) == 0:
             return None, None
@@ -272,7 +273,9 @@ class MultiRoomEditorTab(ttk.Frame):
         chunk = template.rooms[chunk_index]
         return chunk_index, chunk
 
-    def __get_template_draw_item(self, template, template_index, map_index, row, column):
+    def __get_template_draw_item(
+        self, template, template_index, map_index, row, column
+    ):
         chunk_index, chunk = self.__get_chunk_for_template_draw_item(
             template, template_index, map_index, row, column
         )
@@ -313,7 +316,9 @@ class MultiRoomEditorTab(ttk.Frame):
                         template,
                         overlapping_row,
                         overlapping_column,
-                    ) = self.template_item_at(map_index, row + row_offset, col + col_offset)
+                    ) = self.template_item_at(
+                        map_index, row + row_offset, col + col_offset
+                    )
                     if template is not None and (
                         overlapping_row != row or overlapping_column != col
                     ):
@@ -335,10 +340,12 @@ class MultiRoomEditorTab(ttk.Frame):
                                 row.append(None)
 
                 expand_to_height_if_necessary(
-                    self.template_draw_map[map_index].rooms, row + template_draw_item.height_in_rooms
+                    self.template_draw_map[map_index].rooms,
+                    row + template_draw_item.height_in_rooms,
                 )
                 expand_to_width_if_necessary(
-                    self.template_draw_map[map_index].rooms, col + template_draw_item.width_in_rooms
+                    self.template_draw_map[map_index].rooms,
+                    col + template_draw_item.width_in_rooms,
                 )
                 for row_offset in range(template_draw_item.height_in_rooms):
                     for col_offset in range(template_draw_item.width_in_rooms):
@@ -796,8 +803,12 @@ class MultiRoomEditorTab(ttk.Frame):
             height = len(draw_rooms)
             width = len(draw_rooms[0])
 
-            self.canvas.configure_size(width * 10, height * 8, CanvasIndex(0, map_index))
-            self.canvas.configure_size(width * 10, height * 8, CanvasIndex(1, map_index))
+            self.canvas.configure_size(
+                width * 10, height * 8, CanvasIndex(0, map_index)
+            )
+            self.canvas.configure_size(
+                width * 10, height * 8, CanvasIndex(1, map_index)
+            )
 
             self.canvas.draw_background(self.lvl_biome, CanvasIndex(0, map_index))
             self.canvas.draw_background(self.lvl_biome, CanvasIndex(1, map_index))
@@ -909,7 +920,9 @@ class MultiRoomEditorTab(ttk.Frame):
                             )
 
     def template_item_at(self, map_index, row, col):
-        for room_row_index, room_row in enumerate(self.template_draw_map[map_index].rooms):
+        for room_row_index, room_row in enumerate(
+            self.template_draw_map[map_index].rooms
+        ):
             if room_row_index > row:
                 return None, None, None
             for room_column_index, template_draw_item in enumerate(room_row):

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -161,7 +161,7 @@ class MultiRoomEditorTab(ttk.Frame):
 
         self.canvas.clear()
         self.hide_intro()
-        self.canvas.configure_size(width, height)
+        self.canvas.configure_size(width * 10, height * 8)
 
         self.canvas.draw_background(self.lvl_biome)
         self.canvas.draw_grid()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -284,18 +284,18 @@ class MultiRoomEditorTab(ttk.Frame):
                 lbl2.grid(row=1, column=0)
 
                 separator = ttk.Separator(win)
-                separator.grid(row=2, column=0, columnspan=3, pady=5, sticky="nsew")
+                separator.grid(row=2, column=0, columnspan=3, pady=5, sticky="news")
 
                 buttons = ttk.Frame(win)
-                buttons.grid(row=3, column=0, columnspan=2, sticky="nsew")
+                buttons.grid(row=3, column=0, columnspan=2, sticky="news")
                 buttons.columnconfigure(0, weight=1)
                 buttons.columnconfigure(1, weight=1)
 
                 ok_button = ttk.Button(buttons, text="Proceed", command=update_then_destroy)
-                ok_button.grid(row=0, column=0, pady=5, sticky="nsew")
+                ok_button.grid(row=0, column=0, pady=5, sticky="news")
 
                 cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
-                cancel_button.grid(row=0, column=1, pady=5, sticky="nsew")
+                cancel_button.grid(row=0, column=1, pady=5, sticky="news")
 
             else:
                 update_template()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -678,9 +678,10 @@ class MultiRoomEditorTab(ttk.Frame):
         layer = layers[canvas_index.tab_index]
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
+        data_tile_col = tile_col
         if TemplateSetting.ONLYFLIP in chunk.settings:
-            tile_col = 9 - tile_col
-        layer[tile_row][tile_col] = tile_code
+            data_tile_col = template_draw_item.width_in_rooms * 10 - 1 - tile_col
+        layer[tile_row][data_tile_col] = tile_code
         self.on_modify_room(template_draw_item)
 
         for r, room_rows in enumerate(self.template_draw_map):
@@ -732,7 +733,7 @@ class MultiRoomEditorTab(ttk.Frame):
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
         if TemplateSetting.ONLYFLIP in chunk.settings:
-            tile_col = 9 - tile_col
+            tile_col = template_draw_item.width_in_rooms * 10 - 1 - tile_col
 
         tile_code = layer[tile_row][tile_col]
         tile = self.tile_palette_map[tile_code]

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -194,7 +194,7 @@ class MultiRoomEditorTab(ttk.Frame):
 
     def room_was_deleted(self, template_index, chunk_index):
         replaced = False
-        for row, template_row in enumerate(self.template_draw_map):
+        for _, template_row in enumerate(self.template_draw_map):
             for col, template in enumerate(template_row):
                 if template is None:
                     continue
@@ -202,28 +202,6 @@ class MultiRoomEditorTab(ttk.Frame):
                     new_draw_item = get_template_draw_item(template.template, template_index)
                     template_row[col] = new_draw_item
                     replaced = True
-                    # new_chunk_index = None
-                    # if len(template.rooms) == 0:
-                    #     return None
-                    # for i, c in enumerate(room_template.rooms):
-                    #     if TemplateSetting.IGNORE not in c.settings:
-                    #         chunk_index = i
-                    #         break
-
-                    # if chunk_index is None:
-                    #     return None
-
-                    # chunk = room_template.rooms[chunk_index]
-                    # if chunk is None or len(chunk.front) == 0:
-                    #     return None
-                    # return TemplateDrawItem(
-                    #     room_template,
-                    #     index,
-                    #     chunk,
-                    #     chunk_index,
-                    #     int(math.ceil(len(chunk.front[0]) / 10)),
-                    #     int(math.ceil(len(chunk.front) / 8)),
-                    # )
         if replaced:
             self.redraw()
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from PIL import Image, ImageTk
 import tkinter as tk
 from tkinter import ttk
 
@@ -7,6 +8,7 @@ from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
+from modlunky2.ui.levels.vanilla_levels.multi_room.options_panel import OptionsPanel
 from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap
 from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
@@ -25,6 +27,8 @@ class MultiRoomEditorTab(ttk.Frame):
         modlunky_config: Config,
         texture_fetcher,
         textures_dir,
+        zoom,
+        on_zoom_change,
         on_add_tilecode,
         on_delete_tilecode,
         on_select_palette_tile,
@@ -36,7 +40,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.modlunky_config = modlunky_config
         self.texture_fetcher = texture_fetcher
 
-        #   self.on_edit_room = on_edit_room
+        self.on_zoom_change = on_zoom_change
         self.on_add_tilecode = on_add_tilecode
         self.on_delete_tilecode = on_delete_tilecode
         self.on_select_palette_tile = on_select_palette_tile
@@ -45,8 +49,11 @@ class MultiRoomEditorTab(ttk.Frame):
         self.lvl = None
         self.lvl_biome = None
         self.tile_palette_map = {}
+        self.tile_image_map = {}
         self.room_templates = []
         self.template_draw_map = []
+
+        self.zoom_level = zoom
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
@@ -65,7 +72,7 @@ class MultiRoomEditorTab(ttk.Frame):
             editor_view,
             textures_dir,
             ["Foreground", "Background"],
-            50,
+            self.zoom_level,
             self.canvas_click,
             self.canvas_shiftclick,
             intro_text="Select a level file to begin viewing",
@@ -109,24 +116,44 @@ class MultiRoomEditorTab(ttk.Frame):
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )
-        # self.options_panel = OptionsPanel(
-        #     side_panel_tab_control,
-        #     modlunky_config,
-        #     self.zoom_level,
-        #     self.select_theme,
-        #     self.update_level_size,
-        #     self.set_current_save_format,
-        #     self.canvas.hide_grid_lines,
-        #     self.canvas.hide_room_lines,
-        #     self.update_zoom,
-        # )
+        self.options_panel = OptionsPanel(
+            side_panel_tab_control,
+            modlunky_config,
+            self.zoom_level,
+            self.canvas.hide_grid_lines,
+            self.canvas.hide_room_lines,
+            self.__update_zoom_internal,
+        )
         side_panel_tab_control.add(self.palette_panel, text="Tiles")
-        # side_panel_tab_control.add(self.options_panel, text="Settings")
+        side_panel_tab_control.add(self.options_panel, text="Settings")
+
+    def image_for_tile_code(self, tile_code):
+        tile_name = self.tile_palette_map[tile_code][0].split(" ", 2)[0]
+
+        if tile_name in self.tile_image_map:
+            return self.tile_image_map[tile_name]
+
+        new_tile_image = ImageTk.PhotoImage(self.texture_fetcher.get_texture(
+            tile_name, self.lvl_biome, self.lvl, self.zoom_level
+        ))
+
+        # original_size_tile = self.tile_palette_map[tile_code][1]
+        # new_tile_image = ImageTk.PhotoImage(
+        #     ImageTk.getimage(original_size_tile)
+        #     .resize(
+        #         (self.zoom_level, self.zoom_level),
+        #         Image.Resampling.LANCZOS,
+        #     )
+        #     .convert("RGBA")
+        # )
+        self.tile_image_map[tile_name] = new_tile_image
+        return new_tile_image
 
     def open_lvl(self, lvl, biome, tile_palette_map, room_templates):
         self.lvl = lvl
         self.lvl_biome = biome
         self.tile_palette_map = tile_palette_map
+        self.tile_image_map = {}
         self.room_templates = room_templates
 
         self.canvas.clear()
@@ -138,6 +165,20 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.clear()
         self.show_intro()
         self.draw_canvas()
+
+    def update_zoom_level(self, zoom):
+        self.options_panel.update_zoom_level(zoom)
+        self.__set_zoom(zoom)
+
+    def __update_zoom_internal(self, zoom):
+        self.on_zoom_change(zoom)
+        self.__set_zoom(zoom)
+
+    def __set_zoom(self, zoom):
+        self.zoom_level = zoom
+        self.canvas.set_zoom(zoom)
+        self.tile_image_map = {}
+        self.redraw()
 
     def populate_tilecode_palette(self, tile_palette, suggestions):
         self.palette_panel.update_with_palette(
@@ -160,21 +201,22 @@ class MultiRoomEditorTab(ttk.Frame):
         self.on_delete_tilecode(tile_name, tile_code)
 
     def canvas_click(self, canvas_index, row, column, is_primary):
-        tile_name, tile_code = self.palette_panel.selected_tile(is_primary)
-        x_offset, y_offset = self.offset_for_tile(tile_name, tile_code, 50)
-
-        self.canvas.replace_tile_at(
-            canvas_index,
-            row,
-            column,
-            self.tile_palette_map[tile_code][1],
-            x_offset,
-            y_offset,
-        )
-
         room_row, room_col = row // 8, column // 10
         template_draw_item = self.template_draw_map[room_row][room_col]
+
+        if template_draw_item is None:
+            # Do not draw on empty room.
+            return
+
         chunk = template_draw_item.room_chunk
+
+        if canvas_index == 1 and TemplateSetting.DUAL not in chunk.settings:
+            # Do not draw on backlayer of non-dual room.
+            return
+
+        tile_name, tile_code = self.palette_panel.selected_tile(is_primary)
+        x_offset, y_offset = self.offset_for_tile(tile_name, tile_code, self.zoom_level)
+
         layer = [chunk.front, chunk.back][canvas_index]
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
@@ -183,15 +225,36 @@ class MultiRoomEditorTab(ttk.Frame):
         layer[tile_row][tile_col] = tile_code
         self.on_modify_room(template_draw_item)
 
+        self.canvas.replace_tile_at(
+            canvas_index,
+            row,
+            column,
+            self.image_for_tile_code(tile_code),
+            x_offset,
+            y_offset,
+        )
+
     def canvas_shiftclick(self, canvas_index, row, column, is_primary):
         room_row, room_col = row // 8, column // 10
         template_draw_item = self.template_draw_map[room_row][room_col]
+
+        if template_draw_item is None:
+            # Do not attempt to pull tile from empty room.
+            return
+
         chunk = template_draw_item.room_chunk
+
+        if canvas_index == 1 and TemplateSetting.DUAL not in chunk.settings:
+            # Do not attempt to pull tile from backlayer of non-dual room.
+            return
+
         layer = [chunk.front, chunk.back][canvas_index]
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
         if TemplateSetting.ONLYFLIP in chunk.settings:
             tile_col = 9 - tile_col
+
+
 
         tile_code = layer[tile_row][tile_col]
         tile = self.tile_palette_map[tile_code]
@@ -201,9 +264,11 @@ class MultiRoomEditorTab(ttk.Frame):
 
     # Looks up the expected offset type and tile image size and computes the offset of the tile's anchor in the grid.
     def offset_for_tile(self, tile_name, tile_code, tile_size):
-        tile_ref = self.tile_palette_map[tile_code]
-        if tile_ref:
-            img = tile_ref[1]
+        # tile_ref = self.tile_palette_map[tile_code]
+        img = self.image_for_tile_code(tile_code)
+        # if tile_ref:
+            # img = tile_ref[1]
+        if img:
             return self.texture_fetcher.adjust_texture_xy(
                 img.width(), img.height(), tile_name, tile_size
             )
@@ -246,12 +311,13 @@ class MultiRoomEditorTab(ttk.Frame):
                         continue
                     tilecode = self.tile_palette_map[tile]
                     tile_name = tilecode[0].split(" ", 1)[0]
-                    tile_image = tilecode[1]
+                    # tile_image = tilecode[1]
+                    tile_image = self.image_for_tile_code(tile)
                     x_offset, y_offset = self.texture_fetcher.adjust_texture_xy(
                         tile_image.width(),
                         tile_image.height(),
                         tile_name,
-                        50,  # self.zoom_level
+                        self.zoom_level,
                     )
                     self.canvas.replace_tile_at(
                         canvas_index,

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -8,17 +8,35 @@ from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContain
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap
-from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import TemplateDrawItem
-from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
+    TemplateDrawItem,
+)
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import (
+    RoomInstance,
+    RoomTemplate,
+    MatchedSetroomTemplate,
+)
 
 
 class MultiRoomEditorTab(ttk.Frame):
-    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, on_select_palette_tile, on_modify_room, *args, **kwargs):
+    def __init__(
+        self,
+        parent,
+        modlunky_config: Config,
+        texture_fetcher,
+        textures_dir,
+        on_add_tilecode,
+        on_delete_tilecode,
+        on_select_palette_tile,
+        on_modify_room,
+        *args,
+        **kwargs
+    ):
         super().__init__(parent, *args, **kwargs)
         self.modlunky_config = modlunky_config
         self.texture_fetcher = texture_fetcher
 
-     #   self.on_edit_room = on_edit_room
+        #   self.on_edit_room = on_edit_room
         self.on_add_tilecode = on_add_tilecode
         self.on_delete_tilecode = on_delete_tilecode
         self.on_select_palette_tile = on_select_palette_tile
@@ -151,7 +169,7 @@ class MultiRoomEditorTab(ttk.Frame):
             column,
             self.tile_palette_map[tile_code][1],
             x_offset,
-            y_offset
+            y_offset,
         )
 
         room_row, room_col = row // 8, column // 10
@@ -233,7 +251,7 @@ class MultiRoomEditorTab(ttk.Frame):
                         tile_image.width(),
                         tile_image.height(),
                         tile_name,
-                        50 ,# self.zoom_level
+                        50,  # self.zoom_level
                     )
                     self.canvas.replace_tile_at(
                         canvas_index,

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -231,8 +231,8 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.configure_size(width * 10, height * 8)
 
         self.canvas.draw_background(self.lvl_biome)
-        self.canvas.draw_grid()
-        self.canvas.draw_room_grid()
+        self.canvas.draw_grid(2)
+        self.canvas.draw_room_grid(2)
 
         # Draws all of the images of a layer on its canvas, and stores the images in
         # the proper index of tile_images so they can be removed from the grid when
@@ -272,4 +272,10 @@ class MultiRoomEditorTab(ttk.Frame):
                         front = list(map(lambda row: row[::-1], front))
                         back = list(map(lambda row: row[::-1], back))
                     draw_chunk(0, room_column_index * 10, room_row_index * 8, front)
-                    draw_chunk(1, room_column_index * 10, room_row_index * 8, back)
+                    if TemplateSetting.DUAL in chunk.settings:
+                        draw_chunk(1, room_column_index * 10, room_row_index * 8, back)
+                    else:
+                        self.canvas.draw_background_over_room(1, self.lvl_biome, room_row_index, room_column_index)
+                else:
+                    self.canvas.draw_background_over_room(0, self.lvl_biome, room_row_index, room_column_index)
+                    self.canvas.draw_background_over_room(1, self.lvl_biome, room_row_index, room_column_index)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -193,6 +193,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.canvas_click,
             self.canvas_shiftclick,
             intro_text="Select a level file to begin viewing",
+            vertical = True,
         )
         self.canvas.grid(row=0, column=0, columnspan=3, rowspan=2, sticky="news")
         self.canvas.show_intro()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -360,7 +360,7 @@ class MultiRoomEditorTab(ttk.Frame):
     def template_item_at(self, row, col):
         for room_row_index, room_row in enumerate(self.template_draw_map):
             if room_row_index > row:
-                return None
+                return None, None, None
             for room_column_index, template_draw_item in enumerate(room_row):
                 if room_column_index > col:
                     break
@@ -368,3 +368,5 @@ class MultiRoomEditorTab(ttk.Frame):
                     continue
                 if room_row_index + template_draw_item.height_in_rooms - 1 >= row and room_column_index + template_draw_item.width_in_rooms - 1 >= col:
                     return template_draw_item, room_row_index, room_column_index
+
+        return None, None, None

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -13,7 +13,7 @@ from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomT
 
 
 class MultiRoomEditorTab(ttk.Frame):
-    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, on_select_palette_tile, *args, **kwargs):
+    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, on_select_palette_tile, on_modify_room, *args, **kwargs):
         super().__init__(parent, *args, **kwargs)
         self.modlunky_config = modlunky_config
         self.texture_fetcher = texture_fetcher
@@ -22,6 +22,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.on_add_tilecode = on_add_tilecode
         self.on_delete_tilecode = on_delete_tilecode
         self.on_select_palette_tile = on_select_palette_tile
+        self.on_modify_room = on_modify_room
 
         self.lvl = None
         self.lvl_biome = None
@@ -115,6 +116,11 @@ class MultiRoomEditorTab(ttk.Frame):
         self.template_draw_map = find_roommap(room_templates)
         self.draw_canvas()
 
+    def redraw(self):
+        self.canvas.clear()
+        self.show_intro()
+        self.draw_canvas()
+
     def populate_tilecode_palette(self, tile_palette, suggestions):
         self.palette_panel.update_with_palette(
             tile_palette,
@@ -130,15 +136,12 @@ class MultiRoomEditorTab(ttk.Frame):
         self.palette_panel.select_tile(tile_name, image, is_primary)
 
     def add_tilecode(self, tile, percent, alt_tile):
-        print("Add")
         self.on_add_tilecode(tile, percent, alt_tile)
 
     def delete_tilecode(self, tile_name, tile_code):
-        print("Delete")
         self.on_delete_tilecode(tile_name, tile_code)
 
     def canvas_click(self, canvas_index, row, column, is_primary):
-        print("canvas click")
         tile_name, tile_code = self.palette_panel.selected_tile(is_primary)
         x_offset, y_offset = self.offset_for_tile(tile_name, tile_code, 50)
 
@@ -160,9 +163,9 @@ class MultiRoomEditorTab(ttk.Frame):
         if TemplateSetting.ONLYFLIP in chunk.settings:
             tile_col = 9 - tile_col
         layer[tile_row][tile_col] = tile_code
+        self.on_modify_room(template_draw_item)
 
     def canvas_shiftclick(self, canvas_index, row, column, is_primary):
-        print("canvas shiftclick")
         room_row, room_col = row // 8, column // 10
         template_draw_item = self.template_draw_map[room_row][room_col]
         chunk = template_draw_item.room_chunk

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+import tkinter as tk
+from tkinter import ttk
+
+from modlunky2.config import Config
+from modlunky2.levels.level_templates import TemplateSetting
+from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
+from modlunky2.ui.levels.shared.palette_panel import PalettePanel
+from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
+from modlunky2.ui.levels.vanilla_levels.multi_room.room_map import find_roommap
+from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import TemplateDrawItem
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+
+
+class MultiRoomEditorTab(ttk.Frame):
+    def __init__(self, parent, modlunky_config: Config, texture_fetcher, textures_dir, on_add_tilecode, on_delete_tilecode, *args, **kwargs):
+        super().__init__(parent, *args, **kwargs)
+        self.modlunky_config = modlunky_config
+        self.texture_fetcher = texture_fetcher
+
+     #   self.on_edit_room = on_edit_room
+        self.on_add_tilecode = on_add_tilecode
+        self.on_delete_tilecode = on_delete_tilecode
+
+        self.lvl = None
+        self.lvl_biome = None
+        self.tile_palette_map = {}
+        self.room_templates = []
+        self.template_draw_map = []
+
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        # View that contains the canvases to edit the level along with some controls.
+        editor_view = tk.Frame(self)
+        editor_view.grid(row=0, column=0, sticky="news")
+        self.editor_container = editor_view
+
+        editor_view.columnconfigure(0, weight=1)
+        editor_view.columnconfigure(2, minsize=0)
+        editor_view.columnconfigure(1, minsize=50)
+        editor_view.rowconfigure(1, weight=1)
+
+        self.canvas = MultiCanvasContainer(
+            editor_view,
+            textures_dir,
+            ["Foreground", "Background"],
+            50,
+            self.canvas_click,
+            self.canvas_shiftclick,
+            intro_text="Select a level file to begin viewing",
+        )
+        self.canvas.grid(row=0, column=0, columnspan=3, rowspan=2, sticky="news")
+        self.canvas.show_intro()
+
+        # Side panel with the tile palette and level settings.
+        side_panel = tk.Frame(self)
+        side_panel.grid(column=1, row=0, rowspan=2, sticky="news")
+        side_panel.rowconfigure(0, weight=1)
+        side_panel.columnconfigure(0, weight=1)
+
+        # Allow hiding the side panel so more level can be seen.
+        side_panel_hidden = False
+        side_panel_hide_button = tk.Button(editor_view, text=">>")
+
+        def toggle_panel_hidden():
+            nonlocal side_panel_hidden
+            side_panel_hidden = not side_panel_hidden
+            if side_panel_hidden:
+                side_panel.grid_remove()
+                side_panel_hide_button.configure(text="<<")
+            else:
+                side_panel.grid()
+                side_panel_hide_button.configure(text=">>")
+
+        side_panel_hide_button.configure(
+            command=toggle_panel_hidden,
+        )
+        side_panel_hide_button.grid(column=1, row=0, sticky="nwe")
+
+        side_panel_tab_control = ttk.Notebook(side_panel)
+        side_panel_tab_control.grid(row=0, column=0, sticky="nswe")
+
+        self.palette_panel = PalettePanel(
+            side_panel_tab_control,
+            self.delete_tilecode,
+            self.add_tilecode,
+            self.texture_fetcher,
+            self.texture_fetcher.sprite_fetcher,
+        )
+        # self.options_panel = OptionsPanel(
+        #     side_panel_tab_control,
+        #     modlunky_config,
+        #     self.zoom_level,
+        #     self.select_theme,
+        #     self.update_level_size,
+        #     self.set_current_save_format,
+        #     self.canvas.hide_grid_lines,
+        #     self.canvas.hide_room_lines,
+        #     self.update_zoom,
+        # )
+        side_panel_tab_control.add(self.palette_panel, text="Tiles")
+        # side_panel_tab_control.add(self.options_panel, text="Settings")
+
+    def open_lvl(self, lvl, biome, tile_palette_map, room_templates):
+        self.lvl = lvl
+        self.lvl_biome = biome
+        self.tile_palette_map = tile_palette_map
+        self.room_templates = room_templates
+
+        self.canvas.clear()
+        self.show_intro()
+        self.template_draw_map = find_roommap(room_templates)
+        self.draw_canvas()
+
+    def populate_tilecode_palette(self, tile_palette, suggestions):
+        self.palette_panel.update_with_palette(
+            tile_palette,
+            suggestions,
+            self.lvl_biome,
+            self.lvl,
+        )
+
+    def add_tilecode(self, tile, percent, alt_tile):
+        print("Add")
+        self.on_add_tilecode(tile, percent, alt_tile)
+
+    def delete_tilecode(self, tile_name, tile_code):
+        print("Delete")
+        self.on_delete_tilecode(tile_name, tile_code)
+
+    def canvas_click(self, canvas_index, row, column, is_primary):
+        print("canvas click")
+
+    def canvas_shiftclick(self, canvas_index, row, column, is_primary):
+        print("canvas shiftclick")
+
+    def show_intro(self):
+        self.canvas.show_intro()
+        self.editor_container.columnconfigure(2, minsize=0)
+
+    def hide_intro(self):
+        self.canvas.hide_intro()
+        self.editor_container.columnconfigure(2, minsize=17)
+
+    def draw_canvas(self):
+        if len(self.template_draw_map) == 0:
+            return
+        if len(self.template_draw_map[0]) == 0:
+            return
+        height = len(self.template_draw_map)
+        width = len(self.template_draw_map[0])
+
+        self.canvas.clear()
+        self.hide_intro()
+        self.canvas.configure_size(width, height)
+
+        self.canvas.draw_background(self.lvl_biome)
+        self.canvas.draw_grid()
+        self.canvas.draw_room_grid()
+
+        # Draws all of the images of a layer on its canvas, and stores the images in
+        # the proper index of tile_images so they can be removed from the grid when
+        # replaced with another tile.
+        def draw_chunk(canvas_index, chunk_start_x, chunk_start_y, tile_codes):
+            for row_index, room_row in enumerate(tile_codes):
+                if row_index + chunk_start_y >= height * 8:
+                    continue
+                for tile_index, tile in enumerate(room_row):
+                    if tile_index + chunk_start_x >= width * 10:
+                        continue
+                    tilecode = self.tile_palette_map[tile]
+                    tile_name = tilecode[0].split(" ", 1)[0]
+                    tile_image = tilecode[1]
+                    x_offset, y_offset = self.texture_fetcher.adjust_texture_xy(
+                        tile_image.width(),
+                        tile_image.height(),
+                        tile_name,
+                        50 ,# self.zoom_level
+                    )
+                    self.canvas.replace_tile_at(
+                        canvas_index,
+                        row_index + chunk_start_y,
+                        tile_index + chunk_start_x,
+                        tile_image,
+                        x_offset,
+                        y_offset,
+                    )
+
+        for room_row_index, room_row in enumerate(self.template_draw_map):
+            for room_column_index, template_draw_item in enumerate(room_row):
+                if template_draw_item:
+                    chunk = template_draw_item.room_chunk
+                    front = chunk.front
+                    back = chunk.back
+                    if TemplateSetting.ONLYFLIP in chunk.settings:
+                        front = list(map(lambda row: row[::-1], front))
+                        back = list(map(lambda row: row[::-1], back))
+                    draw_chunk(0, room_column_index * 10, room_row_index * 8, front)
+                    draw_chunk(1, room_column_index * 10, room_row_index * 8, back)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -132,6 +132,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.change_template_at,
             self.clear_template_at,
             self.change_room_at,
+            self.room_setting_change_at,
         )
         side_panel_tab_control.add(self.palette_panel, text="Tiles")
         side_panel_tab_control.add(self.options_panel, text="Settings")
@@ -169,6 +170,9 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.clear()
         self.show_intro()
         self.draw_canvas()
+
+    def update_templates(self):
+        self.options_panel.set_templates(self.template_draw_map, self.room_templates)
 
     def update_zoom_level(self, zoom):
         self.options_panel.update_zoom_level(zoom)
@@ -415,6 +419,22 @@ class MultiRoomEditorTab(ttk.Frame):
 
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
         self.redraw()
+
+    def room_setting_change_at(self, setting, value, row, col):
+        template_item = self.template_draw_map[row][col]
+
+        if template_item is None:
+            return
+
+        room = template_item.room_chunk
+        if value and not setting in room.settings:
+            room.settings.append(setting)
+        elif not value and setting in room.settings:
+            room.settings.remove(setting)
+
+        self.on_modify_room(template_item)
+        if setting == TemplateSetting.DUAL or setting == TemplateSetting.ONLYFLIP:
+            self.redraw()
 
     def populate_tilecode_palette(self, tile_palette, suggestions):
         self.palette_panel.update_with_palette(

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -195,7 +195,13 @@ class MultiRoomEditorTab(ttk.Frame):
                 mappy.append(
                     RoomMap(
                         segment.name,
-                        [[get_template_draw_item_named(template_name) for template_name in row] for row in segment.templates]
+                        [
+                            [
+                                get_template_draw_item_named(template_name)
+                                for template_name in row
+                            ]
+                            for row in segment.templates
+                        ],
                     )
                 )
             return mappy

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -243,7 +243,6 @@ class MultiRoomEditorTab(ttk.Frame):
                         overlaps_room = True
 
             def update_template():
-                self.template_draw_map[row][col] = template_draw_item
                 def expand_to_height_if_necessary(room_map, height):
                     if len(room_map) < height:
                         for _ in range(height - len(room_map)):
@@ -264,7 +263,9 @@ class MultiRoomEditorTab(ttk.Frame):
                     for col_offset in range(template_draw_item.width_in_rooms):
                         if row_offset == 0 and col_offset == 0:
                             continue
-                        self.template_draw_map[row + row_offset][col + col_offset] = None
+                        _, overlapping_row, overlapping_column = self.template_item_at(row + row_offset, col + col_offset)
+                        self.template_draw_map[overlapping_row][overlapping_column] = None
+                self.template_draw_map[row][col] = template_draw_item
                 self.options_panel.set_templates(self.template_draw_map, self.room_templates)
                 self.redraw()
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -7,7 +7,10 @@ from tkinter import ttk
 from modlunky2.config import Config
 from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.levels.shared.level_canvas import GridRoom
-from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
+from modlunky2.ui.levels.shared.multi_canvas_container import (
+    MultiCanvasContainer,
+    CanvasIndex,
+)
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.multi_room.options_panel import OptionsPanel
@@ -90,6 +93,7 @@ class MultiRoomEditorTab(ttk.Frame):
             editor_view,
             textures_dir,
             ["Foreground", "Background"],
+            [],
             self.zoom_level,
             self.canvas_click,
             self.canvas_shiftclick,
@@ -659,7 +663,7 @@ class MultiRoomEditorTab(ttk.Frame):
             backlayer_canvas = 0
 
         if (
-            canvas_index == backlayer_canvas
+            canvas_index.tab_index == backlayer_canvas
             and TemplateSetting.DUAL not in chunk.settings
         ):
             # Do not draw on backlayer of non-dual room.
@@ -671,7 +675,7 @@ class MultiRoomEditorTab(ttk.Frame):
         layers = [chunk.front, chunk.back]
         if self.reverse_layers and template_draw_item.template.name in REVERSED_ROOMS:
             layers = [chunk.back, chunk.front]
-        layer = layers[canvas_index]
+        layer = layers[canvas_index.tab_index]
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
         if TemplateSetting.ONLYFLIP in chunk.settings:
@@ -715,7 +719,7 @@ class MultiRoomEditorTab(ttk.Frame):
             backlayer_canvas = 0
 
         if (
-            canvas_index == backlayer_canvas
+            canvas_index.tab_index == backlayer_canvas
             and TemplateSetting.DUAL not in chunk.settings
         ):
             # Do not attempt to pull tile from backlayer of non-dual room.
@@ -724,7 +728,7 @@ class MultiRoomEditorTab(ttk.Frame):
         layers = [chunk.front, chunk.back]
         if self.reverse_layers and template_draw_item.template.name in REVERSED_ROOMS:
             layers = [chunk.back, chunk.front]
-        layer = layers[canvas_index]
+        layer = layers[canvas_index.tab_index]
         tile_row = row - room_row * 8
         tile_col = column - room_col * 10
         if TemplateSetting.ONLYFLIP in chunk.settings:
@@ -786,7 +790,7 @@ class MultiRoomEditorTab(ttk.Frame):
                     )
                 )
 
-        self.canvas.draw_room_grid(2, grid_sizes)
+        self.canvas.draw_room_grid(2, [grid_sizes])
 
         # Draws all of the images of a layer on its canvas, and stores the images in
         # the proper index of tile_images so they can be removed from the grid when
@@ -835,14 +839,14 @@ class MultiRoomEditorTab(ttk.Frame):
                         front = list(map(lambda row: row[::-1], front))
                         back = list(map(lambda row: row[::-1], back))
                     draw_chunk(
-                        frontlayer_canvas,
+                        CanvasIndex(frontlayer_canvas, 0),
                         room_column_index * 10,
                         room_row_index * 8,
                         front,
                     )
                     if TemplateSetting.DUAL in chunk.settings:
                         draw_chunk(
-                            backlayer_canvas,
+                            CanvasIndex(backlayer_canvas, 0),
                             room_column_index * 10,
                             room_row_index * 8,
                             back,
@@ -851,7 +855,7 @@ class MultiRoomEditorTab(ttk.Frame):
                         for r in range(template_draw_item.height_in_rooms):
                             for c in range(template_draw_item.width_in_rooms):
                                 self.canvas.draw_background_over_room(
-                                    backlayer_canvas,
+                                    CanvasIndex(backlayer_canvas, 0),
                                     self.lvl_biome,
                                     room_row_index + r,
                                     room_column_index + c,
@@ -862,10 +866,16 @@ class MultiRoomEditorTab(ttk.Frame):
                     )
                     if template is None:
                         self.canvas.draw_background_over_room(
-                            0, self.lvl_biome, room_row_index, room_column_index
+                            CanvasIndex(0, 0),
+                            self.lvl_biome,
+                            room_row_index,
+                            room_column_index,
                         )
                         self.canvas.draw_background_over_room(
-                            1, self.lvl_biome, room_row_index, room_column_index
+                            CanvasIndex(1, 0),
+                            self.lvl_biome,
+                            room_row_index,
+                            room_column_index,
                         )
 
     def template_item_at(self, row, col):

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -62,26 +62,10 @@ class RoomOptions(ttk.Frame):
 
         template_setting_row = 0
 
-        room_label = tk.Label(self.template_container, text="Room:")
-        room_label.grid(row=template_setting_row, column=0, sticky="w")
-
-        template_setting_row += 1
-
-        self.room_combobox = ttk.Combobox(self.template_container, height=25)
-        self.room_combobox.grid(row=template_setting_row, column=0, sticky="nsw")
-        self.room_combobox["values"] = []
-        self.room_combobox.set("")
-        self.room_combobox["state"] = "readonly"
-        self.room_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_room())
-
-        template_setting_row += 1
-
         self.reverse_layers_container = tk.Frame(self.template_container)
         self.reverse_layers_container.grid(
             row=template_setting_row, column=0, sticky="news"
         )
-
-        template_setting_row += 1
 
         self.var_reverse_layers = tk.IntVar()
         self.var_reverse_layers.set(True)
@@ -111,6 +95,22 @@ class RoomOptions(ttk.Frame):
         )
         self.reverse_layers_description_on.grid(row=1, column=0, sticky="nws")
         self.reverse_layers_description_off.grid(row=2, column=0, sticky="nws")
+
+        template_setting_row += 1
+
+        room_label = tk.Label(self.template_container, text="Room:")
+        room_label.grid(row=template_setting_row, column=0, sticky="w")
+
+        template_setting_row += 1
+
+        self.room_combobox = ttk.Combobox(self.template_container, height=25)
+        self.room_combobox.grid(row=template_setting_row, column=0, sticky="nsw")
+        self.room_combobox["values"] = []
+        self.room_combobox.set("")
+        self.room_combobox["state"] = "readonly"
+        self.room_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_room())
+
+        template_setting_row += 1
 
         buttons_container = tk.Frame(self.template_container)
         buttons_container.grid(row=template_setting_row, column=0, sticky="news")

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -356,13 +356,10 @@ class OptionsPanel(ttk.Frame):
         template_combobox = ttk.Combobox(win, height=25)
         template_combobox.grid(row=1, column=0, sticky="nsw")
         template_combobox["values"] = [template.name for template in self.templates]
-        # template_combobox.set("")
         template_combobox["state"] = "readonly"
-        # template_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_template())
 
         def add_then_destroy():
             template_index = template_combobox.current()
-            print(template_index)
             if template_index is None or template_index == -1:
                 warning_label["text"] = "Select a room template"
                 warning_label.grid()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -41,6 +41,13 @@ class RoomOptions(ttk.Frame):
             "<<ComboboxSelected>>", lambda _: self.select_template()
         )
 
+    def reset(self):
+        self.current_template_row = None
+        self.current_template_column = None
+        self.current_template_item = None
+        self.template_combobox["values"] = ["None"]
+        self.template_combobox.set("None")
+
     def select_template(self):
         template_index = self.template_combobox.current()
 
@@ -208,6 +215,7 @@ class OptionsPanel(ttk.Frame):
             self, self.update_room_map_template, self.clear_template
         )
         self.room_options.grid(row=settings_row, column=1, sticky="news")
+        self.room_options.grid_remove()
 
     def update_room_map_template(self, template_index, row, column):
         template = self.templates[template_index]
@@ -216,9 +224,17 @@ class OptionsPanel(ttk.Frame):
     def clear_template(self, row, column):
         self.on_clear_template(row, column)
 
+    def reset(self):
+        print("reset")
+        self.button_for_selected_room = None
+        self.button_for_selected_empty_room = None
+        self.room_options.grid_remove()
+        self.room_options.reset()
+
     def set_templates(self, room_map, templates):
         self.button_for_selected_room = None
         self.button_for_selected_empty_room = None
+        self.room_options.grid_remove()
         # self.room_options.grid_remove()
         if self.room_map is not None:
             for row_index in range(len(self.room_map) + 1):
@@ -380,24 +396,26 @@ class OptionsPanel(ttk.Frame):
             self.button_for_selected_room.configure(
                 bg="#228B22", activebackground="#228B22"
             )
-            self.button_for_selected_room = None
+            self.room_options.grid()
         if self.button_for_selected_empty_room is not None:
             self.button_for_selected_empty_room.configure(
                 bg="#1A201A", activebackground="#1A201A"
             )
-            self.button_for_selected_empty_room = None
+            self.room_options.grid()
 
     def select_template_item(self, template_item, button, row, column):
         self.reset_selected_button()
         self.button_for_selected_room = button
         self.highlight_selected_button()
         self.room_options.set_current_template(template_item, row, column)
+        self.room_options.grid()
 
     def select_empty_cell(self, button, row, column):
         self.reset_selected_button()
         self.button_for_selected_empty_room = button
         self.highlight_selected_button()
         self.room_options.set_empty_cell(row, column)
+        self.room_options.grid()
 
     def show_create_new_dialog(self, row, column):
         win = PopupWindow("Add room", self.modlunky_config)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -20,14 +20,10 @@ class OptionsPanel(ttk.Frame):
         self.on_update_hide_room_lines = on_update_hide_room_lines
         self.on_update_zoom_level = on_update_zoom_level
 
-
-        # self.rowconfigure(2, minsize=20)
-        # self.rowconfigure(4, minsize=20)
         self.columnconfigure(0, minsize=10)
         self.columnconfigure(1, weight=1)
         self.columnconfigure(2, minsize=10)
 
-        # right_padding = 10
         settings_row = 0
 
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -3,7 +3,7 @@ from tkinter import ttk
 
 from modlunky2.config import Config
 from modlunky2.levels.level_templates import TemplateSetting
-from modlunky2.ui.widgets import PopupWindow
+from modlunky2.ui.widgets import PopupWindow, ScrollableFrameLegacy
 
 
 class RoomOptions(ttk.Frame):
@@ -135,7 +135,7 @@ class RoomOptions(ttk.Frame):
             command=self.on_flip_dual,
         )
 
-        wrap = 400
+        wrap = 350
         label_dual = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Whether this room has a backlayer.")
         label_ignore = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room will never appear in-game.")
         label_purge = tk.Label (self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, other rooms of this same template which were already loaded (eg, loaded from another file or appear first in this file) will not appear in-game when this room's file is loaded.")
@@ -345,12 +345,21 @@ class OptionsPanel(ttk.Frame):
         self.columnconfigure(0, minsize=10)
         self.columnconfigure(1, weight=1)
         self.columnconfigure(2, minsize=10)
+        self.rowconfigure(0, weight=1)
 
         self.room_map = []
         self.templates = []
 
         self.button_for_selected_room = None
         self.button_for_selected_empty_room = None
+
+
+
+        # The tile palettes are loaded into here as buttons with their image
+        # as a tile and text as their value to grab when needed.
+        self.scrollview = ScrollableFrameLegacy(self, text="", width=50)
+        self.scrollview.scrollable_frame["width"] = 50
+        self.scrollview.grid(row=0, column=1, sticky="news")
 
         settings_row = 0
 
@@ -365,13 +374,13 @@ class OptionsPanel(ttk.Frame):
 
         settings_row += 1
         tk.Checkbutton(
-            self,
+            self.scrollview.scrollable_frame,
             text="Hide grid lines",
             variable=hide_grid_var,
             onvalue=True,
             offvalue=False,
             command=toggle_hide_grid,
-        ).grid(row=settings_row, column=1, sticky="nw", pady=5)
+        ).grid(row=settings_row, column=0, sticky="nw", pady=5)
 
         # Checkbox to toggle the visibility of the grid lines on room boundaries.
         hide_room_grid_var = tk.IntVar()
@@ -383,17 +392,17 @@ class OptionsPanel(ttk.Frame):
 
         settings_row += 1
         tk.Checkbutton(
-            self,
+            self.scrollview.scrollable_frame,
             text="Hide room lines",
             variable=hide_room_grid_var,
             onvalue=True,
             offvalue=False,
             command=toggle_hide_room_grid,
-        ).grid(row=settings_row, column=1, sticky="nw", pady=5)
+        ).grid(row=settings_row, column=0, sticky="nw", pady=5)
 
         settings_row += 1
-        grid_size_frame = tk.Frame(self)
-        grid_size_frame.grid(row=settings_row, column=1, sticky="nw", pady=5)
+        grid_size_frame = tk.Frame(self.scrollview.scrollable_frame)
+        grid_size_frame.grid(row=settings_row, column=0, sticky="nw", pady=5)
         grid_size_frame.columnconfigure(0, weight=1)
         grid_size_var = tk.StringVar()
         grid_size_var.set(str(zoom_level))
@@ -411,7 +420,7 @@ class OptionsPanel(ttk.Frame):
             to=200,
             orient=tk.HORIZONTAL,
             variable=grid_size_var,
-            length=390,
+            length=370,
             showvalue=False,
         )
         grid_size_scale.grid(row=1, column=0, sticky="nwe")
@@ -424,9 +433,9 @@ class OptionsPanel(ttk.Frame):
 
         settings_row += 1
 
-        self.room_type_frame = tk.Frame(self)
+        self.room_type_frame = tk.Frame(self.scrollview.scrollable_frame)
         self.room_type_frame.grid(
-            row=settings_row, column=1, sticky="news", padx=10, pady=10
+            row=settings_row, column=0, sticky="news", padx=10, pady=10
         )
 
         self.room_view_size = 30
@@ -445,9 +454,9 @@ class OptionsPanel(ttk.Frame):
         settings_row += 1
 
         self.room_options = RoomOptions(
-            self, self.update_room_map_template, self.clear_template, self.on_select_room, self.on_flip_setting
+            self.scrollview.scrollable_frame, self.update_room_map_template, self.clear_template, self.on_select_room, self.on_flip_setting
         )
-        self.room_options.grid(row=settings_row, column=1, sticky="news")
+        self.room_options.grid(row=settings_row, column=0, sticky="news")
         self.room_options.grid_remove()
 
     def update_room_map_template(self, template_index, row, column):

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -317,7 +317,9 @@ class RoomOptions(ttk.Frame):
         if template_index == 0:
             self.clear_templates()
             self.on_clear_template(
-                self.current_template_map_index, self.current_template_row, self.current_template_column
+                self.current_template_map_index,
+                self.current_template_row,
+                self.current_template_column,
             )
         else:
             self.on_select_template(
@@ -330,17 +332,32 @@ class RoomOptions(ttk.Frame):
     def select_room(self):
         room_index = self.room_combobox.current()
         self.on_select_room(
-            room_index, self.current_template_map_index, self.current_template_row, self.current_template_column
+            room_index,
+            self.current_template_map_index,
+            self.current_template_row,
+            self.current_template_column,
         )
 
     def duplicate_room(self):
-        self.on_duplicate_room(self.current_template_map_index, self.current_template_row, self.current_template_column)
+        self.on_duplicate_room(
+            self.current_template_map_index,
+            self.current_template_row,
+            self.current_template_column,
+        )
 
     def rename_room(self):
-        self.on_rename_room(self.current_template_map_index, self.current_template_row, self.current_template_column)
+        self.on_rename_room(
+            self.current_template_map_index,
+            self.current_template_row,
+            self.current_template_column,
+        )
 
     def delete_room(self):
-        self.on_delete_room(self.current_template_map_index, self.current_template_row, self.current_template_column)
+        self.on_delete_room(
+            self.current_template_map_index,
+            self.current_template_row,
+            self.current_template_column,
+        )
 
     def clear_templates(self):
         self.template_combobox["values"] = ["None"]
@@ -394,7 +411,11 @@ class RoomOptions(ttk.Frame):
 
     def flip_setting(self, setting, value):
         self.on_flip_setting(
-            setting, value, self.current_template_map_index, self.current_template_row, self.current_template_column
+            setting,
+            value,
+            self.current_template_map_index,
+            self.current_template_row,
+            self.current_template_column,
         )
 
     def on_flip_ignore(self):
@@ -652,14 +673,16 @@ class OptionsPanel(ttk.Frame):
         room_row_start = 0
         if self.room_map is not None:
             for template_map in self.room_map:
-
                 for row_index in range(len(template_map.rooms) + 1):
-                    self.room_type_frame.rowconfigure(room_row_start + row_index * 2, minsize=0)
+                    self.room_type_frame.rowconfigure(
+                        room_row_start + row_index * 2, minsize=0
+                    )
                     if row_index + room_row_start != 0:
-                        self.room_type_frame.rowconfigure(room_row_start + row_index * 2 - 1, minsize=0)
+                        self.room_type_frame.rowconfigure(
+                            room_row_start + row_index * 2 - 1, minsize=0
+                        )
 
                 room_row_start += (len(template_map.rooms) + 1) * 2
-
 
         self.room_map = room_map
         self.templates = templates
@@ -675,10 +698,14 @@ class OptionsPanel(ttk.Frame):
                     )
                     if row_index != 0:
                         self.room_type_frame.rowconfigure(
-                            room_row_start + row_index * 2 - 1, minsize=self.room_view_padding
+                            room_row_start + row_index * 2 - 1,
+                            minsize=self.room_view_padding,
                         )
                     elif room_row_start != 0:
-                        self.room_type_frame.rowconfigure(room_row_start + row_index * 2 - 1, minsize=self.room_view_size)
+                        self.room_type_frame.rowconfigure(
+                            room_row_start + row_index * 2 - 1,
+                            minsize=self.room_view_size,
+                        )
                 room_row_start += (len(template_map.rooms) + 1) * 2
 
         for button in self.room_buttons:
@@ -712,15 +739,21 @@ class OptionsPanel(ttk.Frame):
                                 )
                             )
                             new_button.grid(
-                                row=room_row_start + row_index * 2, column=col_index * 2, sticky="news"
+                                row=room_row_start + row_index * 2,
+                                column=col_index * 2,
+                                sticky="news",
                             )
                             if (
-                                map_index == self.room_options.current_template_map_index and
-                                row_index == self.room_options.current_template_row
-                                and col_index == self.room_options.current_template_column
+                                map_index
+                                == self.room_options.current_template_map_index
+                                and row_index == self.room_options.current_template_row
+                                and col_index
+                                == self.room_options.current_template_column
                             ):
                                 self.button_for_selected_empty_room = new_button
-                                self.room_options.set_empty_cell(map_index, row_index, col_index)
+                                self.room_options.set_empty_cell(
+                                    map_index, row_index, col_index
+                                )
                     else:
                         new_button = tk.Button(
                             self.room_type_frame,
@@ -741,8 +774,8 @@ class OptionsPanel(ttk.Frame):
                             sticky="news",
                         )
                         if (
-                            map_index == self.room_options.current_template_map_index and
-                            row_index == self.room_options.current_template_row
+                            map_index == self.room_options.current_template_map_index
+                            and row_index == self.room_options.current_template_row
                             and col_index == self.room_options.current_template_column
                         ):
                             self.button_for_selected_room = new_button
@@ -755,7 +788,9 @@ class OptionsPanel(ttk.Frame):
                 if len(template_row) < 10:
                     edge_frame = tk.Frame(self.room_type_frame)
                     edge_frame.grid(
-                        row=room_row_start + row_index * 2, column=len(template_row) * 2, sticky="news"
+                        row=room_row_start + row_index * 2,
+                        column=len(template_row) * 2,
+                        sticky="news",
                     )
                     edge_frame.columnconfigure(0, weight=1)
                     edge_frame.rowconfigure(0, weight=1)
@@ -776,7 +811,9 @@ class OptionsPanel(ttk.Frame):
                     )
 
                     edge_frame.bind("<Enter>", lambda _, eb=edge_button: eb.grid())
-                    edge_frame.bind("<Leave>", lambda _, eb=edge_button: eb.grid_remove())
+                    edge_frame.bind(
+                        "<Leave>", lambda _, eb=edge_button: eb.grid_remove()
+                    )
                     self.edge_frames.append(edge_frame)
 
             rooms = template_map.rooms
@@ -798,13 +835,15 @@ class OptionsPanel(ttk.Frame):
                     edge_button.grid(row=0, column=0, sticky="news")
                     edge_button.grid_remove()
                     edge_button.configure(
-                        command=lambda r=len(rooms), c=col, m=map_index: self.show_create_new_dialog(
-                            m, r, c
-                        )
+                        command=lambda r=len(
+                            rooms
+                        ), c=col, m=map_index: self.show_create_new_dialog(m, r, c)
                     )
 
                     edge_frame.bind("<Enter>", lambda _, eb=edge_button: eb.grid())
-                    edge_frame.bind("<Leave>", lambda _, eb=edge_button: eb.grid_remove())
+                    edge_frame.bind(
+                        "<Leave>", lambda _, eb=edge_button: eb.grid_remove()
+                    )
                     self.edge_frames.append(edge_frame)
             room_row_start += (len(template_map.rooms) + 1) * 2
         self.highlight_selected_button()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -6,6 +6,7 @@ class RoomOptions(ttk.Frame):
         self,
         parent,
         on_select_template,
+        on_clear_template,
         *args,
         **kwargs,
     ):
@@ -14,6 +15,7 @@ class RoomOptions(ttk.Frame):
         setting_row = 0
 
         self.on_select_template = on_select_template
+        self.on_clear_template = on_clear_template
 
         self.current_template_row = None
         self.current_template_column = None
@@ -28,16 +30,26 @@ class RoomOptions(ttk.Frame):
 
         self.template_combobox = ttk.Combobox(self, height=25)
         self.template_combobox.grid(row=setting_row, column=0, sticky="nsw")
+        self.template_combobox["values"] = ["None"]
+        self.template_combobox.set("None")
         self.template_combobox["state"] = "readonly"
         self.template_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_template())
 
     def select_template(self):
         template_index = self.template_combobox.current()
 
-        self.on_select_template(template_index, self.current_template_row, self.current_template_column)
+        if template_index == 0:
+            self.clear_templates()
+            self.on_clear_template(self.current_template_row, self.current_template_column)
+        else:
+            self.on_select_template(template_index - 1, self.current_template_row, self.current_template_column)
+
+    def clear_templates(self):
+        self.template_combobox["values"] = ["None"]
+        self.template_combobox.set("None")
 
     def set_templates(self, templates):
-        self.template_combobox["values"] = [template.name for template in templates]
+        self.template_combobox["values"] = ["None"] + [template.name for template in templates]
         self.current_template_item = None
 
     def set_current_template(self, template, row, column):
@@ -57,6 +69,7 @@ class OptionsPanel(ttk.Frame):
         on_update_hide_room_lines,
         on_update_zoom_level,
         on_change_template_at,
+        on_clear_template,
         *args,
         **kwargs
     ):
@@ -67,6 +80,7 @@ class OptionsPanel(ttk.Frame):
         self.on_update_hide_room_lines = on_update_hide_room_lines
         self.on_update_zoom_level = on_update_zoom_level
         self.on_change_template_at = on_change_template_at
+        self.on_clear_template = on_clear_template
 
         self.columnconfigure(0, minsize=10)
         self.columnconfigure(1, weight=1)
@@ -166,12 +180,15 @@ class OptionsPanel(ttk.Frame):
 
         settings_row += 1
 
-        self.room_options = RoomOptions(self, self.update_room_map_template)
+        self.room_options = RoomOptions(self, self.update_room_map_template, self.clear_template)
         self.room_options.grid(row=settings_row, column=1, sticky="news")
 
     def update_room_map_template(self, template_index, row, column):
         template = self.templates[template_index]
         self.on_change_template_at(row, column, template, template_index)
+
+    def clear_template(self, row, column):
+        self.on_clear_template(row, column)
 
     def set_templates(self, room_map, templates):
         # self.room_options.grid_remove()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -225,7 +225,6 @@ class OptionsPanel(ttk.Frame):
         self.on_clear_template(row, column)
 
     def reset(self):
-        print("reset")
         self.button_for_selected_room = None
         self.button_for_selected_empty_room = None
         self.room_options.grid_remove()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -211,7 +211,7 @@ class RoomOptions(ttk.Frame):
             self.template_combobox.set(template.template.name)
             self.room_combobox["values"] = [
                 room.name or "room " + (index + 1) for index, room in enumerate(template.template.rooms)
-            ]
+            ] + ["Create New"]
             self.room_combobox.set(template.room_chunk.name or "room " + (template.room_index + 1))
             self.room_combobox.current(template.room_index)
             self.template_container.grid()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -14,6 +14,9 @@ class RoomOptions(ttk.Frame):
         on_clear_template,
         on_select_room,
         on_flip_setting,
+        on_duplicate_room,
+        on_rename_room,
+        on_delete_room,
         *args,
         **kwargs,
     ):
@@ -25,6 +28,9 @@ class RoomOptions(ttk.Frame):
         self.on_clear_template = on_clear_template
         self.on_select_room = on_select_room
         self.on_flip_setting = on_flip_setting
+        self.on_duplicate_room = on_duplicate_room
+        self.on_rename_room = on_rename_room
+        self.on_delete_room = on_delete_room
 
         self.current_template_row = None
         self.current_template_column = None
@@ -42,7 +48,9 @@ class RoomOptions(ttk.Frame):
         self.template_combobox["values"] = ["None"]
         self.template_combobox.set("None")
         self.template_combobox["state"] = "readonly"
-        self.template_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_template())
+        self.template_combobox.bind(
+            "<<ComboboxSelected>>", lambda _: self.select_template()
+        )
 
         setting_row += 1
 
@@ -59,8 +67,26 @@ class RoomOptions(ttk.Frame):
         self.room_combobox["state"] = "readonly"
         self.room_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_room())
 
+        buttons_container = tk.Frame(self.template_container)
+        buttons_container.grid(row=2, column=0, sticky="news")
+
+        duplicate_button = ttk.Button(
+            buttons_container, text="Duplicate", command=self.duplicate_room
+        )
+        duplicate_button.grid(row=0, column=1, pady=5, sticky="news")
+
+        rename_button = ttk.Button(
+            buttons_container, text="Rename", command=self.rename_room
+        )
+        rename_button.grid(row=0, column=0, pady=5, sticky="news")
+
+        delete_button = ttk.Button(
+            buttons_container, text="Delete", command=self.delete_room
+        )
+        delete_button.grid(row=0, column=2, pady=5, sticky="news")
+
         self.room_settings_container = tk.Frame(self.template_container)
-        self.room_settings_container.grid(row=2, column=0, sticky="news")
+        self.room_settings_container.grid(row=3, column=0, sticky="news")
 
         self.var_ignore = tk.IntVar()
         self.var_flip = tk.IntVar()
@@ -136,14 +162,54 @@ class RoomOptions(ttk.Frame):
         )
 
         wrap = 350
-        label_dual = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Whether this room has a backlayer.")
-        label_ignore = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room will never appear in-game.")
-        label_purge = tk.Label (self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, other rooms of this same template which were already loaded (eg, loaded from another file or appear first in this file) will not appear in-game when this room's file is loaded.")
-        label_rare = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room has a 5% chance of being used.")
-        label_hard = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room only appears in X-3 and X-4.")
-        label_liquid = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Mark this room as containing liquid to optimize the liquid engine.")
-        label_flip = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Creates two rooms, one which is horizontally flipped from the original.")
-        label_only_flip = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Like flip, but the original room is ignored.")
+        label_dual = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="Whether this room has a backlayer.",
+        )
+        label_ignore = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="If checked, this room will never appear in-game.",
+        )
+        label_purge = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="If checked, other rooms of this same template which were already loaded (eg, loaded from another file or appear first in this file) will not appear in-game when this room's file is loaded.",
+        )
+        label_rare = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="If checked, this room has a 5% chance of being used.",
+        )
+        label_hard = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="If checked, this room only appears in X-3 and X-4.",
+        )
+        label_liquid = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="Mark this room as containing liquid to optimize the liquid engine.",
+        )
+        label_flip = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="Creates two rooms, one which is horizontally flipped from the original.",
+        )
+        label_only_flip = tk.Label(
+            self.room_settings_container,
+            wraplength=wrap,
+            justify=tk.LEFT,
+            text="Like flip, but the original room is ignored.",
+        )
 
         self.checkbox_dual.grid(row=0, column=0, sticky="w")
         label_dual.grid(row=1, column=0, sticky="nws")
@@ -163,7 +229,6 @@ class RoomOptions(ttk.Frame):
         label_only_flip.grid(row=15, column=0, sticky="nws")
 
         self.columnconfigure(0, weight=1)
-
 
     def reset(self):
         self.current_template_row = None
@@ -189,7 +254,18 @@ class RoomOptions(ttk.Frame):
 
     def select_room(self):
         room_index = self.room_combobox.current()
-        self.on_select_room(room_index, self.current_template_row, self.current_template_column)
+        self.on_select_room(
+            room_index, self.current_template_row, self.current_template_column
+        )
+
+    def duplicate_room(self):
+        self.on_duplicate_room(self.current_template_row, self.current_template_column)
+
+    def rename_room(self):
+        self.on_rename_room(self.current_template_row, self.current_template_column)
+
+    def delete_room(self):
+        self.on_delete_room(self.current_template_row, self.current_template_column)
 
     def clear_templates(self):
         self.template_combobox["values"] = ["None"]
@@ -210,9 +286,12 @@ class RoomOptions(ttk.Frame):
         if template:
             self.template_combobox.set(template.template.name)
             self.room_combobox["values"] = [
-                room.name or "room " + (index + 1) for index, room in enumerate(template.template.rooms)
+                room.name or "room " + (index + 1)
+                for index, room in enumerate(template.template.rooms)
             ] + ["Create New"]
-            self.room_combobox.set(template.room_chunk.name or "room " + (template.room_index + 1))
+            self.room_combobox.set(
+                template.room_chunk.name or "room " + (template.room_index + 1)
+            )
             self.room_combobox.current(template.room_index)
             self.template_container.grid()
 
@@ -220,17 +299,11 @@ class RoomOptions(ttk.Frame):
             self.set_dual(TemplateSetting.DUAL in current_settings)
             self.set_flip(TemplateSetting.FLIP in current_settings)
             self.set_purge(TemplateSetting.PURGE in current_settings)
-            self.set_only_flip(
-                TemplateSetting.ONLYFLIP in current_settings
-            )
-            self.set_ignore(
-                TemplateSetting.IGNORE in current_settings
-            )
+            self.set_only_flip(TemplateSetting.ONLYFLIP in current_settings)
+            self.set_ignore(TemplateSetting.IGNORE in current_settings)
             self.set_rare(TemplateSetting.RARE in current_settings)
             self.set_hard(TemplateSetting.HARD in current_settings)
-            self.set_liquid(
-                TemplateSetting.LIQUID in current_settings
-            )
+            self.set_liquid(TemplateSetting.LIQUID in current_settings)
         else:
             self.set_empty_cell(row, column)
 
@@ -241,7 +314,9 @@ class RoomOptions(ttk.Frame):
         self.template_container.grid_remove()
 
     def flip_setting(self, setting, value):
-        self.on_flip_setting(setting, value, self.current_template_row, self.current_template_column)
+        self.on_flip_setting(
+            setting, value, self.current_template_row, self.current_template_column
+        )
 
     def on_flip_ignore(self):
         self.flip_setting(TemplateSetting.IGNORE, self.ignore())
@@ -315,6 +390,7 @@ class RoomOptions(ttk.Frame):
     def set_dual(self, dual):
         self.var_dual.set(dual and 1 or 0)
 
+
 class OptionsPanel(ttk.Frame):
     def __init__(
         self,
@@ -328,6 +404,9 @@ class OptionsPanel(ttk.Frame):
         on_clear_template,
         on_select_room,
         on_flip_setting,
+        on_duplicate_room,
+        on_rename_room,
+        on_delete_room,
         *args,
         **kwargs,
     ):
@@ -341,6 +420,9 @@ class OptionsPanel(ttk.Frame):
         self.on_clear_template = on_clear_template
         self.on_select_room = on_select_room
         self.on_flip_setting = on_flip_setting
+        self.on_duplicate_room = on_duplicate_room
+        self.on_rename_room = on_rename_room
+        self.on_delete_room = on_delete_room
 
         self.columnconfigure(0, minsize=10)
         self.columnconfigure(1, weight=1)
@@ -352,8 +434,6 @@ class OptionsPanel(ttk.Frame):
 
         self.button_for_selected_room = None
         self.button_for_selected_empty_room = None
-
-
 
         # The tile palettes are loaded into here as buttons with their image
         # as a tile and text as their value to grab when needed.
@@ -454,7 +534,14 @@ class OptionsPanel(ttk.Frame):
         settings_row += 1
 
         self.room_options = RoomOptions(
-            self.scrollview.scrollable_frame, self.update_room_map_template, self.clear_template, self.on_select_room, self.on_flip_setting
+            self.scrollview.scrollable_frame,
+            self.update_room_map_template,
+            self.clear_template,
+            self.on_select_room,
+            self.on_flip_setting,
+            self.on_duplicate_room,
+            self.on_rename_room,
+            self.on_delete_room,
         )
         self.room_options.grid(row=settings_row, column=0, sticky="news")
         self.room_options.grid_remove()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -224,7 +224,7 @@ class RoomOptions(ttk.Frame):
         self.checkbox_liquid.grid(row=10, column=0, sticky="w")
         label_liquid.grid(row=11, column=0, sticky="nws")
         self.checkbox_flip.grid(row=12, column=0, sticky="w")
-        label_flip.grid(row=12, column=0, sticky="nws")
+        label_flip.grid(row=13, column=0, sticky="nws")
         self.checkbox_only_flip.grid(row=14, column=0, sticky="w")
         label_only_flip.grid(row=15, column=0, sticky="nws")
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -4,6 +4,7 @@ from tkinter import ttk
 from modlunky2.config import Config
 from modlunky2.ui.widgets import PopupWindow
 
+
 class RoomOptions(ttk.Frame):
     def __init__(
         self,
@@ -36,23 +37,33 @@ class RoomOptions(ttk.Frame):
         self.template_combobox["values"] = ["None"]
         self.template_combobox.set("None")
         self.template_combobox["state"] = "readonly"
-        self.template_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_template())
+        self.template_combobox.bind(
+            "<<ComboboxSelected>>", lambda _: self.select_template()
+        )
 
     def select_template(self):
         template_index = self.template_combobox.current()
 
         if template_index == 0:
             self.clear_templates()
-            self.on_clear_template(self.current_template_row, self.current_template_column)
+            self.on_clear_template(
+                self.current_template_row, self.current_template_column
+            )
         else:
-            self.on_select_template(template_index - 1, self.current_template_row, self.current_template_column)
+            self.on_select_template(
+                template_index - 1,
+                self.current_template_row,
+                self.current_template_column,
+            )
 
     def clear_templates(self):
         self.template_combobox["values"] = ["None"]
         self.template_combobox.set("None")
 
     def set_templates(self, templates):
-        self.template_combobox["values"] = ["None"] + [template.name for template in templates]
+        self.template_combobox["values"] = ["None"] + [
+            template.name for template in templates
+        ]
         self.current_template_item = None
 
     def set_current_template(self, template, row, column):
@@ -67,6 +78,7 @@ class RoomOptions(ttk.Frame):
         self.current_template_column = column
         self.template_combobox.set("None")
 
+
 class OptionsPanel(ttk.Frame):
     def __init__(
         self,
@@ -79,7 +91,7 @@ class OptionsPanel(ttk.Frame):
         on_change_template_at,
         on_clear_template,
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(parent, *args, **kwargs)
 
@@ -101,7 +113,6 @@ class OptionsPanel(ttk.Frame):
         self.button_for_selected_empty_room = None
 
         settings_row = 0
-
 
         # Checkbox to toggle the visibility of the grid lines.
         hide_grid_var = tk.IntVar()
@@ -174,7 +185,9 @@ class OptionsPanel(ttk.Frame):
         settings_row += 1
 
         self.room_type_frame = tk.Frame(self)
-        self.room_type_frame.grid(row=settings_row, column=1, sticky="news", padx=10, pady=10)
+        self.room_type_frame.grid(
+            row=settings_row, column=1, sticky="news", padx=10, pady=10
+        )
 
         self.room_view_size = 30
         self.room_view_padding = 5
@@ -182,14 +195,18 @@ class OptionsPanel(ttk.Frame):
         for n in range(10):
             self.room_type_frame.columnconfigure(n * 2, minsize=self.room_view_size)
             if n != 0:
-                self.room_type_frame.columnconfigure(n * 2 - 1, minsize=self.room_view_padding)
+                self.room_type_frame.columnconfigure(
+                    n * 2 - 1, minsize=self.room_view_padding
+                )
 
         self.room_buttons = []
         self.edge_frames = []
 
         settings_row += 1
 
-        self.room_options = RoomOptions(self, self.update_room_map_template, self.clear_template)
+        self.room_options = RoomOptions(
+            self, self.update_room_map_template, self.clear_template
+        )
         self.room_options.grid(row=settings_row, column=1, sticky="news")
 
     def update_room_map_template(self, template_index, row, column):
@@ -216,9 +233,13 @@ class OptionsPanel(ttk.Frame):
 
         if room_map is not None:
             for row_index in range(len(room_map) + 1):
-                self.room_type_frame.rowconfigure(row_index * 2, minsize=self.room_view_size)
+                self.room_type_frame.rowconfigure(
+                    row_index * 2, minsize=self.room_view_size
+                )
                 if row_index != 0:
-                    self.room_type_frame.rowconfigure(row_index * 2 - 1, minsize=self.room_view_padding)
+                    self.room_type_frame.rowconfigure(
+                        row_index * 2 - 1, minsize=self.room_view_padding
+                    )
 
         for button in self.room_buttons:
             button.grid_remove()
@@ -233,14 +254,28 @@ class OptionsPanel(ttk.Frame):
             for col_index, template in enumerate(template_row):
                 new_button = None
                 if template is None:
-                    overlapping_template, _, _ = self.template_item_at(room_map, row_index, col_index)
+                    overlapping_template, _, _ = self.template_item_at(
+                        room_map, row_index, col_index
+                    )
                     if overlapping_template is None:
-                        new_button = tk.Button(self.room_type_frame, bg="#5A605A", activebackground="#5A605A", relief=tk.GROOVE)
-                        new_button.configure(
-                            command=lambda nb=new_button, r=row_index, c=col_index: self.select_empty_cell(nb, r, c)
+                        new_button = tk.Button(
+                            self.room_type_frame,
+                            bg="#5A605A",
+                            activebackground="#5A605A",
+                            relief=tk.GROOVE,
                         )
-                        new_button.grid(row=row_index * 2, column=col_index * 2, sticky="news")
-                        if row_index == self.room_options.current_template_row and col_index == self.room_options.current_template_column:
+                        new_button.configure(
+                            command=lambda nb=new_button, r=row_index, c=col_index: self.select_empty_cell(
+                                nb, r, c
+                            )
+                        )
+                        new_button.grid(
+                            row=row_index * 2, column=col_index * 2, sticky="news"
+                        )
+                        if (
+                            row_index == self.room_options.current_template_row
+                            and col_index == self.room_options.current_template_column
+                        ):
                             self.button_for_selected_empty_room = new_button
                             self.room_options.set_empty_cell(row_index, col_index)
                 else:
@@ -251,7 +286,9 @@ class OptionsPanel(ttk.Frame):
                         relief=tk.GROOVE,
                     )
                     new_button.configure(
-                        command=lambda t=template, nb=new_button, r=row_index, c=col_index: self.select_template_item(t, nb, r, c)
+                        command=lambda t=template, nb=new_button, r=row_index, c=col_index: self.select_template_item(
+                            t, nb, r, c
+                        )
                     )
                     new_button.grid(
                         row=row_index * 2,
@@ -260,25 +297,39 @@ class OptionsPanel(ttk.Frame):
                         columnspan=template.width_in_rooms * 2 - 1,
                         sticky="news",
                     )
-                    if row_index == self.room_options.current_template_row and col_index == self.room_options.current_template_column:
+                    if (
+                        row_index == self.room_options.current_template_row
+                        and col_index == self.room_options.current_template_column
+                    ):
                         self.button_for_selected_room = new_button
-                        self.room_options.set_current_template(template, row_index, col_index)
+                        self.room_options.set_current_template(
+                            template, row_index, col_index
+                        )
                 if new_button is not None:
                     self.room_buttons.append(new_button)
 
             if len(template_row) < 10:
                 edge_frame = tk.Frame(self.room_type_frame)
-                edge_frame.grid(row=row_index * 2, column=len(template_row) * 2, sticky="news")
+                edge_frame.grid(
+                    row=row_index * 2, column=len(template_row) * 2, sticky="news"
+                )
                 edge_frame.columnconfigure(0, weight=1)
                 edge_frame.rowconfigure(0, weight=1)
 
-                edge_button = tk.Button(edge_frame, text="+", bg="#A0C0A6", activebackground="#A0C0A6", relief=tk.GROOVE)
+                edge_button = tk.Button(
+                    edge_frame,
+                    text="+",
+                    bg="#A0C0A6",
+                    activebackground="#A0C0A6",
+                    relief=tk.GROOVE,
+                )
                 edge_button.grid(row=0, column=0, sticky="news")
                 edge_button.grid_remove()
                 edge_button.configure(
-                    command=lambda r=row_index, c=len(template_row): self.show_create_new_dialog(r, c)
+                    command=lambda r=row_index, c=len(
+                        template_row
+                    ): self.show_create_new_dialog(r, c)
                 )
-
 
                 edge_frame.bind("<Enter>", lambda _, eb=edge_button: eb.grid())
                 edge_frame.bind("<Leave>", lambda _, eb=edge_button: eb.grid_remove())
@@ -292,13 +343,20 @@ class OptionsPanel(ttk.Frame):
                 edge_frame.columnconfigure(0, weight=1)
                 edge_frame.rowconfigure(0, weight=1)
 
-                edge_button = tk.Button(edge_frame, text="+", bg="#A0C0A6", activebackground="#A0C0A6", relief=tk.GROOVE)
+                edge_button = tk.Button(
+                    edge_frame,
+                    text="+",
+                    bg="#A0C0A6",
+                    activebackground="#A0C0A6",
+                    relief=tk.GROOVE,
+                )
                 edge_button.grid(row=0, column=0, sticky="news")
                 edge_button.grid_remove()
                 edge_button.configure(
-                    command=lambda r=len(room_map), c=col: self.show_create_new_dialog(r, c)
+                    command=lambda r=len(room_map), c=col: self.show_create_new_dialog(
+                        r, c
+                    )
                 )
-
 
                 edge_frame.bind("<Enter>", lambda _, eb=edge_button: eb.grid())
                 edge_frame.bind("<Leave>", lambda _, eb=edge_button: eb.grid_remove())
@@ -307,18 +365,26 @@ class OptionsPanel(ttk.Frame):
 
     def reset_selected_button(self):
         if self.button_for_selected_room is not None:
-            self.button_for_selected_room.configure(bg="#30F030", activebackground="#30F030")
+            self.button_for_selected_room.configure(
+                bg="#30F030", activebackground="#30F030"
+            )
             self.button_for_selected_room = None
         if self.button_for_selected_empty_room is not None:
-            self.button_for_selected_empty_room.configure(bg="#5A605A", activebackground="#5A605A")
+            self.button_for_selected_empty_room.configure(
+                bg="#5A605A", activebackground="#5A605A"
+            )
             self.button_for_selected_empty_room = None
 
     def highlight_selected_button(self):
         if self.button_for_selected_room is not None:
-            self.button_for_selected_room.configure(bg="#228B22", activebackground="#228B22")
+            self.button_for_selected_room.configure(
+                bg="#228B22", activebackground="#228B22"
+            )
             self.button_for_selected_room = None
         if self.button_for_selected_empty_room is not None:
-            self.button_for_selected_empty_room.configure(bg="#1A201A", activebackground="#1A201A")
+            self.button_for_selected_empty_room.configure(
+                bg="#1A201A", activebackground="#1A201A"
+            )
             self.button_for_selected_empty_room = None
 
     def select_template_item(self, template_item, button, row, column):
@@ -375,7 +441,6 @@ class OptionsPanel(ttk.Frame):
         cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
         cancel_button.grid(row=0, column=1, pady=5, sticky="news")
 
-
     def update_zoom_level(self, zoom_level):
         self.grid_size_var.set(zoom_level)
 
@@ -388,7 +453,10 @@ class OptionsPanel(ttk.Frame):
                     break
                 if template_draw_item is None:
                     continue
-                if room_row_index + template_draw_item.height_in_rooms - 1 >= row and room_column_index + template_draw_item.width_in_rooms - 1 >= col:
+                if (
+                    room_row_index + template_draw_item.height_in_rooms - 1 >= row
+                    and room_column_index + template_draw_item.width_in_rooms - 1 >= col
+                ):
                     return template_draw_item, room_row_index, room_column_index
 
         return None, None, None

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -622,11 +622,12 @@ class OptionsPanel(ttk.Frame):
         settings_row += 1
 
         self.layout_frame = tk.Frame(self.scrollview.scrollable_frame)
-        self.layout_frame.grid(row=settings_row, column=0, sticky="news", padx=10, pady=10)
+        self.layout_frame.grid(
+            row=settings_row, column=0, sticky="news", padx=10, pady=10
+        )
 
         self.layout_label = tk.Label(self.layout_frame, text="Layout:")
         self.layout_label.grid(row=0, column=0, sticky="w")
-
 
         self.layout_combobox = ttk.Combobox(self.layout_frame, height=25)
         self.layout_combobox.grid(row=0, column=1, sticky="nsw", padx=(0, 10))
@@ -640,7 +641,9 @@ class OptionsPanel(ttk.Frame):
         self.layout_combobox.grid_remove()
         self.layout_label.grid_remove()
 
-        self.save_layout_button = tk.Button(self.layout_frame, text="Save layout", command=self.save_room_map)
+        self.save_layout_button = tk.Button(
+            self.layout_frame, text="Save layout", command=self.save_room_map
+        )
         self.save_layout_button.grid(row=0, column=2, sticky="w")
         self.save_layout_button.grid_remove()
         self.layout_frame.grid_remove()
@@ -681,7 +684,6 @@ class OptionsPanel(ttk.Frame):
         self.room_options.grid(row=settings_row, column=0, sticky="news")
         self.room_options.grid_remove()
 
-
     def save_room_map(self):
         win = PopupWindow("Save Layout", self.modlunky_config)
 
@@ -700,7 +702,10 @@ class OptionsPanel(ttk.Frame):
             for template_map in self.room_map:
                 segment = CustomRoomMapSegment(
                     template_map.name,
-                    [[room.template.name if room else "" for room in row] for row in template_map.rooms]
+                    [
+                        [room.template.name if room else "" for room in row]
+                        for row in template_map.rooms
+                    ],
                 )
                 segments.append(segment)
             room_map = CustomRoomMap(col1_ent.get(), segments)
@@ -709,7 +714,9 @@ class OptionsPanel(ttk.Frame):
                 level_room_maps = []
             level_room_maps.append(room_map)
             self.modlunky_config.custom_room_maps[self.lvl] = level_room_maps
-            self.modlunky_config.default_custom_room_maps[self.lvl] = len(level_room_maps) - 1
+            self.modlunky_config.default_custom_room_maps[self.lvl] = (
+                len(level_room_maps) - 1
+            )
             self.modlunky_config.save()
             self.update_layouts()
 
@@ -763,7 +770,9 @@ class OptionsPanel(ttk.Frame):
             self.layout_combobox.grid()
             self.layout_label.grid()
             self.layout_frame.grid()
-            self.layout_combobox["values"] = ["Default"] + [map.name for map in level_room_maps]
+            self.layout_combobox["values"] = ["Default"] + [
+                map.name for map in level_room_maps
+            ]
             default_layout = self.modlunky_config.default_custom_room_maps.get(self.lvl)
             layout_index = default_layout + 1 if default_layout is not None else 0
             self.layout_combobox.current(layout_index)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -381,11 +381,11 @@ class RoomOptions(ttk.Frame):
             self.configure_reverse_rooms_container()
             self.template_combobox.set(template.template.name)
             self.room_combobox["values"] = [
-                room.name or "room " + (index + 1)
+                room.name or "room " + str(index + 1)
                 for index, room in enumerate(template.template.rooms)
             ] + ["Create New"]
             self.room_combobox.set(
-                template.room_chunk.name or "room " + (template.room_index + 1)
+                template.room_chunk.name or "room " + str(template.room_index + 1)
             )
             self.room_combobox.current(template.room_index)
             self.template_container.grid()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk
 
 from modlunky2.config import Config
+from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.widgets import PopupWindow
 
 
@@ -12,6 +13,7 @@ class RoomOptions(ttk.Frame):
         on_select_template,
         on_clear_template,
         on_select_room,
+        on_flip_setting,
         *args,
         **kwargs,
     ):
@@ -22,6 +24,7 @@ class RoomOptions(ttk.Frame):
         self.on_select_template = on_select_template
         self.on_clear_template = on_clear_template
         self.on_select_room = on_select_room
+        self.on_flip_setting = on_flip_setting
 
         self.current_template_row = None
         self.current_template_column = None
@@ -55,6 +58,112 @@ class RoomOptions(ttk.Frame):
         self.room_combobox.set("")
         self.room_combobox["state"] = "readonly"
         self.room_combobox.bind("<<ComboboxSelected>>", lambda _: self.select_room())
+
+        self.room_settings_container = tk.Frame(self.template_container)
+        self.room_settings_container.grid(row=2, column=0, sticky="news")
+
+        self.var_ignore = tk.IntVar()
+        self.var_flip = tk.IntVar()
+        self.var_only_flip = tk.IntVar()
+        self.var_dual = tk.IntVar()
+        self.var_rare = tk.IntVar()
+        self.var_hard = tk.IntVar()
+        self.var_liquid = tk.IntVar()
+        self.var_purge = tk.IntVar()
+        self.checkbox_ignore = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Ignore",
+            var=self.var_ignore,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_ignore,
+        )
+        self.checkbox_flip = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Flip",
+            var=self.var_flip,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_flip,
+        )
+        self.checkbox_only_flip = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Only Flip",
+            var=self.var_only_flip,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_only_flip,
+        )
+        self.checkbox_rare = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Rare",
+            var=self.var_rare,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_rare,
+        )
+        self.checkbox_hard = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Hard",
+            var=self.var_hard,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_hard,
+        )
+        self.checkbox_liquid = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Optimize Liquids",
+            var=self.var_liquid,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_liquid,
+        )
+        self.checkbox_purge = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Purge",
+            var=self.var_purge,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_purge,
+        )
+        self.checkbox_dual = ttk.Checkbutton(
+            self.room_settings_container,
+            text="Dual",
+            var=self.var_dual,
+            onvalue=1,
+            offvalue=0,
+            command=self.on_flip_dual,
+        )
+
+        wrap = 400
+        label_dual = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Whether this room has a backlayer.")
+        label_ignore = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room will never appear in-game.")
+        label_purge = tk.Label (self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, other rooms of this same template which were already loaded (eg, loaded from another file or appear first in this file) will not appear in-game when this room's file is loaded.")
+        label_rare = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room has a 5% chance of being used.")
+        label_hard = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="If checked, this room only appears in X-3 and X-4.")
+        label_liquid = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Mark this room as containing liquid to optimize the liquid engine.")
+        label_flip = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Creates two rooms, one which is horizontally flipped from the original.")
+        label_only_flip = tk.Label(self.room_settings_container, wraplength=wrap, justify=tk.LEFT, text="Like flip, but the original room is ignored.")
+
+        self.checkbox_dual.grid(row=0, column=0, sticky="w")
+        label_dual.grid(row=1, column=0, sticky="nws")
+        self.checkbox_ignore.grid(row=2, column=0, sticky="w")
+        label_ignore.grid(row=3, column=0, sticky="nws")
+        self.checkbox_purge.grid(row=4, column=0, sticky="w")
+        label_purge.grid(row=5, column=0, sticky="nws")
+        self.checkbox_rare.grid(row=6, column=0, sticky="w")
+        label_rare.grid(row=7, column=0, sticky="nws")
+        self.checkbox_hard.grid(row=8, column=0, sticky="w")
+        label_hard.grid(row=9, column=0, sticky="nws")
+        self.checkbox_liquid.grid(row=10, column=0, sticky="w")
+        label_liquid.grid(row=11, column=0, sticky="nws")
+        self.checkbox_flip.grid(row=12, column=0, sticky="w")
+        label_flip.grid(row=12, column=0, sticky="nws")
+        self.checkbox_only_flip.grid(row=14, column=0, sticky="w")
+        label_only_flip.grid(row=15, column=0, sticky="nws")
+
+        self.columnconfigure(0, weight=1)
+
 
     def reset(self):
         self.current_template_row = None
@@ -106,6 +215,22 @@ class RoomOptions(ttk.Frame):
             self.room_combobox.set(template.room_chunk.name or "room " + (template.room_index + 1))
             self.room_combobox.current(template.room_index)
             self.template_container.grid()
+
+            current_settings = template.room_chunk.settings
+            self.set_dual(TemplateSetting.DUAL in current_settings)
+            self.set_flip(TemplateSetting.FLIP in current_settings)
+            self.set_purge(TemplateSetting.PURGE in current_settings)
+            self.set_only_flip(
+                TemplateSetting.ONLYFLIP in current_settings
+            )
+            self.set_ignore(
+                TemplateSetting.IGNORE in current_settings
+            )
+            self.set_rare(TemplateSetting.RARE in current_settings)
+            self.set_hard(TemplateSetting.HARD in current_settings)
+            self.set_liquid(
+                TemplateSetting.LIQUID in current_settings
+            )
         else:
             self.set_empty_cell(row, column)
 
@@ -115,6 +240,80 @@ class RoomOptions(ttk.Frame):
         self.template_combobox.set("None")
         self.template_container.grid_remove()
 
+    def flip_setting(self, setting, value):
+        self.on_flip_setting(setting, value, self.current_template_row, self.current_template_column)
+
+    def on_flip_ignore(self):
+        self.flip_setting(TemplateSetting.IGNORE, self.ignore())
+
+    def on_flip_liquid(self):
+        self.flip_setting(TemplateSetting.LIQUID, self.liquid())
+
+    def on_flip_hard(self):
+        self.flip_setting(TemplateSetting.HARD, self.hard())
+
+    def on_flip_rare(self):
+        self.flip_setting(TemplateSetting.RARE, self.rare())
+
+    def on_flip_flip(self):
+        self.flip_setting(TemplateSetting.FLIP, self.flip())
+
+    def on_flip_only_flip(self):
+        self.flip_setting(TemplateSetting.ONLYFLIP, self.only_flip())
+
+    def on_flip_purge(self):
+        self.flip_setting(TemplateSetting.PURGE, self.purge())
+
+    def on_flip_dual(self):
+        self.flip_setting(TemplateSetting.DUAL, self.dual())
+
+    def ignore(self):
+        return int(self.var_ignore.get()) == 1
+
+    def liquid(self):
+        return int(self.var_liquid.get()) == 1
+
+    def hard(self):
+        return int(self.var_hard.get()) == 1
+
+    def rare(self):
+        return int(self.var_rare.get()) == 1
+
+    def flip(self):
+        return int(self.var_flip.get()) == 1
+
+    def only_flip(self):
+        return int(self.var_only_flip.get()) == 1
+
+    def purge(self):
+        return int(self.var_purge.get()) == 1
+
+    def dual(self):
+        return int(self.var_dual.get()) == 1
+
+    def set_ignore(self, ignore):
+        self.var_ignore.set(ignore and 1 or 0)
+
+    def set_liquid(self, liquid):
+        self.var_liquid.set(liquid and 1 or 0)
+
+    def set_hard(self, hard):
+        self.var_hard.set(hard and 1 or 0)
+
+    def set_rare(self, rare):
+        self.var_rare.set(rare and 1 or 0)
+
+    def set_flip(self, flip):
+        self.var_flip.set(flip and 1 or 0)
+
+    def set_only_flip(self, only_flip):
+        self.var_only_flip.set(only_flip and 1 or 0)
+
+    def set_purge(self, purge):
+        self.var_purge.set(purge and 1 or 0)
+
+    def set_dual(self, dual):
+        self.var_dual.set(dual and 1 or 0)
 
 class OptionsPanel(ttk.Frame):
     def __init__(
@@ -128,6 +327,7 @@ class OptionsPanel(ttk.Frame):
         on_change_template_at,
         on_clear_template,
         on_select_room,
+        on_flip_setting,
         *args,
         **kwargs,
     ):
@@ -140,6 +340,7 @@ class OptionsPanel(ttk.Frame):
         self.on_change_template_at = on_change_template_at
         self.on_clear_template = on_clear_template
         self.on_select_room = on_select_room
+        self.on_flip_setting = on_flip_setting
 
         self.columnconfigure(0, minsize=10)
         self.columnconfigure(1, weight=1)
@@ -244,7 +445,7 @@ class OptionsPanel(ttk.Frame):
         settings_row += 1
 
         self.room_options = RoomOptions(
-            self, self.update_room_map_template, self.clear_template, self.on_select_room
+            self, self.update_room_map_template, self.clear_template, self.on_select_room, self.on_flip_setting
         )
         self.room_options.grid(row=settings_row, column=1, sticky="news")
         self.room_options.grid_remove()

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -1,0 +1,103 @@
+import tkinter as tk
+from tkinter import ttk
+
+class OptionsPanel(ttk.Frame):
+    def __init__(
+        self,
+        parent,
+        modlunky_config,
+        zoom_level,
+        on_update_hide_grid_lines,
+        on_update_hide_room_lines,
+        on_update_zoom_level,
+        *args,
+        **kwargs
+    ):
+        super().__init__(parent, *args, **kwargs)
+
+        self.modlunky_config = modlunky_config
+        self.on_update_hide_grid_lines = on_update_hide_grid_lines
+        self.on_update_hide_room_lines = on_update_hide_room_lines
+        self.on_update_zoom_level = on_update_zoom_level
+
+
+        # self.rowconfigure(2, minsize=20)
+        # self.rowconfigure(4, minsize=20)
+        self.columnconfigure(0, minsize=10)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, minsize=10)
+
+        # right_padding = 10
+        settings_row = 0
+
+
+        # Checkbox to toggle the visibility of the grid lines.
+        hide_grid_var = tk.IntVar()
+        hide_grid_var.set(False)
+
+        def toggle_hide_grid():
+            nonlocal hide_grid_var
+
+            self.on_update_hide_grid_lines(hide_grid_var.get())
+
+        settings_row += 1
+        tk.Checkbutton(
+            self,
+            text="Hide grid lines",
+            variable=hide_grid_var,
+            onvalue=True,
+            offvalue=False,
+            command=toggle_hide_grid,
+        ).grid(row=settings_row, column=1, sticky="nw", pady=5)
+
+        # Checkbox to toggle the visibility of the grid lines on room boundaries.
+        hide_room_grid_var = tk.IntVar()
+        hide_room_grid_var.set(False)
+
+        def toggle_hide_room_grid():
+            nonlocal hide_room_grid_var
+            self.on_update_hide_room_lines(hide_room_grid_var.get())
+
+        settings_row += 1
+        tk.Checkbutton(
+            self,
+            text="Hide room lines",
+            variable=hide_room_grid_var,
+            onvalue=True,
+            offvalue=False,
+            command=toggle_hide_room_grid,
+        ).grid(row=settings_row, column=1, sticky="nw", pady=5)
+
+        settings_row += 1
+        grid_size_frame = tk.Frame(self)
+        grid_size_frame.grid(row=settings_row, column=1, sticky="nw", pady=5)
+        grid_size_frame.columnconfigure(0, weight=1)
+        grid_size_var = tk.StringVar()
+        grid_size_var.set(str(zoom_level))
+        grid_size_label_frame = tk.Frame(grid_size_frame)
+        grid_size_label_frame.grid(row=0, column=0, sticky="nw")
+
+        grid_size_header_label = tk.Label(grid_size_label_frame, text="Zoom:")
+        grid_size_header_label.grid(row=0, column=0, sticky="nwe")
+        grid_size_label = tk.Label(grid_size_label_frame, textvariable=grid_size_var)
+        grid_size_label.grid(row=0, column=1, sticky="nw")
+
+        grid_size_scale = tk.Scale(
+            grid_size_frame,
+            from_=10,
+            to=200,
+            orient=tk.HORIZONTAL,
+            variable=grid_size_var,
+            length=390,
+            showvalue=False,
+        )
+        grid_size_scale.grid(row=1, column=0, sticky="nwe")
+
+        def update_grid_size(_):
+            self.on_update_zoom_level(int(grid_size_var.get()))
+
+        grid_size_scale["command"] = update_grid_size
+        self.grid_size_var = grid_size_var
+
+    def update_zoom_level(self, zoom_level):
+        self.grid_size_var.set(zoom_level)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/reversed_rooms.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/reversed_rooms.py
@@ -1,0 +1,7 @@
+REVERSED_ROOMS = [
+    "palaceofpleasure_1-1",
+    "palaceofpleasure_3-2",
+    "udjatentrance",
+    "challenge_entrance",
+    "blackmarket_exit",
+]

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -13,6 +13,7 @@ from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
 )
 
+
 @dataclass
 class RoomMap:
     name: str
@@ -167,11 +168,10 @@ def find_roommap(templates):
 
     olmecship_room = template_map.get("olmecship_room")
     if olmecship_room:
-        for i, room in enumerate(room_map[more_rooms_start - 1]):
+        for i, room in enumerate(path_map[more_rooms_start - 1]):
             if room is None:
                 set_room(path_map, i, more_rooms_start - 1, olmecship_room)
                 break
-
 
     challenge_entrance = template_map.get("challenge_entrance")
     challenge_special = template_map.get("challenge_special")
@@ -228,7 +228,6 @@ def find_roommap(templates):
 
     if len(path_map) > 0:
         room_map.append(RoomMap("path", path_map))
-
 
     other_rooms_map = []
 
@@ -294,11 +293,15 @@ def find_roommap(templates):
         if bottom_room:
             if vertical_max_height < r + 1:
                 vertical_max_height = r + 1
-            set_room(other_rooms_map, vertical_room_column, more_rooms_start + r, bottom_room)
+            set_room(
+                other_rooms_map, vertical_room_column, more_rooms_start + r, bottom_room
+            )
         if top_room is not None or bottom_room is not None:
             vertical_room_column += 1
 
-    more_rooms_bottom = more_rooms_start + vertical_max_height - 1
+    more_rooms_bottom = max(
+        more_rooms_start, more_rooms_start + vertical_max_height - 1
+    )
 
     other_rooms_to_add = [
         "abzu_backdoor",
@@ -363,7 +366,9 @@ def find_roommap(templates):
 
             if not added_room:
                 if len(other_rooms_map) > 0 and len(other_rooms_map[0]) < 3:
-                    set_room(other_rooms_map, len(other_rooms_map[0]), more_rooms_start, room)
+                    set_room(
+                        other_rooms_map, len(other_rooms_map[0]), more_rooms_start, room
+                    )
                 else:
                     more_rooms_start = more_rooms_bottom + 1
                     more_rooms_bottom = more_rooms_start

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -137,4 +137,52 @@ def find_roommap(templates):
             set_room(room_map, ec, path_start + er, path_exit_notop)
         more_rooms_start = path_start + er + 1
 
+    olmecship_room = template_map.get("olmecship_room")
+    if olmecship_room:
+        for i, room in enumerate(room_map[more_rooms_start - 1]):
+            if room is None:
+                set_room(room_map, i, more_rooms_start - 1, olmecship_room)
+                break
+
+    challenge_entrance = template_map.get("challenge_entrance")
+    challenge_special = template_map.get("challenge_special")
+    challenge_bottom = template_map.get("challenge_bottom")
+    entrancer, entrancec = None, None
+    if challenge_entrance:
+        for i, room in enumerate(room_map[more_rooms_start - 1]):
+            if room is None:
+                entrancer, entrancec = more_rooms_start - 1, i
+                set_room(room_map, i, more_rooms_start - 1, challenge_entrance)
+                break
+        if entrancer is None:
+            entrancer, entrancec = more_rooms_start, 0
+            set_room(room_map, 0, more_rooms_start, challenge_entrance)
+            more_rooms_start += 1
+
+    bottomr, bottomc = None, None
+    if challenge_bottom:
+        if entrancer is not None and entrancec is not None:
+            set_room(room_map, entrancec, entrancer + 1, challenge_bottom)
+            bottomr, bottomc = entrancer + 1, entrancec
+            more_rooms_start += 1
+        else:
+            set_room(room_map, 0, more_rooms_start, challenge_bottom)
+            bottomr, bottomc = more_rooms_start, 0
+            more_rooms_start += 1
+
+    if challenge_special:
+        if bottomc is not None and bottomr is not None:
+            set_room(room_map, bottomc < len(room_map[0]) and bottomc + 1 or bottomc - 1, bottomr, challenge_special)
+        elif entrancer is not None and entrancec is not None:
+            cr, cc = entrancer + 1, entrancec
+            if entrancec < len(room_map[entrancer]) and room_map[entrancer][entrancec + 1] is None:
+                cr, cc = entrancer, entrancec + 1
+            elif entrancec > 0 and room_map[entrancer][entrancec - 1] is None:
+                cr, cc = entrancer, entrancec - 1
+            set_room(room_map, cc, cr, challenge_special)
+            more_rooms_start = cr + 1
+        else:
+            set_room(room_map, 0, more_rooms_start, challenge_special)
+            more_rooms_start += 1
+
     return room_map

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -1,6 +1,13 @@
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
-from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
-from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import TemplateDrawItem
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import (
+    RoomInstance,
+    RoomTemplate,
+    MatchedSetroomTemplate,
+)
+from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
+    TemplateDrawItem,
+)
+
 
 def find_roommap(templates):
     setrooms = {}
@@ -9,12 +16,13 @@ def find_roommap(templates):
         if matched_template:
             if matched_template.name not in setrooms:
                 setrooms[matched_template.name] = []
-            setrooms[matched_template.name].append(MatchedSetroomTemplate(room_template, matched_template))
+            setrooms[matched_template.name].append(
+                MatchedSetroomTemplate(room_template, matched_template)
+            )
         # if not matched_template:
         #     continue
 
         # setrooms.append(MatchedSetroomTemplate(room_template, matched_template))
-
 
     def expand_to_height_if_necessary(room_map, height):
         if len(room_map) < height:
@@ -41,7 +49,12 @@ def find_roommap(templates):
             expand_to_height_if_necessary(room_map, y + setroom_start + 1)
             expand_to_width_if_necessary(room_map, x + 1)
 
-            room_map[setroom_start + y][x] = TemplateDrawItem(matchedtemplate.template, templates.index(matchedtemplate.template), matchedtemplate.template.rooms[0], 0)
+            room_map[setroom_start + y][x] = TemplateDrawItem(
+                matchedtemplate.template,
+                templates.index(matchedtemplate.template),
+                matchedtemplate.template.rooms[0],
+                0,
+            )
 
         setroom_start = len(room_map)
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -11,6 +11,7 @@ from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
 )
 
+
 def get_template_draw_item(room_template, index):
     chunk_index = None
     if len(room_template.rooms) == 0:
@@ -34,6 +35,7 @@ def get_template_draw_item(room_template, index):
         int(math.ceil(len(chunk.front[0]) / 10)),
         int(math.ceil(len(chunk.front) / 8)),
     )
+
 
 def find_roommap(templates):
     setrooms = {}
@@ -73,7 +75,9 @@ def find_roommap(templates):
             match = matchedtemplate.setroom
             x, y = match.coords.x, match.coords.y
 
-            template_item = get_template_draw_item(matchedtemplate.template, templates.index(matchedtemplate.template))
+            template_item = get_template_draw_item(
+                matchedtemplate.template, templates.index(matchedtemplate.template)
+            )
             if template_item:
                 set_room(room_map, x, setroom_start + y, template_item)
 
@@ -180,10 +184,18 @@ def find_roommap(templates):
 
     if challenge_special:
         if bottomc is not None and bottomr is not None:
-            set_room(room_map, bottomc < len(room_map[0]) and bottomc + 1 or bottomc - 1, bottomr, challenge_special)
+            set_room(
+                room_map,
+                bottomc < len(room_map[0]) and bottomc + 1 or bottomc - 1,
+                bottomr,
+                challenge_special,
+            )
         elif entrancer is not None and entrancec is not None:
             cr, cc = entrancer + 1, entrancec
-            if entrancec < len(room_map[entrancer]) and room_map[entrancer][entrancec + 1] is None:
+            if (
+                entrancec < len(room_map[entrancer])
+                and room_map[entrancer][entrancec + 1] is None
+            ):
                 cr, cc = entrancer, entrancec + 1
             elif entrancec > 0 and room_map[entrancer][entrancec - 1] is None:
                 cr, cc = entrancer, entrancec - 1
@@ -309,7 +321,7 @@ def find_roommap(templates):
         room = template_map.get(room_name)
         added_room = False
         if room:
-            for row in range(more_rooms_start, more_rooms_bottom+1):
+            for row in range(more_rooms_start, more_rooms_bottom + 1):
                 if added_room:
                     break
                 if len(room_map) <= row:

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -11,6 +11,30 @@ from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import (
     TemplateDrawItem,
 )
 
+def get_template_draw_item(room_template, index):
+    chunk_index = None
+    if len(room_template.rooms) == 0:
+        return None
+    for i, c in enumerate(room_template.rooms):
+        if TemplateSetting.IGNORE not in c.settings:
+            chunk_index = i
+            break
+
+    if chunk_index is None:
+        return None
+
+    chunk = room_template.rooms[chunk_index]
+    if chunk is None or len(chunk.front) == 0:
+        return None
+    return TemplateDrawItem(
+        room_template,
+        index,
+        chunk,
+        chunk_index,
+        int(math.ceil(len(chunk.front[0]) / 10)),
+        int(math.ceil(len(chunk.front) / 8)),
+    )
+
 def find_roommap(templates):
     setrooms = {}
     for room_template in templates:
@@ -43,31 +67,6 @@ def find_roommap(templates):
 
     room_map = []
     setroom_start = 0
-
-    def get_template_draw_item(room_template, index):
-        chunk_index = None
-        if len(room_template.rooms) == 0:
-            return None
-        for i, c in enumerate(room_template.rooms):
-            if TemplateSetting.IGNORE not in c.settings:
-                chunk_index = i
-                break
-
-        if chunk_index is None:
-            return None
-
-        chunk = room_template.rooms[chunk_index]
-        if chunk is None or len(chunk.front) == 0:
-            return None
-        return TemplateDrawItem(
-            room_template,
-            index,
-            chunk,
-            chunk_index,
-            int(math.ceil(len(chunk.front[0]) / 10)),
-            int(math.ceil(len(chunk.front) / 8)),
-        )
-
 
     for _, setroomtype in setrooms.items():
         for matchedtemplate in setroomtype:

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -185,4 +185,40 @@ def find_roommap(templates):
             set_room(room_map, 0, more_rooms_start, challenge_special)
             more_rooms_start += 1
 
+    bigroom_side = template_map.get("machine_bigroom_side")
+    wideroom_side = template_map.get("machine_wideroom_side")
+    tallroom_side = template_map.get("machine_tallroom_side")
+    side = template_map.get("side")
+
+    sideroomsc, sideroomsr = 0, 0
+    sider, sidec = 0, 0
+    highest_room = 0
+    if bigroom_side:
+        set_room(room_map, 0, more_rooms_start, bigroom_side)
+        sideroomsc = 2
+        sideroomsr = 2
+        sider, sidec = 0, 2
+        highest_room = 2
+    if tallroom_side:
+        set_room(room_map, sideroomsc, more_rooms_start, tallroom_side)
+        sideroomsr = 2
+        sideroomsc += 1
+        sider, sidec = 0, sideroomsc
+        highest_room = 2
+    if wideroom_side:
+        wider, widec = sideroomsr, 0
+        sider, sidec = wider, widec + 2
+        if sideroomsc <= 2:
+            wider, widec = 0, sideroomsc
+            sider, sidec = wider + 1, widec
+        if wider + 1 > highest_room:
+            highest_room = wider + 1
+        set_room(room_map, widec, more_rooms_start + wider, wideroom_side)
+    if side:
+        set_room(room_map, sidec, more_rooms_start + sider, side)
+        if sider + 1 > highest_room:
+            highest_room = sider + 1
+
+    more_rooms_start += highest_room
+
     return room_map

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -1,5 +1,6 @@
 import math
 
+from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.vanilla_types import (
     RoomInstance,
@@ -44,9 +45,17 @@ def find_roommap(templates):
     setroom_start = 0
 
     def get_template_draw_item(room_template, index):
-        chunk_index = 0
+        chunk_index = None
         if len(room_template.rooms) == 0:
             return None
+        for i, c in enumerate(room_template.rooms):
+            if TemplateSetting.IGNORE not in c.settings:
+                chunk_index = i
+                break
+
+        if chunk_index is None:
+            return None
+
         chunk = room_template.rooms[chunk_index]
         if chunk is None or len(chunk.front) == 0:
             return None

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -58,4 +58,28 @@ def find_roommap(templates):
 
         setroom_start = len(room_map)
 
+    for template_index, room_template in enumerate(templates):
+        if room_template.name == "machine_bigroom_path":
+            expand_to_height_if_necessary(room_map, setroom_start + 2)
+            expand_to_width_if_necessary(room_map, 2)
+            room_map[setroom_start][0] = TemplateDrawItem(
+                room_template,
+                template_index,
+                room_template.rooms[0],
+                0,
+                2,
+                2,
+            )
+        elif room_template.name == "machine_bigroom_side":
+            expand_to_height_if_necessary(room_map, setroom_start + 2)
+            expand_to_width_if_necessary(room_map, 4)
+            room_map[setroom_start][2] = TemplateDrawItem(
+                room_template,
+                template_index,
+                room_template.rooms[0],
+                0,
+                2,
+                2,
+            )
+
     return room_map

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -221,4 +221,102 @@ def find_roommap(templates):
 
     more_rooms_start += highest_room
 
+    other_vertical_paired_rooms_to_add = [
+        ["idol_top", "idol"],
+        ["udjattop", "udjatentrance"],
+        ["machine_keyroom", "machine_rewardroom"],
+        ["cog_altar_top", "altar"],
+        ["oldhunter_keyroom", "oldhunter_rewardroom"],
+    ]
+
+    vertical_room_column = 0
+    vertical_max_height = 0
+    for room_pair in other_vertical_paired_rooms_to_add:
+        top_room = template_map.get(room_pair[0])
+        r = 0
+        if top_room:
+            set_room(room_map, vertical_room_column, more_rooms_start, top_room)
+            r = 1
+            if vertical_max_height == 0:
+                vertical_max_height = 1
+        bottom_room = template_map.get(room_pair[1])
+        if bottom_room:
+            if vertical_max_height < r + 1:
+                vertical_max_height = r + 1
+            set_room(room_map, vertical_room_column, more_rooms_start + r, bottom_room)
+        if top_room is not None or bottom_room is not None:
+            vertical_room_column += 1
+
+    more_rooms_bottom = more_rooms_start + vertical_max_height - 1
+
+    other_rooms_to_add = [
+        "abzu_backdoor",
+        "lake_normal",
+        "lake_notop",
+        "lake_exit",
+        "lakeoffire_back_entrance",
+        "lakeoffire_back_exit",
+        "mothership_entrance",
+        "mothership_exit",
+        "mothership_coffin",
+        "storage_room",
+        "moai",
+        "coffin_unlockable",
+        "coffin_player",
+        "coffin_player_vertical",
+        "quest_thief2",
+        "beehive",
+        "beehive_entrance",
+        "blackmarket_entrance",
+        "blackmarket_exit",
+        "blackmarket_coffin",
+        "apep",
+        "pen_room",
+        "ghistshop",
+        "empress_grave",
+        "vault",
+        "shop_entrance_up",
+        "shop_entrance_down",
+        "diceshop",
+        "curioshop",
+        "cavemanshop",
+        "posse",
+        "quest_thief1",
+        "room2",
+        "passage_horz",
+        "passage_vert",
+        "passage_turn",
+        "ushabti_entrance",
+        "ushabti_room",
+        "sisters_room",
+        "motherstatue_room",
+        "crashedship_entrance",
+        "crashedship_entrance_notop",
+        "anubis_room",
+        "oldhunter_cursedroom",
+    ]
+
+    for room_name in other_rooms_to_add:
+        room = template_map.get(room_name)
+        added_room = False
+        if room:
+            for row in range(more_rooms_start, more_rooms_bottom+1):
+                if added_room:
+                    break
+                if len(room_map) <= row:
+                    break
+                for col, template_item in enumerate(room_map[row]):
+                    if template_item is None:
+                        set_room(room_map, col, row, room)
+                        added_room = True
+                        break
+
+            if not added_room:
+                if len(room_map) > 0 and len(room_map[0]) < 3:
+                    set_room(room_map, len(room_map[0]), more_rooms_start, room)
+                else:
+                    more_rooms_start = more_rooms_bottom + 1
+                    more_rooms_bottom = more_rooms_start
+                    set_room(room_map, 0, more_rooms_start, room)
+
     return room_map

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -222,6 +222,8 @@ def find_roommap(templates):
     more_rooms_start += highest_room
 
     other_vertical_paired_rooms_to_add = [
+        ["shop_attic", "shop_entrance_up"],
+        ["shop_entrance_down", "shop_basement"],
         ["idol_top", "idol"],
         ["udjattop", "udjatentrance"],
         ["machine_keyroom", "machine_rewardroom"],
@@ -274,9 +276,8 @@ def find_roommap(templates):
         "pen_room",
         "ghistshop",
         "empress_grave",
+        "shop",
         "vault",
-        "shop_entrance_up",
-        "shop_entrance_down",
         "diceshop",
         "curioshop",
         "cavemanshop",

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -1,0 +1,48 @@
+from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+from modlunky2.ui.levels.vanilla_levels.multi_room.template_draw_item import TemplateDrawItem
+
+def find_roommap(templates):
+    setrooms = {}
+    for room_template in templates:
+        matched_template = Setroom.find_vanilla_setroom(room_template.name)
+        if matched_template:
+            if matched_template.name not in setrooms:
+                setrooms[matched_template.name] = []
+            setrooms[matched_template.name].append(MatchedSetroomTemplate(room_template, matched_template))
+        # if not matched_template:
+        #     continue
+
+        # setrooms.append(MatchedSetroomTemplate(room_template, matched_template))
+
+
+    def expand_to_height_if_necessary(room_map, height):
+        if len(room_map) < height:
+            for _ in range(height - len(room_map)):
+                if len(room_map) == 0:
+                    room_map.append([None])
+                else:
+                    room_map.append([None for _ in range(len(room_map[0]))])
+
+    def expand_to_width_if_necessary(room_map, width):
+        for row in room_map:
+            if len(row) < width:
+                for _ in range(width - len(row)):
+                    row.append(None)
+
+    room_map = []
+    setroom_start = 0
+
+    for _, setroomtype in setrooms.items():
+        for matchedtemplate in setroomtype:
+            match = matchedtemplate.setroom
+            x, y = match.coords.x, match.coords.y
+
+            expand_to_height_if_necessary(room_map, y + setroom_start + 1)
+            expand_to_width_if_necessary(room_map, x + 1)
+
+            room_map[setroom_start + y][x] = TemplateDrawItem(matchedtemplate.template, templates.index(matchedtemplate.template), matchedtemplate.template.rooms[0], 0)
+
+        setroom_start = len(room_map)
+
+    return room_map

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+
+@dataclass
+class TemplateDrawItem:
+    template: RoomTemplate
+    template_index: int
+    room_chunk: RoomInstance
+    room_index: int

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 
-from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import (
+    RoomInstance,
+    RoomTemplate,
+    MatchedSetroomTemplate,
+)
+
 
 @dataclass
 class TemplateDrawItem:

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/template_draw_item.py
@@ -13,3 +13,5 @@ class TemplateDrawItem:
     template_index: int
     room_chunk: RoomInstance
     room_index: int
+    width_in_rooms: int = 1
+    height_in_rooms: int = 1

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -155,6 +155,7 @@ class VanillaLevelEditor(ttk.Frame):
                 tile, percent, alt_tile, self.palette_panel, self.mag
             ),
             self.delete_tilecode,
+            self.multiroom_editor_selected_tile,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -309,6 +310,7 @@ class VanillaLevelEditor(ttk.Frame):
             lambda tile, percent, alt_tile: self.add_tilecode(
                 tile, percent, alt_tile, self.palette_panel, self.mag
             ),
+            self.palette_selected_tile,
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )
@@ -381,6 +383,9 @@ class VanillaLevelEditor(ttk.Frame):
                 self.palette_panel.select_tile(
                     tilecode_item[0], tilecode_item[2], False
                 )
+
+                self.multi_room_editor_tab.select_tile(tilecode_item[0], tilecode_item[2], True)
+                self.multi_room_editor_tab.select_tile(tilecode_item[0], tilecode_item[2], False)
 
                 for i in self.tile_palette_ref_in_use:
                     if str(i[0]).split(" ", 1)[1] == str(tilecode.value):
@@ -559,6 +564,12 @@ class VanillaLevelEditor(ttk.Frame):
         )
         self.multi_room_editor_tab.populate_tilecode_palette(self.tile_palette_ref_in_use, None)
 
+    def palette_selected_tile(self, tile_name, image, is_primary):
+        self.multi_room_editor_tab.select_tile(tile_name, image, is_primary)
+
+    def multiroom_editor_selected_tile(self, tile_name, image, is_primary):
+        self.palette_panel.select_tile(tile_name, image, is_primary)
+
     def save_requested(self):
         if self.save_needed:
             msg_box = tk.messagebox.askquestion(
@@ -721,6 +732,7 @@ class VanillaLevelEditor(ttk.Frame):
         tile = self.tile_palette_map[tile_code]
 
         self.palette_panel.select_tile(tile[0], tile[2], is_primary)
+        self.multi_room_editor_tab.select_tile(tile[0], tile[2], is_primary)
 
     # Looks up the expected offset type and tile image size and computes the offset of the tile's anchor in the grid.
     def offset_for_tile(self, tile_name, tile_code, tile_size):

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -601,7 +601,7 @@ class VanillaLevelEditor(ttk.Frame):
     def multiroom_editor_modified_room(self, template_draw_item):
         if template_draw_item.room_chunk == self.current_selected_room:
             self.room_select(None)
-            self.changes_made()
+        self.changes_made()
 
     def save_requested(self):
         if self.save_needed:

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -177,6 +177,9 @@ class VanillaLevelEditor(ttk.Frame):
             self.multiroom_editor_selected_tile,
             self.multiroom_editor_modified_room,
             self.on_insert_room,
+            self.on_duplicate_room,
+            self.on_rename_room,
+            self.on_delete_room,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -1112,7 +1115,7 @@ class VanillaLevelEditor(ttk.Frame):
         if self.last_selected_tab == "Full Level View":
             self.load_full_preview()
 
-    def on_insert_room(self, parent_index, name = None):
+    def on_insert_room(self, parent_index, name=None):
         room_template = self.template_list[parent_index]
         # Set default prompt based on parent name
         roomsize_key = "normal: 10x8"

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -432,6 +432,33 @@ class VanillaLevelEditor(ttk.Frame):
                 self.tile_palette_ref_in_use.append(tilecode_item)
                 self.tile_palette_map[tilecode.value] = tilecode_item
 
+        # Populate the default tile code for left clicks.
+        if "1" in self.tile_palette_map:
+            # If there is a "1" tile code, guess it is a good default tile since it is often the floor.
+            tile = self.tile_palette_map["1"]
+            self.palette_panel.select_tile(tile[0], tile[2], True)
+        elif len(self.tile_palette_ref_in_use) > 0:
+            # If there is no "1" tile, just populate with the first tile.
+            tile = self.tile_palette_ref_in_use[0]
+            self.palette_panel.select_tile(tile[0], tile[2], True)
+            secondary_backup_index = 1
+
+        # Populate the default tile code for right clicks.
+        if "0" in self.tile_palette_map:
+            # If there is a "0" tile code, guess it is a good default secondary tile since it is often the empty tile.
+            tile = self.tile_palette_map["0"]
+            self.palette_panel.select_tile(tile[0], tile[2], False)
+        elif len(self.tile_palette_ref_in_use) > secondary_backup_index:
+            # If there is not a "0" tile code, populate with the second tile code if the
+            # primary tile code was populated from the first one.
+            tile = self.tile_palette_ref_in_use[secondary_backup_index]
+            self.palette_panel.select_tile(tile[0], tile[2], False)
+        elif len(self.tile_palette_ref_in_use) > 0:
+            # If there are only one tile code available, populate both right and
+            # left click with it.
+            tile = self.tile_palette_ref_in_use[0]
+            self.palette_panel.select_tile(tile[0], tile[2], False)
+
         if level is None:
             return
 

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -270,7 +270,6 @@ class VanillaLevelEditor(ttk.Frame):
         # Level Editor Tab
         self.tab_control.add(self.editor_tab, text="Level Editor")
         self.tab_control.add(self.rules_tab, text="Rules")
-        self.tab_control.add(self.preview_tab, text="Full Level View")
         self.tab_control.add(self.multi_room_editor_tab, text="Full Level Editor")
         self.tab_control.add(self.variables_tab, text="Variables (Experimental)")
 

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -176,6 +176,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.delete_tilecode,
             self.multiroom_editor_selected_tile,
             self.multiroom_editor_modified_room,
+            self.multiroom_editor_changed_filetree,
             self.on_insert_room,
             self.on_duplicate_room,
             self.on_rename_room,
@@ -607,6 +608,11 @@ class VanillaLevelEditor(ttk.Frame):
         if template_draw_item.room_chunk == self.current_selected_room:
             self.room_select(None)
         self.changes_made()
+
+    def multiroom_editor_changed_filetree(self):
+        self.level_list_panel.reset()
+        self.level_list_panel.set_rooms(self.template_list)
+        self.room_select(None)
 
     def save_requested(self):
         if self.save_needed:

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -1157,6 +1157,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.canvas.show_intro()
         del room_template.rooms[room_index]
         self.changes_made()
+        self.multi_room_editor_tab.room_was_deleted(parent_index, room_index)
 
     def on_copy_room(self, parent_index, room_index):
         room_template = self.template_list[parent_index]

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -29,9 +29,15 @@ from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.dual_util import make_dual, remove_dual
 from modlunky2.ui.levels.vanilla_levels.level_list_panel import LevelListPanel
 from modlunky2.ui.levels.vanilla_levels.level_settings_bar import LevelSettingsBar
-from modlunky2.ui.levels.vanilla_levels.multi_room.multi_room_editor_tab import MultiRoomEditorTab
+from modlunky2.ui.levels.vanilla_levels.multi_room.multi_room_editor_tab import (
+    MultiRoomEditorTab,
+)
 from modlunky2.ui.levels.vanilla_levels.rules.rules_tab import RulesTab
-from modlunky2.ui.levels.vanilla_levels.vanilla_types import RoomInstance, RoomTemplate, MatchedSetroomTemplate
+from modlunky2.ui.levels.vanilla_levels.vanilla_types import (
+    RoomInstance,
+    RoomTemplate,
+    MatchedSetroomTemplate,
+)
 from modlunky2.ui.levels.vanilla_levels.variables.level_dependencies import (
     LevelDependencies,
 )
@@ -45,6 +51,7 @@ logger = logging.getLogger(__name__)
 class LAYER:
     FRONT = 0
     BACK = 1
+
 
 @dataclass
 class RoomType:
@@ -387,8 +394,12 @@ class VanillaLevelEditor(ttk.Frame):
                     tilecode_item[0], tilecode_item[2], False
                 )
 
-                self.multi_room_editor_tab.select_tile(tilecode_item[0], tilecode_item[2], True)
-                self.multi_room_editor_tab.select_tile(tilecode_item[0], tilecode_item[2], False)
+                self.multi_room_editor_tab.select_tile(
+                    tilecode_item[0], tilecode_item[2], True
+                )
+                self.multi_room_editor_tab.select_tile(
+                    tilecode_item[0], tilecode_item[2], False
+                )
 
                 for i in self.tile_palette_ref_in_use:
                     if str(i[0]).split(" ", 1)[1] == str(tilecode.value):
@@ -453,7 +464,9 @@ class VanillaLevelEditor(ttk.Frame):
                 RoomTemplate(template.name, template.comment, data_rooms)
             )
         self.level_list_panel.set_rooms(self.template_list)
-        self.multi_room_editor_tab.open_lvl(self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list)
+        self.multi_room_editor_tab.open_lvl(
+            self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list
+        )
 
     def load_full_preview(self):
         self.list_preview_tiles_ref = []
@@ -564,7 +577,9 @@ class VanillaLevelEditor(ttk.Frame):
             self.lvl_biome,
             self.lvl,
         )
-        self.multi_room_editor_tab.populate_tilecode_palette(self.tile_palette_ref_in_use, None)
+        self.multi_room_editor_tab.populate_tilecode_palette(
+            self.tile_palette_ref_in_use, None
+        )
 
     def palette_selected_tile(self, tile_name, image, is_primary):
         self.multi_room_editor_tab.select_tile(tile_name, image, is_primary)

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -23,7 +23,10 @@ from modlunky2.levels.tile_codes import VALID_TILE_CODES, TileCode, TileCodes, S
 from modlunky2.ui.levels.shared.biomes import Biomes
 from modlunky2.ui.levels.shared.files_tree import FilesTree, PACK_LIST_TYPE, LEVEL_TYPE
 from modlunky2.ui.levels.shared.make_backup import make_backup
-from modlunky2.ui.levels.shared.multi_canvas_container import MultiCanvasContainer
+from modlunky2.ui.levels.shared.multi_canvas_container import (
+    MultiCanvasContainer,
+    CanvasIndex,
+)
 from modlunky2.ui.levels.shared.palette_panel import PalettePanel
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 from modlunky2.ui.levels.vanilla_levels.dual_util import make_dual, remove_dual
@@ -256,6 +259,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.preview_tab,
             textures_dir,
             ["Foreground", "Background"],
+            [],
             self.mag_full,
             intro_text="Select a level file to begin viewing",
         )
@@ -302,12 +306,12 @@ class VanillaLevelEditor(ttk.Frame):
         self.canvas = MultiCanvasContainer(
             vanilla_editor_container,
             textures_dir,
+            [],
             ["Foreground Area", "Background Area"],
             self.mag,
             self.canvas_click,
             self.canvas_shiftclick,
             "Select a room to begin editing",
-            side_by_side=True,
         )
         self.canvas.grid(row=0, column=0, rowspan=4, columnspan=8, sticky="news")
 
@@ -579,7 +583,7 @@ class VanillaLevelEditor(ttk.Frame):
                                 logger.debug("%s Not Found", tile)
 
                             self.full_level_preview_canvas.replace_tile_at(
-                                layer_index,
+                                CanvasIndex(layer_index, 0),
                                 room_y * 8 + currow,
                                 room_x * 10 + curcol,
                                 tile_image_full,
@@ -768,11 +772,11 @@ class VanillaLevelEditor(ttk.Frame):
             y_offset,
         )
 
-        self.tile_codes[canvas_index][row][column] = tile_code
+        self.tile_codes[canvas_index.canvas_index][row][column] = tile_code
         self.changes_made()
 
     def canvas_shiftclick(self, canvas_index, row, column, is_primary):
-        tile_code = self.tile_codes[canvas_index][row][column]
+        tile_code = self.tile_codes[canvas_index.canvas_index][row][column]
         tile = self.tile_palette_map[tile_code]
 
         self.palette_panel.select_tile(tile[0], tile[2], is_primary)
@@ -981,7 +985,7 @@ class VanillaLevelEditor(ttk.Frame):
                             tile_name,
                         )
                         self.canvas.replace_tile_at(
-                            canvas_index,
+                            CanvasIndex(0, canvas_index),
                             row_index,
                             column_index,
                             tile_image,

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -668,8 +668,6 @@ class VanillaLevelEditor(ttk.Frame):
     def convert_from_chunk(self, chunk):
         settings = list(map(lambda setting: setting, chunk.settings))
 
-        i = 0
-
         def map_layer(layer):
             return list(map(lambda line: list(map(lambda tile: tile, line)), layer))
 
@@ -681,13 +679,10 @@ class VanillaLevelEditor(ttk.Frame):
                 ["0" for _ in range(len(row))] for row in foreground_tiles
             ]
 
-        room_name = "room"
         comment = str(chunk.comment).lstrip("/ ").strip()
-        if comment:
-            room_name = comment
 
         return RoomInstance(
-            str(room_name), settings, foreground_tiles, background_tiles
+            comment, settings, foreground_tiles, background_tiles
         )
 
     def convert_to_chunk(self, room_instance):
@@ -1182,7 +1177,7 @@ class VanillaLevelEditor(ttk.Frame):
             return [[t for t in row] for row in layer]
 
         new_room = RoomInstance(
-            room_instance.name + " COPY",
+            (room_instance.name or "room") + " COPY",
             new_settings,
             map_layer(room_instance.front),
             map_layer(room_instance.back),

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -146,6 +146,7 @@ class VanillaLevelEditor(ttk.Frame):
             if str(tab) == "Full Level View":
                 self.load_full_preview()
             if str(tab) == "Full Level Editor":
+                self.multi_room_editor_tab.update_templates()
                 self.multi_room_editor_tab.redraw()
 
         self.tab_control.bind("<<NotebookTabChanged>>", tab_selected)

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -681,9 +681,7 @@ class VanillaLevelEditor(ttk.Frame):
 
         comment = str(chunk.comment).lstrip("/ ").strip()
 
-        return RoomInstance(
-            comment, settings, foreground_tiles, background_tiles
-        )
+        return RoomInstance(comment, settings, foreground_tiles, background_tiles)
 
     def convert_to_chunk(self, room_instance):
         return Chunk(
@@ -1013,7 +1011,7 @@ class VanillaLevelEditor(ttk.Frame):
                             x_coord,
                             y_coord,
                         )
-
+            self.canvas.update_scroll_region()
         else:
             self.canvas.clear()
             self.canvas.hide_canvas(1, True)

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -136,6 +136,8 @@ class VanillaLevelEditor(ttk.Frame):
             self.last_selected_tab = str(tab)
             if str(tab) == "Full Level View":
                 self.load_full_preview()
+            if str(tab) == "Full Level Editor":
+                self.multi_room_editor_tab.redraw()
 
         self.tab_control.bind("<<NotebookTabChanged>>", tab_selected)
 
@@ -156,6 +158,7 @@ class VanillaLevelEditor(ttk.Frame):
             ),
             self.delete_tilecode,
             self.multiroom_editor_selected_tile,
+            self.multiroom_editor_modified_room,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -508,7 +511,6 @@ class VanillaLevelEditor(ttk.Frame):
                     for currow, room_row in enumerate(layer):
                         tile_image_full = None
                         logger.debug("Room row: %s", room_row)
-                        print("Room row: ", room_row)
                         if TemplateSetting.ONLYFLIP in room_instance.settings:
                             room_row = room_row[::-1]
                         for curcol, tile in enumerate(room_row):
@@ -569,6 +571,11 @@ class VanillaLevelEditor(ttk.Frame):
 
     def multiroom_editor_selected_tile(self, tile_name, image, is_primary):
         self.palette_panel.select_tile(tile_name, image, is_primary)
+
+    def multiroom_editor_modified_room(self, template_draw_item):
+        if template_draw_item.room_chunk == self.current_selected_room:
+            self.room_select(None)
+            self.changes_made()
 
     def save_requested(self):
         if self.save_needed:

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -176,6 +176,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.delete_tilecode,
             self.multiroom_editor_selected_tile,
             self.multiroom_editor_modified_room,
+            self.on_insert_room,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -1111,7 +1112,7 @@ class VanillaLevelEditor(ttk.Frame):
         if self.last_selected_tab == "Full Level View":
             self.load_full_preview()
 
-    def on_insert_room(self, parent_index):
+    def on_insert_room(self, parent_index, name = None):
         room_template = self.template_list[parent_index]
         # Set default prompt based on parent name
         roomsize_key = "normal: 10x8"
@@ -1128,7 +1129,7 @@ class VanillaLevelEditor(ttk.Frame):
         back_layer = [
             ["0" for _ in range(room_type.x_size)] for _ in range(room_type.y_size)
         ]
-        new_room = RoomInstance("new room", [], front_layer, back_layer)
+        new_room = RoomInstance(name or "new room", [], front_layer, back_layer)
         room_template.rooms.append(new_room)
         self.changes_made()
         return new_room

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_types.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_types.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from modlunky2.levels.level_templates import  TemplateSetting
+from modlunky2.ui.levels.shared.setrooms import MatchedSetroom
+
+@dataclass
+class RoomInstance:
+    name: Optional[str]
+    settings: List[TemplateSetting]
+    front: List[List[str]]
+    back: List[List[str]]
+
+
+@dataclass
+class RoomTemplate:
+    name: str
+    comment: Optional[str]
+    rooms: List[RoomInstance]
+
+
+@dataclass
+class MatchedSetroomTemplate:
+    template: RoomTemplate
+    setroom: MatchedSetroom

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_types.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_types.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
-from modlunky2.levels.level_templates import  TemplateSetting
+from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.levels.shared.setrooms import MatchedSetroom
+
 
 @dataclass
 class RoomInstance:


### PR DESCRIPTION
Replaces the full level viewer tab with a full level editor that allows editing of multiple rooms in a level at once.

- Creates a canvas with all of the setrooms for editing for any level with setrooms.
- Creates a canvas with path rooms for any level with path rooms.
- Creates a canvas with side and miscellaneous rooms laid out in a grid for simultaneous editing.

The map of rooms in each canvas can be configured to edit any rooms together.

For any room being edited, can select which chunk of the room to edit, and can edit multiple chunks of the same room template at once.