### PR TITLE
Fix variables tab in level editor

### DIFF
--- a/src/modlunky2/ui/levels/custom_levels/create_level_dialog.py
+++ b/src/modlunky2/ui/levels/custom_levels/create_level_dialog.py
@@ -154,9 +154,9 @@ def present_create_level_dialog(
                 Image.open(BASE_DIR / "static/images/help.png").resize((20, 20))
             )
             tiles = [
-                Tile("floor", "1", img, img),
-                Tile("empty", "0", img, img),
-                Tile("floor_hard", "X", img, img),
+                Tile("floor", "1", "", img, img),
+                Tile("empty", "0", "", img, img),
+                Tile("floor_hard", "X", "", img, img),
             ]
             # Fill in the level with empty tiles in the foreground and hard floor in the background.
             foreground = [["0" for _ in range(width * 10)] for _ in range(height * 8)]

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -314,6 +314,7 @@ class CustomLevelEditor(ttk.Frame):
             tilecode_item = Tile(
                 tilecode.name,
                 tilecode.value,
+                tilecode.comment,
                 ImageTk.PhotoImage(img),
                 ImageTk.PhotoImage(img_select),
             )
@@ -339,6 +340,7 @@ class CustomLevelEditor(ttk.Frame):
             tilecode_item = Tile(
                 "floor_hard",
                 str(hard_floor_code),
+                "",
                 ImageTk.PhotoImage(
                     self.texture_fetcher.get_texture(
                         "floor_hard", theme, lvl, self.zoom_level
@@ -754,7 +756,7 @@ class CustomLevelEditor(ttk.Frame):
             )
             return
 
-        ref_tile = Tile(new_tile_code, str(usable_code), tile_image, tile_image_picker)
+        ref_tile = Tile(new_tile_code, str(usable_code), "", tile_image, tile_image_picker)
         self.tile_palette_ref_in_use.append(ref_tile)
         self.tile_palette_map[usable_code] = ref_tile
 

--- a/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
+++ b/src/modlunky2/ui/levels/custom_levels/custom_level_editor.py
@@ -756,7 +756,9 @@ class CustomLevelEditor(ttk.Frame):
             )
             return
 
-        ref_tile = Tile(new_tile_code, str(usable_code), "", tile_image, tile_image_picker)
+        ref_tile = Tile(
+            new_tile_code, str(usable_code), "", tile_image, tile_image_picker
+        )
         self.tile_palette_ref_in_use.append(ref_tile)
         self.tile_palette_map[usable_code] = ref_tile
 

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -149,7 +149,7 @@ class SelectedTilecodeView(ttk.Frame):
             self.img_view["image"] = self.img_empty
 
     def reset(self, disable=True):
-        self.select_tile(Tile("empty", "0", self.img_empty, self.img_empty))
+        self.select_tile(Tile("empty", "0", "", self.img_empty, self.img_empty))
         if disable:
             self.disable()
 

--- a/src/modlunky2/ui/levels/shared/palette_panel.py
+++ b/src/modlunky2/ui/levels/shared/palette_panel.py
@@ -365,9 +365,9 @@ class PalettePanel(ttk.Frame):
 
     def dependency_tile_pick(self, event, tile, dependency):
         if self.on_use_dependency_tile:
-            self.on_use_dependency_tile(tile, dependency)
+            new_tile = self.on_use_dependency_tile(tile, dependency)
 
-            self.select_tile(tile, event.num == 1, True)
+            self.select_tile(new_tile, event.num == 1, True)
 
     def select_tile(self, tile, is_primary, tell_delegate=False):
         tile_view = self.primary_tile_view

--- a/src/modlunky2/ui/levels/shared/tile.py
+++ b/src/modlunky2/ui/levels/shared/tile.py
@@ -7,6 +7,7 @@ from PIL import ImageTk
 class Tile:
     name: str
     code: str
+    comment: str
     image: ImageTk.PhotoImage
     picker_image: ImageTk.PhotoImage
 

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -153,6 +153,8 @@ class VanillaLevelEditor(ttk.Frame):
             if str(tab) == "Full Level Editor":
                 self.multi_room_editor_tab.update_templates()
                 self.multi_room_editor_tab.redraw()
+            if str(tab) == "Variables (Experimental)":
+                self.variables_tab.check_dependencies()
 
         self.tab_control.bind("<<NotebookTabChanged>>", tab_selected)
 

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -446,6 +446,14 @@ class VanillaLevelEditor(ttk.Frame):
                 0, DependencyPalette("From " + dependency, tiles)
             )
 
