### PR TITLE
True Crown Label for CO Categories

### DIFF
--- a/src/modlunky2/config.py
+++ b/src/modlunky2/config.py
@@ -125,6 +125,7 @@ class SaveableCategory(Enum):
     NO = "No%"
     NO_GOLD = "No Gold"
     PACIFIST = "Pacifist"
+    SCORE = "Score"
 
 
 @serialize(rename_all="kebabcase")
@@ -291,7 +292,7 @@ class Config:
     @classmethod
     def from_path(
         cls,
-        config_path: Path = None,
+        config_path: Optional[Path] = None,
         exe_dir: Optional[Path] = None,
         launcher_exe: Optional[Path] = None,
     ):

--- a/src/modlunky2/ui/trackers/label.py
+++ b/src/modlunky2/ui/trackers/label.py
@@ -56,6 +56,7 @@ class Label(Enum):
             SaveableCategory.NO: Label.NO,
             SaveableCategory.NO_GOLD: Label.NO_GOLD,
             SaveableCategory.PACIFIST: Label.PACIFIST,
+            SaveableCategory.SCORE: Label.SCORE,
         }
 
         return mapping[sc]
@@ -89,6 +90,7 @@ class RunLabel:
     _ONLY_SHOW_WITH[Label.JUNGLE_TEMPLE] |= {Label.LOW}
     _ONLY_SHOW_WITH[Label.VOLCANA_TEMPLE] |= {Label.LOW}
     _ONLY_SHOW_WITH[Label.NO_CO] |= {Label.SCORE}
+    _ONLY_SHOW_WITH[Label.TRUE_CROWN] |= {Label.COSMIC_OCEAN}
 
     # Some labels hide others, e.g. we want "Low%" not "Low% Any".
     # If the key is present, hide all of the labels in the value

--- a/src/modlunky2/ui/trackers/runstate.py
+++ b/src/modlunky2/ui/trackers/runstate.py
@@ -242,6 +242,10 @@ class RunState:
         else:
             self.run_label.discard(Label.EGGPLANT)
 
+    def update_true_crown(self, player_item_types):
+        if EntityType.ITEM_POWERUP_TRUECROWN in player_item_types:
+            self.run_label.add(Label.TRUE_CROWN)
+
     def update_low_cosmic(self):
         if self.cosmic_stepper.last_status.failed and self.mc_has_swung_mattock:
             self.fail_low()
@@ -733,6 +737,7 @@ class RunState:
         self.update_no_gold(run_recap_flags)
         self.update_no_tp(player, self.player_item_types, self.player_last_item_types)
         self.update_eggplant()
+        self.update_true_crown(self.player_item_types)
         self.update_low_cosmic()
 
         # Check Category Criteria

--- a/src/tests/ui/trackers/label_matches_mr_test.py
+++ b/src/tests/ui/trackers/label_matches_mr_test.py
@@ -1,5 +1,6 @@
 from pytest import mark
 
+from modlunky2.config import SaveableCategory
 from modlunky2.ui.trackers.label import Label, RunLabel
 
 # This file only contains tests for the correspondence between MossRanking
@@ -46,7 +47,6 @@ MAIN_SCORE_CATEGORIES = [
 
 MISC_CATEGORIES = [
     ({Label.EGGPLANT, Label.COSMIC_OCEAN}, "Eggplant Cosmic Ocean%"),
-    ({Label.TRUE_CROWN, Label.COSMIC_OCEAN}, "True Crown Cosmic Ocean%"),
     (
         {Label.EGGPLANT, Label.TRUE_CROWN, Label.COSMIC_OCEAN},
         "Eggplant True Crown Cosmic Ocean%",
@@ -396,3 +396,28 @@ def test_label_matches_mossranking(labels, expected):
     run_label = RunLabel(labels)
     actual = run_label.text(hide_early=False, excluded_categories=set())
     assert actual == expected
+
+
+TRUE_CROWN_CATEGORIES = [
+    (
+        {Label.SCORE, Label.TRUE_CROWN, Label.COSMIC_OCEAN},
+        "Score",
+        "True Crown Cosmic Ocean%",
+    ),
+    (
+        {Label.SCORE, Label.TRUE_CROWN, Label.ANY},
+        "Score",
+        "Any%",
+    ),
+]
+
+
+@mark.parametrize("labels,expected,expected_no_score", TRUE_CROWN_CATEGORIES)
+def test_tc_label_matches_mossranking(labels, expected, expected_no_score):
+    run_label = RunLabel(labels)
+    actual = run_label.text(hide_early=False, excluded_categories=set())
+    actual_no_score = run_label.text(
+        hide_early=False, excluded_categories={SaveableCategory.SCORE}
+    )
+    assert actual == expected
+    assert actual_no_score == expected_no_score

--- a/src/tests/ui/trackers/runstate_test.py
+++ b/src/tests/ui/trackers/runstate_test.py
@@ -222,8 +222,7 @@ def test_no_tp(
     [
         ({EntityType.ITEM_POWERUP_EGGPLANTCROWN}, False),
         ({EntityType.ITEM_PLASMACANNON}, True),
-        ({EntityType.ITEM_PLASMACANNON}, True),
-        (set(), False),
+        ({EntityType.ITEM_POWERUP_TRUECROWN}, True),
         (set(), False),
     ],
 )
@@ -233,6 +232,23 @@ def test_score_items(item_set, expected_score):
 
     is_score = Label.SCORE in run_state.run_label._set
     assert is_score == expected_score
+
+
+@pytest.mark.parametrize(
+    "item_set,expected_true_crown",
+    [
+        ({EntityType.ITEM_POWERUP_EGGPLANTCROWN}, False),
+        ({EntityType.ITEM_PLASMACANNON}, False),
+        ({EntityType.ITEM_POWERUP_TRUECROWN}, True),
+        (set(), False),
+    ],
+)
+def test_true_crown(item_set, expected_true_crown):
+    run_state = RunState()
+    run_state.update_true_crown(item_set)
+
+    is_true_crown = Label.TRUE_CROWN in run_state.run_label._set
+    assert is_true_crown == expected_true_crown
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Add true crown label to run when collected (only visualized for Cosmic Ocean categories)
- Add option to disable visualizing Score (which is still prioritized when collecting the True Crown)