### PR TITLE
Show an error image and spit out an error log when a nonexistant tilecode is encountered instead of erroring and failing to draw the rest of the level.

### DIFF
--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -73,7 +73,9 @@ class CustomLevelEditor(ttk.Frame):
         self.tool = CANVAS_MODE.DRAW
 
         image_path = BASE_DIR / "static/images/help.png"
-        self.error_image = ImageTk.PhotoImage(Image.open(image_path).resize((self.zoom_level, self.zoom_level)))
+        self.error_image = ImageTk.PhotoImage(
+            Image.open(image_path).resize((self.zoom_level, self.zoom_level))
+        )
 
         self.save_needed = False
 
@@ -561,7 +563,10 @@ class CustomLevelEditor(ttk.Frame):
                             self.zoom_level,
                         )
                     else:
-                        logger.warning("Tile code %s found in room, but does not map to a valid tile code.", tilecode)
+                        logger.warning(
+                            "Tile code %s found in room, but does not map to a valid tile code.",
+                            tilecode,
+                        )
                         tile_image = self.error_image
                         x_offset, y_offset = 0, 0
                     self.canvas.replace_tile_at(
@@ -901,7 +906,9 @@ class CustomLevelEditor(ttk.Frame):
     def update_zoom(self, zoom):
         self.zoom_level = zoom
         image_path = BASE_DIR / "static/images/help.png"
-        self.error_image = ImageTk.PhotoImage(Image.open(image_path).resize((zoom, zoom)))
+        self.error_image = ImageTk.PhotoImage(
+            Image.open(image_path).resize((zoom, zoom))
+        )
         if self.lvl:
             for tile in self.tile_palette_ref_in_use:
                 tile_name = tile.name

--- a/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/multi_room/multi_room_editor_tab.py
@@ -291,7 +291,9 @@ class MultiRoomEditorTab(ttk.Frame):
         self.canvas.set_zoom(zoom)
         self.tile_image_map = {}
         image_path = BASE_DIR / "static/images/help.png"
-        self.error_image = ImageTk.PhotoImage(Image.open(image_path).resize((zoom, zoom)))
+        self.error_image = ImageTk.PhotoImage(
+            Image.open(image_path).resize((zoom, zoom))
+        )
         self.redraw()
 
     def __get_chunk_for_template_draw_item(
@@ -957,7 +959,10 @@ class MultiRoomEditorTab(ttk.Frame):
                                 self.zoom_level,
                             )
                         else:
-                            logger.warning("Tile code %s found in room, but does not map to a valid tile code.", tilecode)
+                            logger.warning(
+                                "Tile code %s found in room, but does not map to a valid tile code.",
+                                tilecode,
+                            )
                             tile_image = self.error_image
                             x_offset, y_offset = 0, 0
                         self.canvas.replace_tile_at(

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 import io
 import logging
-import math
 import os
 import os.path
 from pathlib import Path
@@ -12,6 +11,7 @@ from tkinter import ttk
 import tkinter.messagebox as tkMessageBox
 from typing import List, Optional
 
+from modlunky2.constants import BASE_DIR
 from modlunky2.levels import LevelFile
 from modlunky2.levels.level_templates import (
     Chunk,
@@ -101,6 +101,9 @@ class VanillaLevelEditor(ttk.Frame):
 
         self.modlunky_config = modlunky_config
         self.texture_fetcher = texture_fetcher
+
+        image_path = BASE_DIR / "static/images/help.png"
+        self.error_image = ImageTk.PhotoImage(Image.open(image_path))
 
         self.room_has_been_selected = False
         self.save_needed = False
@@ -914,13 +917,18 @@ class VanillaLevelEditor(ttk.Frame):
             for canvas_index, layer_tile_codes in enumerate(self.tile_codes):
                 for row_index, row in enumerate(layer_tile_codes):
                     for column_index, tile_code in enumerate(row):
-                        tile = self.tile_palette_map[tile_code]
-                        tile_image = tile.image
-                        x_coord, y_coord = self.texture_fetcher.adjust_texture_xy(
-                            tile_image.width(),
-                            tile_image.height(),
-                            tile.name,
-                        )
+                        tile = self.tile_palette_map.get(tile_code)
+                        if tile:
+                            tile_image = tile.image
+                            x_coord, y_coord = self.texture_fetcher.adjust_texture_xy(
+                                tile_image.width(),
+                                tile_image.height(),
+                                tile.name,
+                            )
+                        else:
+                            logger.warning("Tile code %s found in room, but does not map to a valid tile code.", tile_code)
+                            tile_image = self.error_image
+                            x_coord, y_coord = 0, 0
                         self.canvas.replace_tile_at(
                             CanvasIndex(0, canvas_index),
                             row_index,

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -926,7 +926,10 @@ class VanillaLevelEditor(ttk.Frame):
                                 tile.name,
                             )
                         else:
-                            logger.warning("Tile code %s found in room, but does not map to a valid tile code.", tile_code)
+                            logger.warning(
+                                "Tile code %s found in room, but does not map to a valid tile code.",
+                                tile_code,
+                            )
                             tile_image = self.error_image
                             x_coord, y_coord = 0, 0
                         self.canvas.replace_tile_at(


### PR DESCRIPTION
Modifies all editors to show the help ? icon in place of these tiles.