+        # Clear tilecodes from all sister locations so they do not get reused.
+        sister_locations = LevelDependencies.sister_locations_for_level(lvl, self.lvls_path, self.extracts_path)
+        for sister_location_path in sister_locations:
+            for level in sister_location_path:
+                for tilecode in level.level.tile_codes.all():
+                    if tilecode.value in self.usable_codes:
+                        self.usable_codes.remove(tilecode.value)
+
         level = LevelFile.from_path(Path(lvl_path))
         tiles = get_level_tilecodes(level)
         self.tile_palette_ref_in_use = tiles

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -1026,11 +1026,14 @@ class VanillaLevelEditor(ttk.Frame):
                 tile.picker_image,
             )
 
+        self.tile_palette_map[new_tile.code] = new_tile
         self.tile_palette_ref_in_use.append(new_tile)
         dependency.tiles.remove(tile)
 
         self.populate_tilecode_palette()
         self.changes_made()
+
+        return new_tile
 
     def add_tilecode(
         self,

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -421,7 +421,7 @@ class VanillaLevelEditor(ttk.Frame):
         def clear_tile_from_dependencies(tile):
             for palette in self.dependency_tile_palette_ref_in_use:
                 for i in palette.tiles:
-                    if i.code == tile.code:
+                    if i.name == tile.name:
                         palette.tiles.remove(i)
 
         def register_tile_code(tile):

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -409,6 +409,7 @@ class VanillaLevelEditor(ttk.Frame):
                 return Tile(
                     str(tilecode.name),
                     str(tilecode.value),
+                    str(tilecode.comment),
                     ImageTk.PhotoImage(img),
                     ImageTk.PhotoImage(selection_img),
                 )
@@ -512,6 +513,7 @@ class VanillaLevelEditor(ttk.Frame):
                         tile = Tile(
                             str(need[1]),
                             str(need[0]),
+                            "",
                             ImageTk.PhotoImage(img),
                             ImageTk.PhotoImage(img_select),
                         )
@@ -646,7 +648,7 @@ class VanillaLevelEditor(ttk.Frame):
                         TileCode(
                             name=tilecode.name,
                             value=tilecode.code,
-                            comment="",
+                            comment=tilecode.comment,
                         )
                     )
 
@@ -1058,7 +1060,7 @@ class VanillaLevelEditor(ttk.Frame):
             )
             return
 
-        ref_tile = Tile(new_tile_code, str(usable_code), tile_image, tile_image_picker)
+        ref_tile = Tile(new_tile_code, str(usable_code), "", tile_image, tile_image_picker)
         self.tile_palette_ref_in_use.append(ref_tile)
         self.tile_palette_map[usable_code] = ref_tile
 

--- a/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/vanilla_level_editor.py
@@ -449,7 +449,9 @@ class VanillaLevelEditor(ttk.Frame):
             )
 
         # Clear tilecodes from all sister locations so they do not get reused.
-        sister_locations = LevelDependencies.sister_locations_for_level(lvl, self.lvls_path, self.extracts_path)
+        sister_locations = LevelDependencies.sister_locations_for_level(
+            lvl, self.lvls_path, self.extracts_path
+        )
         for sister_location_path in sister_locations:
             for level in sister_location_path:
                 for tilecode in level.level.tile_codes.all():
@@ -1000,8 +1002,11 @@ class VanillaLevelEditor(ttk.Frame):
 
     def use_dependency_tile(self, tile, dependency):
         new_tile = tile
+
         def tile_will_conflict():
-            sister_locations = LevelDependencies.sister_locations_for_level(self.lvl, self.lvls_path, self.extracts_path)
+            sister_locations = LevelDependencies.sister_locations_for_level(
+                self.lvl, self.lvls_path, self.extracts_path
+            )
             for sister_location_path in sister_locations:
                 for level in sister_location_path:
                     for tilecode in level.level.tile_codes.all():
@@ -1015,7 +1020,8 @@ class VanillaLevelEditor(ttk.Frame):
                 self.usable_codes.remove(usable_code)
             else:
                 tkMessageBox.showinfo(
-                    "Uh Oh!", "This tile has a conflict, and you've reached the tilecode limit; delete some to add more"
+                    "Uh Oh!",
+                    "This tile has a conflict, and you've reached the tilecode limit; delete some to add more",
                 )
                 return
             new_tile = Tile(
@@ -1100,7 +1106,9 @@ class VanillaLevelEditor(ttk.Frame):
             )
             return
 
