### PR TITLE
Split tilecodes from dependencies into separate palettes

### DIFF
--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -173,6 +173,7 @@ class CustomLevelEditor(ttk.Frame):
             self.delete_tilecode,
             self.add_tilecode,
             None,
+            None,
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )
@@ -454,6 +455,7 @@ class CustomLevelEditor(ttk.Frame):
         self.palette_panel.update_with_palette(
             self.tile_palette_ref_in_use,
             self.tile_palette_suggestions,
+            None,
             self.lvl_biome,
             self.lvl,
         )

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -205,7 +205,9 @@ class PalettePanel(ttk.Frame):
             if self.secondary_tile_view.tile_code() == tile_code:
                 self.secondary_tile_view.reset(disable=False)
 
-    def update_with_palette(self, new_palette, suggestions, dependency_tiles, biome, lvl):
+    def update_with_palette(
+        self, new_palette, suggestions, dependency_tiles, biome, lvl
+    ):
         for widget in self.palette.scrollable_frame.winfo_children():
             widget.destroy()
 
@@ -316,8 +318,12 @@ class PalettePanel(ttk.Frame):
                 count_col = -1
                 self.palette.scrollable_frame.rowconfigure(count_row + 1, minsize=15)
                 count_row += 2
-                dependency_label = ttk.Label(self.palette.scrollable_frame, text=str(dependency.name) + ":")
-                dependency_label.grid(row=count_row, column=0, columnspan=5, sticky="nw")
+                dependency_label = ttk.Label(
+                    self.palette.scrollable_frame, text=str(dependency.name) + ":"
+                )
+                dependency_label.grid(
+                    row=count_row, column=0, columnspan=5, sticky="nw"
+                )
                 count_row += 1
 
                 for tile in dependency.tiles:
@@ -349,7 +355,6 @@ class PalettePanel(ttk.Frame):
                             event, t, d
                         ),
                     )
-
 
         self.primary_tile_view.enable()
         self.secondary_tile_view.enable()

--- a/src/modlunky2/ui/levels/shared/tile.py
+++ b/src/modlunky2/ui/levels/shared/tile.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from modlunky2.levels.level_templates import TemplateSetting
 from modlunky2.ui.levels.shared.setrooms import MatchedSetroom
 
+
 @dataclass
 class DependencyPalette:
     name: str

--- a/src/modlunky2/ui/levels/shared/tile.py
+++ b/src/modlunky2/ui/levels/shared/tile.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from modlunky2.levels.level_templates import TemplateSetting
+from modlunky2.ui.levels.shared.setrooms import MatchedSetroom
+
+@dataclass
+class DependencyPalette:
+    name: str
+    tiles: List

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -42,6 +42,7 @@ class MultiRoomEditorTab(ttk.Frame):
         on_add_tilecode,
         on_delete_tilecode,
         on_select_palette_tile,
+        on_use_dependency_tile,
         on_modify_room,
         on_change_filetree,
         on_add_room,
@@ -139,6 +140,7 @@ class MultiRoomEditorTab(ttk.Frame):
             self.delete_tilecode,
             self.add_tilecode,
             self.palette_selected_tile,
+            on_use_dependency_tile,
             self.texture_fetcher,
             self.texture_fetcher.sprite_fetcher,
         )
@@ -720,10 +722,11 @@ class MultiRoomEditorTab(ttk.Frame):
         if setting == TemplateSetting.DUAL or setting == TemplateSetting.ONLYFLIP:
             self.redraw()
 
-    def populate_tilecode_palette(self, tile_palette, suggestions):
+    def populate_tilecode_palette(self, tile_palette, suggestions, dependency_tiles):
         self.palette_panel.update_with_palette(
             tile_palette,
             suggestions,
+            dependency_tiles,
             self.lvl_biome,
             self.lvl,
         )

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -416,6 +416,7 @@ class VanillaLevelEditor(ttk.Frame):
                 return tilecode_item
 
             return [tilecode_item(tc) for tc in level_tilecodes]
+
         def clear_tile_from_dependencies(tile):
             for palette in self.dependency_tile_palette_ref_in_use:
                 for i in palette.tiles:
@@ -443,7 +444,9 @@ class VanillaLevelEditor(ttk.Frame):
                 clear_tile_from_dependencies(tile)
                 register_tile_code(tile)
 
-            self.dependency_tile_palette_ref_in_use.insert(0, DependencyPalette("From " + dependency, tiles))
+            self.dependency_tile_palette_ref_in_use.insert(
+                0, DependencyPalette("From " + dependency, tiles)
+            )
 
         level = LevelFile.from_path(Path(lvl_path))
         tiles = get_level_tilecodes(level)
@@ -978,7 +981,6 @@ class VanillaLevelEditor(ttk.Frame):
 
         self.populate_tilecode_palette()
         self.changes_made()
-
 
     def add_tilecode(
         self,


### PR DESCRIPTION
Split tilecodes from dependencies into separate palettes so that they aren't automatically added to the level file when saving, but are still available in the palette to select.