### PR TITLE
Add a button to create a new template of rooms

### DIFF
--- a/src/modlunky2/ui/levels/shared/create_template_dialog.py
+++ b/src/modlunky2/ui/levels/shared/create_template_dialog.py
@@ -72,8 +72,6 @@ def present_create_template_dialog(modlunky_config, callback):
                 template_name += "_"
 
         comment = comment_ent.get()
-        if len(comment) == 0:
-            comment = None
 
         width_str = width_ent.get()
         height_str = height_ent.get()

--- a/src/modlunky2/ui/levels/shared/create_template_dialog.py
+++ b/src/modlunky2/ui/levels/shared/create_template_dialog.py
@@ -1,0 +1,137 @@
+import tkinter as tk
+from tkinter import ttk
+
+from modlunky2.ui.widgets import PopupWindow
+
+
+def present_create_template_dialog(modlunky_config, callback):
+    win = PopupWindow("Create Template", modlunky_config)
+
+    row = 0
+    values_frame = tk.Frame(win)
+    values_frame.grid(row=row, column=0, sticky="nw")
+    row = row + 1
+
+    values_row = 0
+    name_lbl = ttk.Label(values_frame, text="Name: ")
+    name_ent = ttk.Entry(values_frame)
+    name_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
+    name_ent.grid(row=values_row, column=1, pady=2, sticky="we")
+
+    values_row += 1
+
+    comment_lbl = ttk.Label(values_frame, text="Comment: ")
+    comment_ent = ttk.Entry(values_frame)
+    comment_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
+    comment_ent.grid(row=values_row, column=1, pady=2, sticky="we")
+
+    values_row += 1
+
+    size_type_label = tk.Label(values_frame, text="Size in: ")
+    size_type_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+    size_type_combobox = ttk.Combobox(values_frame, height=25)
+    size_type_combobox.set("Subrooms")
+    size_type_combobox.grid(row=values_row, column=1, sticky="we", pady=2)
+    size_type_combobox["state"] = "readonly"
+    size_type_combobox["values"] = ["Subrooms", "Tiles"]
+    size_type_combobox.current(0)
+
+    values_row += 1
+
+    width_label = tk.Label(values_frame, text="Width: ")
+    width_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+    width_ent = ttk.Entry(values_frame)
+    width_ent.insert(0, "1")
+    width_ent.grid(row=values_row, column=1, sticky="we", pady=2)
+
+    values_row += 1
+
+    height_label = tk.Label(values_frame, text="Height: ")
+    height_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+    height_ent = ttk.Entry(values_frame)
+    height_ent.insert(0, "1")
+    height_ent.grid(row=values_row, column=1, sticky="we", pady=2)
+
+    values_row += 1
+
+    error_lbl = tk.Label(values_frame, text="", fg="red")
+    error_lbl.grid(row=values_row, column=0, columnspan=2)
+    error_lbl.grid_remove()
+
+    values_row += 1
+
+    def update_then_destroy_pack():
+        template_name = ""
+        for char in str(name_ent.get()):
+            if str(char) != " ":
+                template_name += str(char)
+            else:
+                template_name += "_"
+
+        comment = comment_ent.get()
+        if len(comment) == 0:
+            comment = None
+
+        width_str = width_ent.get()
+        height_str = height_ent.get()
+        if not width_str.isdecimal():
+            error_lbl.grid()
+            error_lbl["text"] = "Invalid width."
+            return
+
+        if not height_str.isdecimal():
+            error_lbl.grid()
+            error_lbl["text"] = "Invalid height."
+            return
+
+        width = int(width_str)
+        height = int(height_str)
+        if size_type_combobox.current() != 1:
+            width *= 10
+            height *= 8
+
+        error_lbl.grid_remove()
+        if width == 0:
+            error_lbl.grid()
+            error_lbl["text"] = "Invalid width."
+            return
+
+        if height == 0:
+            error_lbl.grid()
+            error_lbl["text"] = "Invalid height."
+            return
+
+        if len(template_name) == 0:
+            error_lbl.grid()
+            error_lbl["text"] = "Name the template."
+            return
+
+        success, error_message = callback(template_name, comment, width, height)
+
+        if success:
+            win.destroy()
+        else:
+            error_lbl.grid()
+            error_lbl["text"] = error_message or "Error creating template."
+            return
+
+    separator = ttk.Separator(win)
+    separator.grid(row=row, column=0, columnspan=2, pady=5, sticky="news")
+
+    row = row + 1
+
+    buttons = ttk.Frame(win)
+    buttons.grid(row=row, column=0, sticky="news")
+    buttons.columnconfigure(0, weight=1)
+    buttons.columnconfigure(1, weight=1)
+
+    ok_button = ttk.Button(buttons, text="Create", command=update_then_destroy_pack)
+    ok_button.grid(row=0, column=0, pady=5, sticky="news")
+
+    cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
+    cancel_button.grid(row=0, column=1, pady=5, sticky="news")
+
+    row = row + 1