-        ref_tile = Tile(new_tile_code, str(usable_code), "", tile_image, tile_image_picker)
+        ref_tile = Tile(
+            new_tile_code, str(usable_code), "", tile_image, tile_image_picker
+        )
         self.tile_palette_ref_in_use.append(ref_tile)
         self.tile_palette_map[usable_code] = ref_tile
 

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/dependencies_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/dependencies_tree.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import logging
 import os
 import os.path
@@ -9,9 +10,14 @@ from modlunky2.levels import LevelFile
 from modlunky2.levels.level_templates import Chunk
 from modlunky2.levels.tile_codes import VALID_TILE_CODES, TileCode, TileCodes, ShortCode
 from modlunky2.utils import tb_info
+from modlunky2.ui.levels.vanilla_levels.variables.level_dependencies import SisterLocation
 
 logger = logging.getLogger(__name__)
 
+@dataclass
+class BrokenTile:
+    level: SisterLocation
+    tile: TileCode
 
 class DependenciesTree(ttk.Treeview):
     def __init__(self, parent, lvls_path, extracts_path, *args, **kwargs):
@@ -20,6 +26,9 @@ class DependenciesTree(ttk.Treeview):
         self.lvls_path = lvls_path
         self.extracts_path = extracts_path
         self.sister_locations = []
+        self.current_location = None
+        self.broken_tiles = []
+        self.current_level_broken_tiles = []
 
         self["columns"] = ("1", "2", "3")
         self["show"] = "headings"
@@ -31,278 +40,116 @@ class DependenciesTree(ttk.Treeview):
         self.heading("3", text="File")
 
     def resolve_conflicts(self):
-        def get_level(file):
-            if os.path.exists(Path(self.lvls_path / file)):
-                levelp = LevelFile.from_path(Path(self.lvls_path / file))
-            else:
-                levelp = LevelFile.from_path(Path(self.extracts_path) / file)
-            return levelp
-
         usable_codes = ShortCode.usable_codes()
 
         # finds tilecodes that are taken in all the dependacy files
-        for level in self.sister_locations:
-            used_codes = level[1].tile_codes.all()
-            for code in used_codes:
-                for usable_code in usable_codes:
-                    if str(code.value) == str(usable_code):
-                        usable_codes.remove(usable_code)
-                        # "sister location" = nick name for lvl files in a dependency group
-                        logger.debug("removed %s from sister location", code.value)
+        for levelpath in self.sister_locations:
+            for level in levelpath:
+                used_codes = level.level.tile_codes.all()
+                for code in used_codes:
+                    if code.value in usable_codes:
+                        usable_codes.remove(code.value)
 
-        for i in self.get_children():  # gets base level conflict to compare
-            try:
-                item = self.item(
-                    i, option="values"
-                )  # gets it values ([0] = tile id [1] = tile code [2] = level file name)
+        for broken_tile in self.broken_tiles:
+            if broken_tile.level.level != self.current_location.level:
+                continue
 
-                levels = []  # gets list of levels to fix tilecodes among
-                # adds item as (level, item values)
-                levels.append([get_level(item[2].split(" ")[0]), item])
-                # removes item cause its already being worked on so it doesn't
-                # get worked on or compared to again
-                # self.tree_depend.delete(i)
+            old_tile = broken_tile.tile
+            old_tile_code = old_tile.value
 
-                for child in self.get_children():
-                    item2 = self.item(child, option="values")
-                    # finds item with conflicting codes
-                    if str(item2[1]) == str(item[1]):
-                        levels.append([get_level(item2[2].split(" ")[0]), item2])
-                        # removes item cause its already being worked on so it doesn't
-                        # get worked on or compared to again
-                        # self.tree_depend.delete(child)
+            level = broken_tile.level.level
+            if len(usable_codes) > 0:
+                new_code = str(usable_codes[0])
+                usable_codes.remove(new_code)
+                level.tile_codes.set_obj(
+                    TileCode(
+                        name = old_tile.name,
+                        value = new_code,
+                        comment = old_tile.comment
+                    )
+                )  # adds new tile to database with new code
+            else:
+                logger.warning("Not enough unique tilecodes left")
+                break
 
