### PR TITLE
Fix Counter to work pre-python-3.10

### DIFF
--- a/src/modlunky2/ui/trackers/co_tracker.py
+++ b/src/modlunky2/ui/trackers/co_tracker.py
@@ -269,7 +269,9 @@ class COTracker(Tracker[COTrackerConfig, WindowData]):
         Example: " 2  (25%)"
         """
         count = theme_count[theme]
-        total_count = theme_count.total()
+        total_count = sum(
+            theme_count.values()
+        )  # theme_count.total() only works in python 3.10+
         percentage_str = f"{f'({count/total_count if total_count > 0 else 0:.0%})':>6}"
         return f"{count:>2} {percentage_str}"
 


### PR DESCRIPTION
I used Counter.total which was only added in python 3.10. (oops)