--- a/src/modlunky2/ui/levels/vanilla_levels/level_list_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/level_list_panel.py
@@ -48,6 +48,9 @@ class LevelListPanel(ttk.Frame):
     def reset(self):
         self.levels_tree.reset()
 
+    def add_room(self, new_room):
+        self.levels_tree.add_room(new_room)
+
     def set_rooms(self, new_rooms):
         self.levels_tree.set_rooms(new_rooms)
 

--- a/src/modlunky2/ui/levels/vanilla_levels/level_list_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/level_list_panel.py
@@ -16,6 +16,7 @@ class LevelListPanel(ttk.Frame):
         on_paste_room,
         on_rename_room,
         on_room_select,
+        on_create_template,
         modlunky_config,
         *args,
         **kwargs
@@ -31,6 +32,8 @@ class LevelListPanel(ttk.Frame):
             on_copy_room,
             on_paste_room,
             on_rename_room,
+            on_room_select,
+            on_create_template,
             modlunky_config,
             selectmode="browse",
         )
@@ -41,8 +44,6 @@ class LevelListPanel(ttk.Frame):
         self.levels_tree.configure(yscrollcommand=self.vsb.set)
         self.levels_tree.grid(row=0, column=0, sticky="nswe")
         self.vsb.grid(row=0, column=0, sticky="nse")
-
-        self.levels_tree.bind("<ButtonRelease-1>", on_room_select)
 
     def reset(self):
         self.levels_tree.reset()

--- a/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 import logging
+from PIL import Image, ImageTk
+import pyperclip
 import tkinter as tk
 from tkinter import ttk
-import pyperclip
 from typing import List
 
 from modlunky2.config import Config