-                # finds tilecodes that are not available in all the dependacy files
-                # (again cause it could have changed since tilecodes are being messed with)
-                # might not actually be needed
-                for level in levels:
-                    used_codes = level[0].tile_codes.all()
-                    for code in used_codes:
-                        for usable_code in usable_codes:
-                            if str(code.value) == str(usable_code):
-                                usable_codes.remove(usable_code)
-                                logger.debug(
-                                    "removed %s cause its already in use", code.value
+            for template in level.level_templates.all():
+                new_chunks = []
+                for room in template.chunks:
+                    foreground = [ [ str(new_code) if str(code) == str(old_tile_code) else str(code) for code in row] for row in room.foreground]
+                    background = [ [ str(new_code) if str(code) == str(old_tile_code) else str(code) for code in row] for row in room.background]
+                    new_chunks.append(
+                        Chunk(
+                            comment = room.comment,
+                            settings = room.settings,
+                            foreground = foreground,
+                            background = background,
+                        )
+                    )
+                template.chunks = new_chunks
+
+        if not self.lvls_path:
+            raise RuntimeError("self.lvls_path not configured.")
+
+        if not os.path.exists(Path(self.lvls_path)):
+            os.makedirs(Path(self.lvls_path))
+
+        path = Path(self.lvls_path / self.current_location.level_name)
+        with Path(path).open("w", encoding="cp1252") as handle:
+            self.current_location.level.write(handle)
+            logger.debug("Fixed conflicts in %s", self.current_location.level_name)
+
+    def update_dependencies(self, level_paths, current_location):
+        self.sister_locations = level_paths
+        self.current_location = current_location
+        broken_tiles = []
+
+        for tilecode in current_location.level.tile_codes.all():
+            checked_levels = [current_location.level_name]
+            added_code = False
+            for level_path in level_paths:
+                for other_location in level_path:
+                    if other_location.level_name in checked_levels:
+                        continue
+
+                    checked_levels.append(other_location.level_name)
+                    for othertilecode in other_location.level.tile_codes.all():
+                        if tilecode.value == othertilecode.value and tilecode.name != othertilecode.name:
+                            if not added_code:
+                                added_code = True
+                                broken_tiles.append(
+                                    BrokenTile(current_location, tilecode)
                                 )
-
-                # replaces all the old tile codes with the new ones in the rooms
-                for level in levels:
-                    # gives tilecodes their own loop
-                    tilecode_count = 0
-                    tile_codes_new = TileCodes()  # new tilecode database
-
-                    for code in level[0].tile_codes.all():
-                        tile_id = str(level[1][0])
-                        old_code = str(level[1][1])
-                        if str(code.name) == str(
-                            tile_id
-                        ):  # finds conflicting tilecode by id
-                            # makes sure there's even codes left to assing new unique ones
-                            if len(usable_codes) > 0:
-                                # gets the next available usable code
-                                new_code = str(usable_codes[0])
-                                tile_codes_new.set_obj(
-                                    TileCode(
-                                        name=tile_id,
-                                        value=new_code,
-                                        comment="",
-                                    )
-                                )  # adds new tilecode to database with new code
-                                old_code_found = False
-                                for usable_code in usable_codes:
-                                    if str(new_code) == str(usable_code):
-                                        usable_codes.remove(usable_code)
-                                        logger.debug("used and removed %s", new_code)
-                                    if str(old_code) == str(usable_code):
-                                        old_code_found = True
-                                if not old_code_found:
-                                    usable_codes.append(
-                                        old_code
-                                    )  # adds back replaced code since its now free for use again
-                            else:
-                                logger.warning("Not enough unique tilecodes left")
-                                return
-                        else:
-                            tile_codes_new.set_obj(
-                                TileCode(
-                                    name=code.name,
-                                    value=code.value,
-                                    comment="",
-                                )  # adds tilecode back to database
+                            broken_tiles.append(BrokenTile(other_location, othertilecode))
+                            logger.debug(
+                                "tilecode conflict: %s",
+                                tilecode.value,
                             )
-                        tilecode_count = tilecode_count + 1
+                            logger.debug(
+                                "in %s %s file and %s %s file",
+                                current_location.level_name,
+                                current_location.location,
+                                other_location.level_name,
+                                other_location.location,
+                            )
+                            logger.debug(
+                                "comparing tileids %s to %s",
+                                tilecode.name,
+                                othertilecode.name,
+                            )
 
-                    for code in level[0].tile_codes.all():
-                        tile_id = str(level[1][0])
-                        old_code = str(level[1][1])
-                        if str(code.name) == str(tile_id):  # finds conflicting tilecode
-                            for new_code in tile_codes_new.all():
-                                if new_code.name == code.name:
-                                    template_count = 0
-                                    for template in level[0].level_templates.all():
-                                        new_chunks = []
-                                        for room in template.chunks:
-                                            row_count = 0
-                                            for row in room.foreground:
-                                                col_count = 0
-                                                for col in row:
-                                                    if str(col) == str(old_code):
-                                                        room.foreground[row_count][
-                                                            col_count
-                                                        ] = str(new_code.value)
-                                                        logger.debug(
-                                                            "replaced %s with %s",
-                                                            old_code,
-                                                            new_code.value,
-                                                        )
-                                                    col_count = col_count + 1
-                                                row_count = row_count + 1
-                                            row_count = 0
-                                            for row in room.background:
-                                                col_count = 0
-                                                for col in row:
-                                                    if str(col) == str(old_code):
-                                                        room.background[row_count][
-                                                            col_count
-                                                        ] = str(new_code.value)
-                                                        logger.debug(
-                                                            "replaced %s with %s",
-                                                            old_code,
-                                                            new_code.value,
-                                                        )
-                                                    col_count = col_count + 1
-                                                row_count = row_count + 1
-                                            new_chunks.append(
-                                                Chunk(
-                                                    comment=room.comment,
-                                                    settings=room.settings,
-                                                    foreground=room.foreground,
-                                                    background=room.background,
-                                                )
-                                            )
-                                        level[0].level_templates.all()[
-                                            template_count
-                                        ].chunks = new_chunks
-                                        template_count = template_count + 1
-                    level[0].tile_codes = tile_codes_new
+        self.broken_tiles = broken_tiles
 
-                    if not self.lvls_path:
-                        raise RuntimeError("self.lvls_path not configured.")
-
-                    path = Path(self.lvls_path / str(level[1][2].split(" ")[0]))
-                    with Path(path).open("w", encoding="cp1252") as handle:
-                        level[0].write(handle)
-                        logger.debug("Fixed conflicts in %s", level[1][2].split(" ")[0])
-            except Exception:  # pylint: disable=broad-except
-                logger.critical("Error: %s", tb_info())
-
-    def update_dependencies(self, levels):
-        self.sister_locations = levels
-        tilecode_compare = []
-        for level in levels:
-            logger.debug("getting tilecodes from %s", level[0])
-            tilecodes = []
-            tilecodes.append(str(level[0]) + " " + str(level[2]) + " file")
-            level_tilecodes = level[1].tile_codes.all()
-
-            for tilecode in level_tilecodes:
-                tilecodes.append(str(tilecode.name) + " " + str(tilecode.value))
-            tilecode_compare.append(tilecodes)
-
-        for lvl_tilecodes in tilecode_compare:  # for list of tilecodes in each lvl
-            for tilecode in lvl_tilecodes:  # for each tilecode in the lvl
-                # for list of tilecodes in each lvl to compare to
-                for lvl_tilecodes_compare in tilecode_compare:
-                    # makes sure it doesn't compare to itself
-                    if lvl_tilecodes_compare[0] != lvl_tilecodes[0]:
-                        # for each tilecode in the lvl being compared to
-                        for tilecode_compare_to in lvl_tilecodes_compare:
-                            # makes sure its not the header
-                            if (
-                                len(tilecode.split(" ")) != 3
-                                and len(tilecode_compare_to.split(" ")) != 3
-                            ):
-                                # if tilecodes match
-                                if str(tilecode.split(" ")[1]) == str(
-                                    tilecode_compare_to.split(" ")[1]
-                                ):
-                                    # if tilecodes aren't assigned to same thing
-                                    if str(tilecode.split(" ")[0]) != str(
-                                        tilecode_compare_to.split(" ")[0]
-                                    ):
-                                        logger.debug(
-                                            "tilecode conflict: %s",
-                                            tilecode.split(" ")[1],
-                                        )
-                                        logger.debug(
-                                            "in %s and %s",
-                                            lvl_tilecodes[0],
-                                            lvl_tilecodes_compare[0],
-                                        )
-                                        logger.debug(
-                                            "comparing tileids %s to %s",
-                                            tilecode.split(" ")[0],
-                                            tilecode_compare_to.split(" ")[0],
-                                        )
-                                        compare_exists = False
-                                        compare_to_exists = False
-                                        # makes sure the detected conflicts are already listed
-                                        for tree_item in self.get_children():
-                                            tree_item_check = self.item(
-                                                tree_item, option="values"
-                                            )
-                                            if (
-                                                tree_item_check[0]
-                                                == str(tilecode.split(" ")[0])
-                                                and tree_item_check[1]
-                                                == str(tilecode.split(" ")[1])
-                                                and tree_item_check[2]
-                                                == str(lvl_tilecodes[0])
-                                            ):
-                                                compare_exists = True
-                                            elif (
-                                                tree_item_check[0]
-                                                == str(
-                                                    tilecode_compare_to.split(" ")[0]
-                                                )
-                                                and tree_item_check[1]
-                                                == str(
-                                                    tilecode_compare_to.split(" ")[1]
-                                                )
-                                                and tree_item_check[2]
-                                                == str(lvl_tilecodes_compare[0])
-                                            ):
-                                                compare_to_exists = True
-                                        if not compare_exists:
-                                            self.insert(
-                                                "",
-                                                "end",
-                                                text="L1",
-                                                values=(
-                                                    str(tilecode.split(" ")[0]),
-                                                    str(tilecode.split(" ")[1]),
-                                                    str(lvl_tilecodes[0]),
-                                                ),
-                                            )
-                                        if not compare_to_exists:
-                                            self.insert(
-                                                "",
-                                                "end",
-                                                text="L1",
-                                                values=(
-                                                    str(
-                                                        tilecode_compare_to.split(" ")[
-                                                            0
-                                                        ]
-                                                    ),
-                                                    str(
-                                                        tilecode_compare_to.split(" ")[
-                                                            1
-                                                        ]
-                                                    ),
-                                                    str(lvl_tilecodes_compare[0]),
-                                                ),
-                                            )
+        for broken_tile in broken_tiles:
+            self.insert(
+                "",
+                "end",
+                text="L1",
+                values=(
+                    str(broken_tile.tile.name),
+                    str(broken_tile.tile.value),
+                    str(broken_tile.level.level_name) + " " + str(broken_tile.level.location) + " file",
+                ),
+            )
 
     def clear(self):
         for i in self.get_children():

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/dependencies_tree.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/dependencies_tree.py
@@ -10,14 +10,18 @@ from modlunky2.levels import LevelFile
 from modlunky2.levels.level_templates import Chunk
 from modlunky2.levels.tile_codes import VALID_TILE_CODES, TileCode, TileCodes, ShortCode
 from modlunky2.utils import tb_info
-from modlunky2.ui.levels.vanilla_levels.variables.level_dependencies import SisterLocation
+from modlunky2.ui.levels.vanilla_levels.variables.level_dependencies import (
+    SisterLocation,
+)
 
 logger = logging.getLogger(__name__)
+
 
 @dataclass
 class BrokenTile:
     level: SisterLocation
     tile: TileCode
+
 
 class DependenciesTree(ttk.Treeview):
     def __init__(self, parent, lvls_path, extracts_path, *args, **kwargs):
@@ -50,13 +54,18 @@ class DependenciesTree(ttk.Treeview):
 
                     checked_levels.append(other_location.level_name)
                     for othertilecode in other_location.level.tile_codes.all():
-                        if tilecode.value == othertilecode.value and tilecode.name != othertilecode.name:
+                        if (
+                            tilecode.value == othertilecode.value
+                            and tilecode.name != othertilecode.name
+                        ):
                             if not added_code:
                                 added_code = True
                                 broken_tiles.append(
                                     BrokenTile(self.current_location, tilecode)
                                 )
-                            broken_tiles.append(BrokenTile(other_location, othertilecode))
+                            broken_tiles.append(
+                                BrokenTile(other_location, othertilecode)
+                            )
                             logger.debug(
                                 "tilecode conflict: %s",
                                 tilecode.value,
@@ -99,9 +108,7 @@ class DependenciesTree(ttk.Treeview):
                 usable_codes.remove(new_code)
                 level.tile_codes.set_obj(
                     TileCode(
-                        name = old_tile.name,
-                        value = new_code,
-                        comment = old_tile.comment
+                        name=old_tile.name, value=new_code, comment=old_tile.comment
                     )
                 )  # adds new tile to database with new code
             else:
@@ -111,14 +118,30 @@ class DependenciesTree(ttk.Treeview):
             for template in level.level_templates.all():
                 new_chunks = []
                 for room in template.chunks:
-                    foreground = [ [ str(new_code) if str(code) == str(old_tile_code) else str(code) for code in row] for row in room.foreground]
-                    background = [ [ str(new_code) if str(code) == str(old_tile_code) else str(code) for code in row] for row in room.background]
+                    foreground = [
+                        [
+                            str(new_code)
+                            if str(code) == str(old_tile_code)
+                            else str(code)
+                            for code in row
+                        ]
+                        for row in room.foreground
+                    ]
+                    background = [
+                        [
+                            str(new_code)
+                            if str(code) == str(old_tile_code)
+                            else str(code)
+                            for code in row
+                        ]
+                        for row in room.background
+                    ]
                     new_chunks.append(
                         Chunk(
-                            comment = room.comment,
-                            settings = room.settings,
-                            foreground = foreground,
-                            background = background,
+                            comment=room.comment,
+                            settings=room.settings,
+                            foreground=foreground,
+                            background=background,
                         )
                     )
                 template.chunks = new_chunks
@@ -147,7 +170,10 @@ class DependenciesTree(ttk.Treeview):
                 values=(
                     str(broken_tile.tile.name),
                     str(broken_tile.tile.value),
-                    str(broken_tile.level.level_name) + " " + str(broken_tile.level.location) + " file",
+                    str(broken_tile.level.level_name)
+                    + " "
+                    + str(broken_tile.level.location)
+                    + " file",
                 ),
             )
 

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
@@ -23,21 +23,23 @@ class LevelDependencies:
             levels.append("generic.lvl")
         if lvl.startswith("base"):
             levels.append("basecamp.lvl")
-        elif lvl.startswith("cave"):
-            levels.append("dwellingarea.lvl")
-        elif (
-            lvl.startswith("blackmark")
-            or lvl.startswith("beehive")
-            or lvl.startswith("challenge_moon")
-        ):
+        elif lvl.startswith("blackmark"):
+            levels.append("junglearea.lvl")
+        elif lvl.startswith("beehive"):
+            levels.append("templearea.lvl")
             levels.append("junglearea.lvl")
         elif lvl.startswith("vlads"):
             levels.append("volcanoarea.lvl")
-        elif lvl.startswith("lake") or lvl.startswith("challenge_star"):
+        elif lvl.startswith("challenge_moon"):
+            levels.append("junglearea.lvl")
+            levels.append("volcanoarea.lvl")
+        elif lvl.startswith("lake"):
             levels.append("tidepoolarea.lvl")
+        elif lvl.startswith("challenge_star"):
+            levels.append("tidepoolarea.lvl")
+            levels.append("templearea.lvl")
         elif (
             lvl.startswith("hallofush")
-            or lvl.startswith("challenge_star")
             or lvl.startswith("babylonarea_1")
             or lvl.startswith("palace")
         ):

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
@@ -9,11 +9,13 @@ from modlunky2.levels import LevelFile
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class SisterLocation:
     level_name: str
     level: LevelFile
     location: str
+
 
 class LevelDependencies:
     @staticmethod
@@ -98,7 +100,10 @@ class LevelDependencies:
             levels.append([get_loaded_level(lvl_name)])
 
         if lvl_name.startswith("generic.lvl"):
-            return [[get_loaded_level(dep)] for dep in LevelDependencies.generic_dependencies()]
+            return [
+                [get_loaded_level(dep)]
+                for dep in LevelDependencies.generic_dependencies()
+            ]
         elif not lvl_name.startswith("basecamp"):
             for dependencies in levels:
                 dependencies.append(get_loaded_level("generic.lvl"))
@@ -108,48 +113,48 @@ class LevelDependencies:
     @staticmethod
     @lru_cache
     def generic_dependencies():
-         return [
-                "dwellingarea.lvl",
-                "cavebossarea.lvl",
-                "junglearea.lvl",
-                "blackmarket.lvl",
-                "beehive.lvl",
-                "challenge_moon.lvl",
-                "volcanoarea.lvl",
-                "vladscastle.lvl",
-                "challenge_moon.lvl",
-                "olmecarea.lvl",
-                "tidepoolarea.lvl",
-                "lake.lvl",
-                "lakeoffire.lvl",
-                "challenge_star.lvl",
-                "abzu.lvl",
-                "templearea.lvl",
-                "beehive.lvl",
-                "challenge_star.lvl",
-                "cityofgold.lvl",
-                "duat.lvl",
-                "icecavesarea.lvl",
-                "babylonarea.lvl",
-                "babylonarea_1-1.lvl",
-                "hallofushabti.lvl",
-                "palaceofpleasure.lvl",
-                "tiamat.lvl",
-                "sunkencityarea.lvl",
-                "challenge_sun.lvl",
-                "eggplantarea.lvl",
-                "hundun.lvl",
-                "ending.lvl",
-                "ending_hard.lvl",
-                "cosmicocean_babylon.lvl",
-                "cosmicocean_dwelling.lvl",
-                "cosmicocean_icecavesarea.lvl",
-                "cosmicocean_jungle.lvl",
-                "cosmicocean_sunkencity.lvl",
-                "cosmicocean_temple.lvl",
-                "cosmicocean_tidepool.lvl",
-                "cosmicocean_volcano.lvl",
-            ]
+        return [
+            "dwellingarea.lvl",
+            "cavebossarea.lvl",
+            "junglearea.lvl",
+            "blackmarket.lvl",
+            "beehive.lvl",
+            "challenge_moon.lvl",
+            "volcanoarea.lvl",
+            "vladscastle.lvl",
+            "challenge_moon.lvl",
+            "olmecarea.lvl",
+            "tidepoolarea.lvl",
+            "lake.lvl",
+            "lakeoffire.lvl",
+            "challenge_star.lvl",
+            "abzu.lvl",
+            "templearea.lvl",
+            "beehive.lvl",
+            "challenge_star.lvl",
+            "cityofgold.lvl",
+            "duat.lvl",
+            "icecavesarea.lvl",
+            "babylonarea.lvl",
+            "babylonarea_1-1.lvl",
+            "hallofushabti.lvl",
+            "palaceofpleasure.lvl",
+            "tiamat.lvl",
+            "sunkencityarea.lvl",
+            "challenge_sun.lvl",
+            "eggplantarea.lvl",
+            "hundun.lvl",
+            "ending.lvl",
+            "ending_hard.lvl",
+            "cosmicocean_babylon.lvl",
+            "cosmicocean_dwelling.lvl",
+            "cosmicocean_icecavesarea.lvl",
+            "cosmicocean_jungle.lvl",
+            "cosmicocean_sunkencity.lvl",
+            "cosmicocean_temple.lvl",
+            "cosmicocean_tidepool.lvl",
+            "cosmicocean_volcano.lvl",
+        ]
 
     @staticmethod
     @lru_cache

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/level_dependencies.py
@@ -88,7 +88,7 @@ class LevelDependencies:
         def get_loaded_level(item):
             return LevelDependencies.get_loaded_level(item, lvls_path, extracts_path)
 
-        for depend in LevelDependencies.dependency_map():
+        for depend in LevelDependencies.dependencies():
             if lvl_name in depend:
                 levels.append([get_loaded_level(dep) for dep in depend])
 
@@ -151,7 +151,7 @@ class LevelDependencies:
 
     @staticmethod
     @lru_cache
-    def dependency_map():
+    def dependencies():
         return [
             [
                 "basecamp.lvl",

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/variables_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/variables_tab.py
@@ -75,6 +75,7 @@ class VariablesTab(ttk.Frame):
         if not self.request_save():
             return
 
+        self.check_dependencies()
         self.tree_depend.resolve_conflicts()
         self.on_conflicts_resolved()
         self.check_dependencies()
@@ -98,21 +99,26 @@ class VariablesTab(ttk.Frame):
         levels = LevelDependencies.sister_locations_for_level(
             self.current_level_name, self.lvls_path, self.extracts_path
         )
-        self.tree_depend.update_dependencies(levels)
+        current_level = LevelDependencies.get_loaded_level(
+            self.current_level_name, self.lvls_path, self.extracts_path
+        )
+        self.tree_depend.update_dependencies(levels, current_level)
 
         if len(self.tree_depend.get_children()) == 0:
-            self.depend_order_label.grid_remove()
             self.tree_depend.grid_remove()
             self.button_resolve_variables.grid_remove()
             self.no_conflicts_label.grid()
         else:
-            self.depend_order_label["text"] = " -> ".join(
-                [level[0] for level in levels]
-            )
-            self.depend_order_label.grid()
             self.tree_depend.grid()
             self.button_resolve_variables.grid()
             self.no_conflicts_label.grid_remove()
+        delimiter = ", "
+        if len(levels) <= 4:
+            delimiter = "\n"
+        self.depend_order_label["text"] = delimiter.join([" -> ".join(
+            [level.level_name for level in level_path]
+        ) for level_path in levels])
+        self.depend_order_label.grid()
 
     def update_lvls_path(self, new_path):
         self.lvls_path = new_path

--- a/src/modlunky2/ui/levels/vanilla_levels/variables/variables_tab.py
+++ b/src/modlunky2/ui/levels/vanilla_levels/variables/variables_tab.py
@@ -115,9 +115,12 @@ class VariablesTab(ttk.Frame):
         delimiter = ", "
         if len(levels) <= 4:
             delimiter = "\n"
-        self.depend_order_label["text"] = delimiter.join([" -> ".join(
-            [level.level_name for level in level_path]
-        ) for level_path in levels])
+        self.depend_order_label["text"] = delimiter.join(
+            [
+                " -> ".join([level.level_name for level in level_path])
+                for level_path in levels
+            ]
+        )
         self.depend_order_label.grid()
 
     def update_lvls_path(self, new_path):


### PR DESCRIPTION
Fixes variables tab to only show conflicts between the current file and its dependencies/dependants, and only apply fixes by modifying the current file instead of attempting to change every other file that conflicts with it.

This also hopefully fixes the resolve conflicts button breaking levels, since the resolving conflicts logic is simpler and makes sense now.

Some other changes are also included which help avoid conflicts being introduced in the first place, or fix related logic.