+from modlunky2.constants import BASE_DIR
 from modlunky2.levels.level_templates import (
     Chunk,
     LevelTemplate,
@@ -31,6 +33,8 @@ class LevelsTree(ttk.Treeview):
         on_copy_room,
         on_paste_room,
         on_rename_room,
+        on_select_room,
+        on_create_template,
         config: Config,
         *args,
         **kwargs
@@ -45,6 +49,14 @@ class LevelsTree(ttk.Treeview):
         self.on_copy_room = on_copy_room
         self.on_paste_room = on_paste_room
         self.on_rename_room = on_rename_room
+        self.on_select_room = on_select_room
+        self.on_create_template = on_create_template
+
+        self.rooms = []
+
+        self.icon_add = ImageTk.PhotoImage(
+            Image.open(BASE_DIR / "static/images/add.png").resize((20, 20))
+        )
 
         # two different context menus to show depending on what is clicked (room or room list)
         self.popup_menu_child = tk.Menu(self, tearoff=0)
@@ -64,6 +76,181 @@ class LevelsTree(ttk.Treeview):
         self.popup_menu_parent.add_command(label="Paste Room", command=self.paste)
 
         self.bind("<Button-3>", self.popup)  # Button-2 on Aqua
+        self.bind("<ButtonRelease-1>", self.click)
+
+    def click(self, event):
+        selection = self.selection()
+        if len(selection) == 0:
+            return
+        item_iid = selection[0]
+        parent_iid = self.parent(item_iid)
+        if parent_iid:
+            self.on_select_room()
+        elif self.index(item_iid) == len(self.rooms):
+            self.create_template_dialog()
+
+    def create_template_dialog(self):
+        win = PopupWindow("Create Template", self.config)
+
+        row = 0
+        values_frame = tk.Frame(win)
+        values_frame.grid(row=row, column=0, sticky="nw")
+        row = row + 1
+
+        values_row = 0
+        name_lbl = ttk.Label(values_frame, text="Name: ")
+        name_ent = ttk.Entry(values_frame)
+        # name_ent.insert(0, "New_Pack")  # Default to rooms current name
+        name_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
+        name_ent.grid(row=values_row, column=1, pady=2, sticky="we")
+
+        values_row += 1
+
+        comment_lbl = ttk.Label(values_frame, text="Comment: ")
+        comment_ent = ttk.Entry(values_frame)
+        # name_ent.insert(0, "New_Pack")  # Default to rooms current name
+        comment_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
+        comment_ent.grid(row=values_row, column=1, pady=2, sticky="we")
+
+        values_row += 1
+
+        size_type_label = tk.Label(values_frame, text="Size in: ")
+        size_type_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+        size_type_combobox = ttk.Combobox(values_frame, height=25)
+        size_type_combobox.set("Subrooms")
+        size_type_combobox.grid(row=values_row, column=1, sticky="we", pady=2)
+        size_type_combobox["state"] = "readonly"
+        size_type_combobox["values"] = ["Subrooms", "Tiles"]
+        size_type_combobox.current(0)
+
+        values_row += 1
+
+        width_label = tk.Label(values_frame, text="Width: ")
+        width_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+        width_ent = ttk.Entry(values_frame)
+        width_ent.insert(0, "1")
+        width_ent.grid(row=values_row, column=1, sticky="we", pady=2)
+
+        values_row += 1
+
+        height_label = tk.Label(values_frame, text="Height: ")
+        height_label.grid(row=values_row, column=0, sticky="e", pady=2)
+
+        height_ent = ttk.Entry(values_frame)
+        height_ent.insert(0, "1")
+        height_ent.grid(row=values_row, column=1, sticky="we", pady=2)
+
+        values_row += 1
+
+        error_lbl = tk.Label(values_frame, text="", fg="red")
+        error_lbl.grid(row=values_row, column=0, columnspan=2)
+        error_lbl.grid_remove()
+
+        values_row += 1
+
+        def update_then_destroy_pack():
+            template_name = ""
+            for char in str(name_ent.get()):
+                if str(char) != " ":
+                    template_name += str(char)
+                else:
+                    template_name += "_"
+
+            comment = comment_ent.get()
+            if len(comment) == 0:
+                comment = None
+
+            width_str = width_ent.get()
+            height_str = height_ent.get()
+            if not width_str.isdecimal():
+                error_lbl.grid()
+                error_lbl["text"] = "Invalid width."
+                return
+
+            if not height_str.isdecimal():
+                error_lbl.grid()
+                error_lbl["text"] = "Invalid height."
+                return
+
+            width = int(width_str)
+            height = int(height_str)
+            if size_type_combobox.current() != 1:
+                width *= 10
+                height *= 8
+
+            error_lbl.grid_remove()
+            if width == 0:
+                error_lbl.grid()
+                error_lbl["text"] = "Invalid width."
+                return
+
+            if height == 0:
+                error_lbl.grid()
+                error_lbl["text"] = "Invalid height."
+                return
+
+            if len(template_name) == 0:
+                error_lbl.grid()
+                error_lbl["text"] = "Name the template."
+                return
+
+            success, error_message, new_room = self.on_create_template(
+                template_name, comment, width, height
+            )
+            if success:
+                # self.delete(len(self.rooms))
+
+                room_display_name = str(new_room.name)
+                if new_room.comment is not None and len(str(new_room.comment)) > 0:
+                    room_display_name += "   // " + new_room.comment
+                new_template_item = self.insert(
+                    "", len(self.rooms), text=room_display_name
+                )
+                for room in new_room.rooms:
+                    child_id = self.insert(
+                        new_template_item, "end", text=room.name or "room"
+                    )
+                    self.focus(child_id)
+                    self.selection_set(child_id)
+
+                self.item(new_template_item, open=True)
+                self.rooms.append(new_room)
+                self.on_select_room()
+                win.destroy()
+            else:
+                error_lbl.grid()
+                error_lbl["text"] = error_message or "Error creating template."
+                return
+            # name_ent.delete(0, "end")
+            # name_ent.insert(0, pack_name)
+            # if not os.path.isdir(self.packs_path / str(name_ent.get())):
+            #     os.mkdir(self.packs_path / str(name_ent.get()))
+            #     self.load_packs()
+            #     win.destroy()
+            # else:
+            #     logger.warning("Pack name taken")
+            #     name_ent.delete(0, "end")
+            #     name_ent.insert(0, "Name Taken")
+
+        separator = ttk.Separator(win)
+        separator.grid(row=row, column=0, columnspan=2, pady=5, sticky="news")
+
+        row = row + 1
+
+        buttons = ttk.Frame(win)
+        buttons.grid(row=row, column=0, sticky="news")
+        buttons.columnconfigure(0, weight=1)
+        buttons.columnconfigure(1, weight=1)
+
+        ok_button = ttk.Button(buttons, text="Create", command=update_then_destroy_pack)
+        ok_button.grid(row=0, column=0, pady=5, sticky="news")
+
+        cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
+        cancel_button.grid(row=0, column=1, pady=5, sticky="news")
+
+        row = row + 1
 
     def popup(self, event):
         try:
@@ -163,14 +350,14 @@ class LevelsTree(ttk.Treeview):
         item_name = ""
         item_name = self.item(item_iid)["text"]
 
-        col1_lbl = ttk.Label(win, text="Name: ")
-        col1_ent = ttk.Entry(win)
-        col1_ent.insert(0, item_name)  # Default to rooms current name
-        col1_lbl.grid(row=0, column=0, padx=2, pady=2, sticky="nse")
-        col1_ent.grid(row=0, column=1, padx=2, pady=2, sticky="nswe")
+        name_lbl = ttk.Label(win, text="Name: ")
+        name_ent = ttk.Entry(win)
+        name_ent.insert(0, item_name)  # Default to rooms current name
+        name_lbl.grid(row=0, column=0, padx=2, pady=2, sticky="nse")
+        name_ent.grid(row=0, column=1, padx=2, pady=2, sticky="nswe")
 
         def update_then_destroy():
-            if self.confirm_entry(col1_ent.get()):
+            if self.confirm_entry(name_ent.get()):
                 win.destroy()
 
         separator = ttk.Separator(win)
@@ -205,6 +392,7 @@ class LevelsTree(ttk.Treeview):
             self.delete(i)
 
     def set_rooms(self, rooms):
+        self.rooms = [room for room in rooms]
         for room in rooms:
             room_display_name = str(room.name)
             if len(str(room.comment)) > 0:
@@ -212,6 +400,8 @@ class LevelsTree(ttk.Treeview):
             entry = self.insert("", "end", text=room_display_name)
             for layout in room.rooms:
                 self.insert(entry, "end", text=layout.name or "room")
+
+        self.insert("", "end", text="Create new template", image=self.icon_add)
 
     def get_selected_room(self):
         selection = self.selection()

--- a/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
@@ -257,13 +257,23 @@ class LevelsTree(ttk.Treeview):
         self.rooms = [room for room in rooms]
         for room in rooms:
             room_display_name = str(room.name)
-            if len(str(room.comment)) > 0:
+            if room.comment is not None and len(str(room.comment)) > 0:
                 room_display_name += "   // " + room.comment
             entry = self.insert("", "end", text=room_display_name)
             for layout in room.rooms:
                 self.insert(entry, "end", text=layout.name or "room")
 
         self.insert("", "end", text="Create new template", image=self.icon_add)
+
+    def add_room(self, room):
+        room_display_name = str(room.name)
+        if room.comment is not None and len(str(room.comment)) > 0:
+            room_display_name += "   // " + room.comment
+        new_template_item = self.insert("", len(self.rooms), text=room_display_name)
+        for room in room.rooms:
+            child_id = self.insert(new_template_item, "end", text=room.name or "room")
+
+        self.rooms.append(room)
 
     def get_selected_room(self):
         selection = self.selection()

--- a/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/levels_tree.py
@@ -15,6 +15,9 @@ from modlunky2.levels.level_templates import (
     TemplateSetting,
 )
 from modlunky2.ui.widgets import PopupWindow
+from modlunky2.ui.levels.shared.create_template_dialog import (
+    present_create_template_dialog,
+)
 from modlunky2.ui.levels.shared.tags import TAGS
 from modlunky2.ui.levels.shared.setrooms import Setroom, MatchedSetroom
 
@@ -87,170 +90,29 @@ class LevelsTree(ttk.Treeview):
         if parent_iid:
             self.on_select_room()
         elif self.index(item_iid) == len(self.rooms):
-            self.create_template_dialog()
+            present_create_template_dialog(self.config, self.create_template)
 
-    def create_template_dialog(self):
-        win = PopupWindow("Create Template", self.config)
-
-        row = 0
-        values_frame = tk.Frame(win)
-        values_frame.grid(row=row, column=0, sticky="nw")
-        row = row + 1
-
-        values_row = 0
-        name_lbl = ttk.Label(values_frame, text="Name: ")
-        name_ent = ttk.Entry(values_frame)
-        # name_ent.insert(0, "New_Pack")  # Default to rooms current name
-        name_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
-        name_ent.grid(row=values_row, column=1, pady=2, sticky="we")
-
-        values_row += 1
-
-        comment_lbl = ttk.Label(values_frame, text="Comment: ")
-        comment_ent = ttk.Entry(values_frame)
-        # name_ent.insert(0, "New_Pack")  # Default to rooms current name
-        comment_lbl.grid(row=values_row, column=0, pady=2, sticky="e")
-        comment_ent.grid(row=values_row, column=1, pady=2, sticky="we")
-
-        values_row += 1
-
-        size_type_label = tk.Label(values_frame, text="Size in: ")
-        size_type_label.grid(row=values_row, column=0, sticky="e", pady=2)
-
-        size_type_combobox = ttk.Combobox(values_frame, height=25)
-        size_type_combobox.set("Subrooms")
-        size_type_combobox.grid(row=values_row, column=1, sticky="we", pady=2)
-        size_type_combobox["state"] = "readonly"
-        size_type_combobox["values"] = ["Subrooms", "Tiles"]
-        size_type_combobox.current(0)
-
-        values_row += 1
-
-        width_label = tk.Label(values_frame, text="Width: ")
-        width_label.grid(row=values_row, column=0, sticky="e", pady=2)
-
-        width_ent = ttk.Entry(values_frame)
-        width_ent.insert(0, "1")
-        width_ent.grid(row=values_row, column=1, sticky="we", pady=2)
-
-        values_row += 1
-
-        height_label = tk.Label(values_frame, text="Height: ")
-        height_label.grid(row=values_row, column=0, sticky="e", pady=2)
-
-        height_ent = ttk.Entry(values_frame)
-        height_ent.insert(0, "1")
-        height_ent.grid(row=values_row, column=1, sticky="we", pady=2)
-
-        values_row += 1
-
-        error_lbl = tk.Label(values_frame, text="", fg="red")
-        error_lbl.grid(row=values_row, column=0, columnspan=2)
-        error_lbl.grid_remove()
-
-        values_row += 1
-
-        def update_then_destroy_pack():
-            template_name = ""
-            for char in str(name_ent.get()):
-                if str(char) != " ":
-                    template_name += str(char)
-                else:
-                    template_name += "_"
-
-            comment = comment_ent.get()
-            if len(comment) == 0:
-                comment = None
-
-            width_str = width_ent.get()
-            height_str = height_ent.get()
-            if not width_str.isdecimal():
-                error_lbl.grid()
-                error_lbl["text"] = "Invalid width."
-                return
-
-            if not height_str.isdecimal():
-                error_lbl.grid()
-                error_lbl["text"] = "Invalid height."
-                return
-
-            width = int(width_str)
-            height = int(height_str)
-            if size_type_combobox.current() != 1:
-                width *= 10
-                height *= 8
-
-            error_lbl.grid_remove()
-            if width == 0:
-                error_lbl.grid()
-                error_lbl["text"] = "Invalid width."
-                return
-
-            if height == 0:
-                error_lbl.grid()
-                error_lbl["text"] = "Invalid height."
-                return
-
-            if len(template_name) == 0:
-                error_lbl.grid()
-                error_lbl["text"] = "Name the template."
-                return
-
-            success, error_message, new_room = self.on_create_template(
-                template_name, comment, width, height
-            )
-            if success:
-                # self.delete(len(self.rooms))
-
-                room_display_name = str(new_room.name)
-                if new_room.comment is not None and len(str(new_room.comment)) > 0:
-                    room_display_name += "   // " + new_room.comment
-                new_template_item = self.insert(
-                    "", len(self.rooms), text=room_display_name
+    def create_template(self, name, comment, width, height):
+        success, error_message, new_room = self.on_create_template(
+            name, comment, width, height
+        )
+        if success:
+            room_display_name = str(new_room.name)
+            if new_room.comment is not None and len(str(new_room.comment)) > 0:
+                room_display_name += "   // " + new_room.comment
+            new_template_item = self.insert("", len(self.rooms), text=room_display_name)
+            for room in new_room.rooms:
+                child_id = self.insert(
+                    new_template_item, "end", text=room.name or "room"
                 )
-                for room in new_room.rooms:
-                    child_id = self.insert(
-                        new_template_item, "end", text=room.name or "room"
-                    )
-                    self.focus(child_id)
-                    self.selection_set(child_id)
+                self.focus(child_id)
+                self.selection_set(child_id)
 
-                self.item(new_template_item, open=True)
-                self.rooms.append(new_room)
-                self.on_select_room()
-                win.destroy()
-            else:
-                error_lbl.grid()
-                error_lbl["text"] = error_message or "Error creating template."
-                return
-            # name_ent.delete(0, "end")
-            # name_ent.insert(0, pack_name)
-            # if not os.path.isdir(self.packs_path / str(name_ent.get())):
-            #     os.mkdir(self.packs_path / str(name_ent.get()))
-            #     self.load_packs()
-            #     win.destroy()
-            # else:
-            #     logger.warning("Pack name taken")
-            #     name_ent.delete(0, "end")
-            #     name_ent.insert(0, "Name Taken")
+            self.item(new_template_item, open=True)
+            self.rooms.append(new_room)
+            self.on_select_room()
 
-        separator = ttk.Separator(win)
-        separator.grid(row=row, column=0, columnspan=2, pady=5, sticky="news")
-
-        row = row + 1
-
-        buttons = ttk.Frame(win)
-        buttons.grid(row=row, column=0, sticky="news")
-        buttons.columnconfigure(0, weight=1)
-        buttons.columnconfigure(1, weight=1)
-
-        ok_button = ttk.Button(buttons, text="Create", command=update_then_destroy_pack)
-        ok_button.grid(row=0, column=0, pady=5, sticky="news")
-
-        cancel_button = ttk.Button(buttons, text="Cancel", command=win.destroy)
-        cancel_button.grid(row=0, column=1, pady=5, sticky="news")
-
-        row = row + 1
+        return success, error_message
 
     def popup(self, event):
         try:

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -48,6 +48,7 @@ class MultiRoomEditorTab(ttk.Frame):
         on_duplicate_room,
         on_rename_room,
         on_delete_room,
+        on_create_template,
         *args,
         **kwargs
     ):
@@ -65,6 +66,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.on_duplicate_room = on_duplicate_room
         self.on_rename_room = on_rename_room
         self.on_delete_room = on_delete_room
+        self.on_create_template = on_create_template
 
         self.lvl = None
         self.lvl_biome = None
@@ -150,6 +152,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.use_roommap_at,
             self.change_template_at,
             self.clear_template_at,
+            self.create_new_template,
             self.change_room_at,
             self.select_random_room,
             self.room_setting_change_at,
@@ -515,6 +518,9 @@ class MultiRoomEditorTab(ttk.Frame):
 
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
         self.redraw()
+
+    def create_new_template(self, name, comment, width, height):
+        return self.on_create_template(name, comment, width, height)
 
     def select_random_room(self, map_index=None, row=None, col=None):
         def select_random_room_at(mi, r, c):

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -75,7 +75,7 @@ class MultiRoomEditorTab(ttk.Frame):
         self.default_draw_map = None
         self.reverse_layers = True
 
-        self.zoom_level = 30 # Sensible default.
+        self.zoom_level = 30  # Sensible default.
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -262,7 +262,9 @@ class MultiRoomEditorTab(ttk.Frame):
         self.reverse_layers = reverse
         self.redraw()
 
-    def update_templates(self):
+    def update_templates(self, templates=None):
+        # if templates is not None:
+        #     self.room_templates = templates
         self.options_panel.set_templates(self.template_draw_map, self.room_templates)
 
     def hide_grid_lines(self, hide_grid_lines):

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/options_panel.py
@@ -373,7 +373,6 @@ class RoomOptions(ttk.Frame):
             self.template_combobox.set(new_room.name)
             self.on_select_template(
                 len(self.templates) - 1,
-                # self.template_combobox.current() - 1,
                 self.current_template_map_index,
                 self.current_template_row,
                 self.current_template_column,
@@ -821,9 +820,6 @@ class OptionsPanel(ttk.Frame):
         success, error_message, new_room = self.on_create_template(
             name, comment, width, height
         )
-
-        # if success:
-        #     self.templates.append(new_room)
 
         return success, error_message, new_room
 

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/room_map.py
@@ -365,7 +365,9 @@ def find_roommap(templates):
                         break
 
             if not added_room:
-                if len(other_rooms_map) > 0 and len(other_rooms_map[0]) < 3:
+                if len(other_rooms_map) == 0:
+                    set_room(other_rooms_map, 0, 0, room)
+                elif len(other_rooms_map[0]) < 3:
                     set_room(
                         other_rooms_map, len(other_rooms_map[0]), more_rooms_start, room
                     )

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -174,6 +174,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.on_duplicate_room,
             self.on_rename_room,
             self.on_delete_room,
+            self.on_create_template,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -1116,9 +1117,9 @@ class VanillaLevelEditor(ttk.Frame):
         self.template_list.append(new_template)
         self.changes_made()
         # self.level_list_panel.set_rooms(self.template_list)
-        self.multi_room_editor_tab.open_lvl(
-            self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list
-        )
+        # self.multi_room_editor_tab.open_lvl(
+        #     self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list
+        # )
         return True, None, new_template
 
     def reset_canvas(self):

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -221,6 +221,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.on_paste_room,
             self.on_rename_room,
             self.room_select,
+            self.on_create_template,
             self.modlunky_config,
         )
         self.level_list_panel.grid(row=0, column=0, rowspan=5, sticky="nswe")
@@ -315,7 +316,7 @@ class VanillaLevelEditor(ttk.Frame):
                     )
                 )
             self.canvas.set_zoom(self.mag)
-            self.room_select(None)
+            self.room_select()
 
         self.slider_zoom = tk.Scale(
             self.editor_tab,
@@ -510,13 +511,13 @@ class VanillaLevelEditor(ttk.Frame):
 
     def multiroom_editor_modified_room(self, template_draw_item):
         if template_draw_item.room_chunk == self.current_selected_room:
-            self.room_select(None)
+            self.room_select()
         self.changes_made()
 
     def multiroom_editor_changed_filetree(self):
         self.level_list_panel.reset()
         self.level_list_panel.set_rooms(self.template_list)
-        self.room_select(None)
+        self.room_select()
 
     def save_requested(self):
         if self.save_needed:
@@ -799,7 +800,7 @@ class VanillaLevelEditor(ttk.Frame):
                     replace_room_chunk([room_instance.front, room_instance.back])
         else:
             replace_room_chunk(self.tile_codes)
-        self.room_select(None)
+        self.room_select()
         self.changes_made()
 
     def clear_canvas(self):
@@ -818,7 +819,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.canvas.draw_grid()
             self.changes_made()
 
-    def room_select(self, _event):  # Loads room when click if not parent node.
+    def room_select(self):  # Loads room when click if not parent node.
         dual_mode = False
         template_index, room_instance_index = self.level_list_panel.get_selected_room()
         if template_index is not None and room_instance_index is not None:
@@ -1097,6 +1098,28 @@ class VanillaLevelEditor(ttk.Frame):
         room_template = self.template_list[parent_index]
         room_instance = room_template.rooms[room_index]
         room_instance.name = new_name
+
+    def on_create_template(self, template_name, comment, width, height):
+        for template in self.template_list:
+            if template.name == template_name:
+                return (
+                    False,
+                    "Template named " + template_name + " already exists.",
+                    None,
+                )
+
+        front_layer = [["0" for _ in range(width)] for _ in range(height)]
+        back_layer = [["0" for _ in range(width)] for _ in range(height)]
+        initial_room = RoomInstance(None, [], front_layer, back_layer)
+
+        new_template = RoomTemplate(template_name, comment, [initial_room])
+        self.template_list.append(new_template)
+        self.changes_made()
+        # self.level_list_panel.set_rooms(self.template_list)
+        self.multi_room_editor_tab.open_lvl(
+            self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list
+        )
+        return True, None, new_template
 
     def reset_canvas(self):
         self.canvas.clear()

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -174,7 +174,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.on_duplicate_room,
             self.on_rename_room,
             self.on_delete_room,
-            self.on_create_template,
+            self.on_create_template_multi,
         )
         self.variables_tab = VariablesTab(
             self.tab_control,
@@ -222,7 +222,7 @@ class VanillaLevelEditor(ttk.Frame):
             self.on_paste_room,
             self.on_rename_room,
             self.room_select,
-            self.on_create_template,
+            self.on_create_template_single,
             self.modlunky_config,
         )
         self.level_list_panel.grid(row=0, column=0, rowspan=5, sticky="nswe")
@@ -1100,6 +1100,25 @@ class VanillaLevelEditor(ttk.Frame):
         room_instance = room_template.rooms[room_index]
         room_instance.name = new_name
 
+    def on_create_template_multi(self, template_name, comment, width, height):
+        success, error_message, new_room = self.on_create_template(
+            template_name, comment, width, height
+        )
+
+        if success:
+            self.level_list_panel.add_room(new_room)
+
+        return success, error_message, new_room
+
+    def on_create_template_single(self, template_name, comment, width, height):
+        success, error_message, new_room = self.on_create_template(
+            template_name, comment, width, height
+        )
+        if success:
+            self.multi_room_editor_tab.update_templates()
+
+        return success, error_message, new_room
+
     def on_create_template(self, template_name, comment, width, height):
         for template in self.template_list:
             if template.name == template_name:
@@ -1116,10 +1135,6 @@ class VanillaLevelEditor(ttk.Frame):
         new_template = RoomTemplate(template_name, comment, [initial_room])
         self.template_list.append(new_template)
         self.changes_made()
-        # self.level_list_panel.set_rooms(self.template_list)
-        # self.multi_room_editor_tab.open_lvl(
-        #     self.lvl, self.lvl_biome, self.tile_palette_map, self.template_list
-        # )
         return True, None, new_template
 
     def reset_canvas(self):


### PR DESCRIPTION
Adds a button to both the room list in the single-room editor and the room type selection dropdown in the multi-room editor to create a new room.

The new room type can be created with any width and height, and it is up to the level creator to make sure it works in game.

The new room type cannot be created with the same name as an existing room type.

Also, a minor improvement was added so that selecting a room type doesn't clear the canvas of the currently editing room; only selecting another room will.